### PR TITLE
Update pohandler.create/validations timestamps

### DIFF
--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -133,25 +133,28 @@ class PreservedObjectHandler
 
   private
 
-  def create_db_objects(status, validate=false)
+  def create_db_objects(status, validates=false)
     results = []
     pp_default = PreservationPolicy.default_preservation_policy
     create_results = with_active_record_rescue do
       po = PreservedObject.create!(druid: druid,
                                    current_version: incoming_version,
                                    preservation_policy: pp_default)
-      pc = PreservedCopy.create!(preserved_object: po,
-                                 version: incoming_version,
-                                 size: incoming_size,
-                                 endpoint: endpoint,
-                                 status: status)
-      if validate
+      pc_attrs = {
+        preserved_object: po,
+        version: incoming_version,
+        size: incoming_size,
+        endpoint: endpoint,
+        status: status
+      }
+
+      if validates
         t = Time.current
         # Returns the value of time as an integer number of seconds since the Epoch.
-        pc.last_audited = t.to_i
-        pc.last_checked_on_storage = t
-        pc.save
+        pc_attrs[:last_audited] = t.to_i
+        pc_attrs[:last_checked_on_storage] = t
       end
+      PreservedCopy.create!(pc_attrs)
       results << result_hash(CREATED_NEW_OBJECT)
     end
     results.concat(create_results)

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe PreservedObjectHandler do
 
     it_behaves_like 'attributes validated', :create_with_validation
 
-    context 'updates timestamp' do
+    context 'updates validation timestamps' do
       let(:t) { Time.current }
       let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
       let(:po_handler) { described_class.new(valid_druid, incoming_version, incoming_size, ep) }
@@ -125,7 +125,9 @@ RSpec.describe PreservedObjectHandler do
         version: incoming_version,
         size: incoming_size,
         endpoint: ep,
-        status: Status.default_status
+        status: Status.default_status,
+        last_audited: an_instance_of(Integer),
+        last_checked_on_storage: an_instance_of(ActiveSupport::TimeWithZone)
       }
 
       expect(PreservedObject).to receive(:create!).with(po_args).and_call_original
@@ -170,7 +172,9 @@ RSpec.describe PreservedObjectHandler do
           version: incoming_version,
           size: incoming_size,
           endpoint: ep,
-          status: Status.invalid
+          status: Status.invalid,
+          last_audited: an_instance_of(Integer),
+          last_checked_on_storage: an_instance_of(ActiveSupport::TimeWithZone)
         }
 
         expect(PreservedObject).to receive(:create!).with(po_args).and_call_original

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -93,6 +93,27 @@ RSpec.describe PreservedObjectHandler do
 
     it_behaves_like 'attributes validated', :create_with_validation
 
+    context 'updates timestamp' do
+      let(:t) { Time.current }
+      let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
+      let(:po_handler) { described_class.new(valid_druid, incoming_version, incoming_size, ep) }
+      let(:po_db_obj) { PreservedObject.find_by(druid: valid_druid) }
+      let(:pc_db_obj) { PreservedCopy.find_by(preserved_object: po_db_obj) }
+      let(:results) do
+        po_handler = described_class.new(valid_druid, incoming_version, incoming_size, ep)
+        po_handler.create_with_validation
+      end
+
+      before { results }
+
+      it "sets last_audited with Epoch time" do
+        expect(pc_db_obj.last_audited).to be_within(10).of(t.to_i)
+      end
+      it "sets last_checked_on_storage with current time" do
+        expect(pc_db_obj.last_checked_on_storage).to be_within(10).of(t)
+      end
+    end
+
     it 'creates the preserved object and preserved copy when there are no validation errors' do
       po_args = {
         druid: valid_druid,


### PR DESCRIPTION
- Added a flag in the `create_db_objects()` method to run the timestamp update for ` create_with_validation` and not for `create` 
- we want to update PC.last_checked_on_storage and PC.last_audited for `create_with_validation`

- I figured that this was a good idea because I have access to the `PreservedCopy` in the `create_db_objects()` method and wouldn't have to use a `.find_by` call. 

connects #288 