### PR TITLE
automatically update shared_configs upon deployment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -34,3 +34,6 @@ append :linked_dirs, "log", "config/settings" # , "tmp/pids", "tmp/cache", "tmp/
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5
+
+# update shared_configs before restarting app
+before 'deploy:restart', 'shared_configs:update'


### PR DESCRIPTION
i'm not sure if we want to do this, but it's something that we do in other projects, and i noticed just now when deploying that we don't do it in preservation catalog.  seemed easier to put up this PR and have people reject it if we don't want it than to file an issue and all, since it's such a simple change.