### PR TITLE
WIP add MV to create

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
-    moab-versioning (2.3.0)
+    moab-versioning (2.4.0)
       confstruct
       druid-tools (>= 1.0.0)
       json

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -5,6 +5,7 @@
 # NOTE: performing validation here to allow this class to be called directly avoiding http overhead
 #
 # inspired by http://www.thegreatcodeadventure.com/smarter-rails-services-with-active-record-modules/
+require 'pp'
 class PreservedObjectHandler
 
   INVALID_ARGUMENTS = 1
@@ -62,6 +63,18 @@ class PreservedObjectHandler
     else
       pp_default = PreservationPolicy.default_preservation_policy
       begin
+        p '-----------------------------------------'
+        p "storage_dir: #{storage_dir}"
+        p "Druid: #{druid}"
+        p "incoming_version: #{incoming_version}"
+        druid_tool = DruidTools::Druid.new(druid)
+        object_dir = "#{storage_dir}/#{druid_tool.tree.join('/')}"
+        so = Moab::StorageObject.new(druid,object_dir)
+        sov = Moab::StorageObjectValidator.new(so)
+
+        pp sov.validation_errors
+        p "Object_dir: #{object_dir}"
+        p '-----------------------------------------'
         po = PreservedObject.create!(druid: druid,
                                      current_version: incoming_version,
                                      preservation_policy: pp_default)
@@ -78,7 +91,6 @@ class PreservedObjectHandler
         results << result_hash(DB_UPDATE_FAILED, "#{e.inspect} #{e.message} #{e.backtrace.inspect}")
       end
     end
-
     log_results(results)
     results
   end
@@ -129,7 +141,7 @@ class PreservedObjectHandler
           results << result_hash(UNEXPECTED_VERSION, 'PreservedCopy')
           results.concat(version_comparison_results(pres_copy, :version))
           results.concat(version_comparison_results(pres_object, :current_version))
-          # FIXME: TODO: should it update existence check timestamps/status?
+          # FIXME: TODO: should it updat3e existence check timestamps/status?
         end
       rescue ActiveRecord::RecordNotFound => e
         results << result_hash(OBJECT_DOES_NOT_EXIST, e.inspect)


### PR DESCRIPTION
- Adding MV check to #create method in po_handler


Things to discuss with team:
- Do we want po_handler#confirm_version to call #create OR do we want M2C check (from lib/audit) to call #create.
- should #create ALWAYS call MV (and D2D) before it creates the actual objects in the catalog?
- should we create records ONLY if the validation_errors are empty?
- should we create records if there are some validation_errors? like... if the moab is perfectly constructed except for one extraneous file...??

connects to #179
connects to #178
 connects to #177
connects to #175