### PR TITLE
Status ok vs default

### DIFF
--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -65,12 +65,11 @@ class PreservedObjectHandler
         po = PreservedObject.create!(druid: druid,
                                      current_version: incoming_version,
                                      preservation_policy: pp_default)
-        status = Status.default_status
         PreservedCopy.create!(preserved_object: po,
                               version: incoming_version,
                               size: incoming_size,
                               endpoint: endpoint,
-                              status: status)
+                              status: Status.default_status)
         results << result_hash(CREATED_NEW_OBJECT)
       rescue ActiveRecord::RecordNotFound => e
         results << result_hash(OBJECT_DOES_NOT_EXIST, e.inspect)
@@ -118,7 +117,7 @@ class PreservedObjectHandler
           # FIXME: only update PreservedCopy.version IFF it's Moab endpoint
           results << result_hash(ARG_VERSION_GREATER_THAN_DB_OBJECT, pres_copy.class.name)
           update_preserved_copy(pres_copy, incoming_version, incoming_size)
-          results.concat(update_status(pres_copy, Status.default_status))
+          results.concat(update_status(pres_copy, Status.ok))
           results.concat(update_db_object(pres_copy))
           if incoming_version > pres_object.current_version # FIXME: need code/test for when it's NOT
             results << result_hash(ARG_VERSION_GREATER_THAN_DB_OBJECT, pres_object.class.name)
@@ -174,7 +173,7 @@ class PreservedObjectHandler
     results << result_hash(ARG_VERSION_GREATER_THAN_DB_OBJECT, db_object.class.name)
     if db_object.is_a?(PreservedCopy)
       update_preserved_copy(db_object, incoming_version, incoming_size)
-      results.concat(update_status(db_object, Status.default_status))
+      results.concat(update_status(db_object, Status.ok))
     else
       update_preserved_object(db_object, incoming_version)
     end

--- a/spec/load_fixtures_helper.rb
+++ b/spec/load_fixtures_helper.rb
@@ -40,7 +40,7 @@ def load_fixture_moabs
       PreservedCopy.create(preserved_object_id: po.id,
                            endpoint_id: @storage_dir_to_endpoint_id[storage_dir],
                            current_version: version,
-                           status_id: Status.default_status.id)
+                           status: Status.default_status)
     end
   end
 end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PreservedCopy, type: :model do
       preserved_object_id: preserved_object.id,
       endpoint_id: endpoint.id,
       version: 0,
-      status_id: status.id,
+      status: status,
       size: 1
     )
   end

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe PreservedObjectHandler do
         it 'updates status of PreservedCopy to "ok"' do
           expect(pc.status).to eq Status.unexpected_version
           po_handler.update_version
-          expect(pc.reload.status).to eq Status.default_status
+          expect(pc.reload.status).to eq Status.ok
         end
         it "logs at info level" do
           expect(Rails.logger).to receive(:log).with(Logger::INFO, version_gt_po_msg)
@@ -403,7 +403,7 @@ RSpec.describe PreservedObjectHandler do
           skip("should it update status of PreservedCopy?")
           expect(pc.status).to eq Status.unexpected_version
           po_handler.update_version
-          expect(pc.reload.status).to eq Status.default_status
+          expect(pc.reload.status).to eq Status.ok
         end
         it "logs at error and info level" do
           expect(Rails.logger).to receive(:log).with(Logger::ERROR, unexpected_version_msg)


### PR DESCRIPTION
This corrects the conflation of default_status (used at create time only) and "ok" status (used in other logic to indicate "ok")