### PR TITLE
A basic rake task to seed the catalog from all the storage roots.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,3 +13,11 @@ task default: [:spec, :rubocop]
 task :travis_setup_postgres do
   sh("psql -U postgres -f db/scripts/pres_test_setup.sql")
 end
+
+require_relative 'lib/audit/moab_to_catalog'
+task seed_catalog: :environment do
+  m2c = MoabToCatalog.new
+  puts "Seeding the database from all storage roots..."
+  m2c.seed_from_disk
+  puts "Done"
+end


### PR DESCRIPTION
Fixes #68

The new rake task is only for seeding the catalog, so maybe break out the rest of the ticket into a new ticket or two?

If anyone knows how to avoid adding the line to application.rb then feel free to amend this branch as you please.