### PR TITLE
centralize common ActiveRecord rescue behavior in PreservedObjectHandler

### DIFF
--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -218,7 +218,7 @@ class PreservedObjectHandler
   def update_db_object(db_object)
     results = []
     if db_object.changed?
-      db_object.save
+      db_object.save!
       results << result_hash(UPDATED_DB_OBJECT, db_object.class.name)
     else
       # FIXME: we may not want to do this, but instead to update specific timestamp for check

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -370,8 +370,6 @@ RSpec.describe PreservedObjectHandler do
   end
 
   describe '#confirm_version' do
-    let!(:default_prez_policy) { PreservationPolicy.default_preservation_policy }
-
     it_behaves_like 'attributes validated', :confirm_version
 
     context 'druid in db' do

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe PreservedObjectHandler do
               allow(pc).to receive(:version).and_return(1)
               allow(pc).to receive(:version=)
               allow(pc).to receive(:changed?).and_return(true)
-              allow(pc).to receive(:save).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+              allow(pc).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
               status = instance_double('Status')
               allow(status).to receive(:status_text)
               allow(pc).to receive(:status).and_return(status)
@@ -284,7 +284,7 @@ RSpec.describe PreservedObjectHandler do
               allow(po).to receive(:current_version).and_return(5)
               allow(po).to receive(:current_version=).with(incoming_version)
               allow(po).to receive(:changed?).and_return(true)
-              allow(po).to receive(:save).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+              allow(po).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
               allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
               pc = instance_double('PreservedCopy')
               allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
@@ -292,7 +292,7 @@ RSpec.describe PreservedObjectHandler do
               allow(pc).to receive(:version=).with(incoming_version)
               allow(pc).to receive(:size=).with(incoming_size)
               allow(pc).to receive(:changed?).and_return(true)
-              allow(pc).to receive(:save)
+              allow(pc).to receive(:save!)
               status = instance_double('Status')
               allow(status).to receive(:status_text)
               allow(pc).to receive(:status).and_return(status)
@@ -315,14 +315,14 @@ RSpec.describe PreservedObjectHandler do
         end
       end
 
-      it 'calls PreservedObject.save and PreservedCopy.save if the existing record is altered' do
+      it 'calls PreservedObject.save! and PreservedCopy.save! if the existing record is altered' do
         po = instance_double(PreservedObject)
         pc = instance_double(PreservedCopy)
         allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
         allow(po).to receive(:current_version).and_return(1)
         allow(po).to receive(:current_version=).with(incoming_version)
         allow(po).to receive(:changed?).and_return(true)
-        allow(po).to receive(:save)
+        allow(po).to receive(:save!)
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
         allow(pc).to receive(:version).and_return(1)
         allow(pc).to receive(:version=).with(incoming_version)
@@ -331,10 +331,10 @@ RSpec.describe PreservedObjectHandler do
         allow(pc).to receive(:changed?).and_return(true)
         allow(pc).to receive(:status).and_return(instance_double(Status, status_text: 'ok'))
         allow(pc).to receive(:status=)
-        allow(pc).to receive(:save)
+        allow(pc).to receive(:save!)
         po_handler.update_version
-        expect(po).to have_received(:save)
-        expect(pc).to have_received(:save)
+        expect(po).to have_received(:save!)
+        expect(pc).to have_received(:save!)
       end
 
       it 'calls PreservedObject.touch and PreservedCopy.touch if the existing record is NOT altered' do
@@ -564,7 +564,7 @@ RSpec.describe PreservedObjectHandler do
             allow(po).to receive(:current_version).and_return(1)
             allow(po).to receive(:current_version=).with(incoming_version)
             allow(po).to receive(:changed?).and_return(true)
-            allow(po).to receive(:save).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+            allow(po).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
             allow(po).to receive(:destroy) # for after() cleanup calls
             po_handler.confirm_version
           end
@@ -582,7 +582,7 @@ RSpec.describe PreservedObjectHandler do
           end
         end
       end
-      it 'calls PreservedObject.save and PreservedCopy.save if the existing record is altered' do
+      it 'calls PreservedObject.save! and PreservedCopy.save! if the existing record is altered' do
         po = instance_double(PreservedObject)
         pc = instance_double(PreservedCopy)
 
@@ -598,7 +598,7 @@ RSpec.describe PreservedObjectHandler do
         allow(po).to receive(:current_version).and_return(1)
         allow(po).to receive(:current_version=).with(incoming_version)
         allow(po).to receive(:changed?).and_return(true)
-        allow(po).to receive(:save)
+        allow(po).to receive(:save!)
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
         allow(pc).to receive(:version).and_return(1)
         allow(pc).to receive(:version=).with(incoming_version)
@@ -606,10 +606,10 @@ RSpec.describe PreservedObjectHandler do
         allow(pc).to receive(:endpoint).with(ep)
         allow(pc).to receive(:changed?).and_return(true)
         allow(pc).to receive(:status).and_return(Status.ok)
-        allow(pc).to receive(:save)
+        allow(pc).to receive(:save!)
         po_handler.confirm_version
-        expect(po).to have_received(:save)
-        expect(pc).to have_received(:save)
+        expect(po).to have_received(:save!)
+        expect(pc).to have_received(:save!)
       end
       it 'calls PreservedObject.touch and PreservedCopy.touch if the existing record is NOT altered' do
         po_handler = described_class.new(druid, 1, 1, storage_dir)

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -98,7 +98,7 @@ RSpec.shared_examples 'PreservedCopy does not exist' do |method_sym|
     allow(po).to receive(:current_version).and_return(2)
     allow(po).to receive(:current_version=)
     allow(po).to receive(:changed?).and_return(true)
-    allow(po).to receive(:save)
+    allow(po).to receive(:save!)
     allow(PreservedObject).to receive(:find_by!).and_return(po)
     # allow(PreservedObject).to receive(:find_by!).and_return(instance_double(PreservedObject))
     allow(PreservedCopy).to receive(:find_by!).and_raise(ActiveRecord::RecordNotFound, 'foo')


### PR DESCRIPTION
looks like more methods will be repeating this pattern, so i took a shot at centralizing it to a method that takes a block and does the error handling.  that part is in the third commit (and required no spec changes).

also, a couple other bits of minor housekeeping (which did require a bit of spec touchup).