### PR TITLE
[WIP] Call create_with_validation in with_active_record_rescue with tests

### DIFF
--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -178,6 +178,7 @@ class PreservedObjectHandler
       yield
     rescue ActiveRecord::RecordNotFound => e
       results << result_hash(OBJECT_DOES_NOT_EXIST, e.inspect)
+      create_with_validation
     rescue ActiveRecord::ActiveRecordError => e
       results << result_hash(DB_UPDATE_FAILED, "#{e.inspect} #{e.message} #{e.backtrace.inspect}")
     end

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -112,13 +112,41 @@ class PreservedObjectHandler
     results
   end
 
-  def update_version
+
+  # If validation doesn't pass then create with Status.invalid - so need another flag to tell create_db_object - 
+  # can jiust call that right?
+  
+  def update_version_with_validation
+    dt = DruidTools::Druid.new(druid)
+    object_dir = "#{storage_location}/#{dt.tree.join('/')}"
+    moab = Moab::StorageObject.new(druid, object_dir)
+    object_validator = Stanford::StorageObjectValidator.new(moab)
+    validation_errors = object_validator.validation_errors
     results = []
     if invalid?
       results << result_hash(INVALID_ARGUMENTS, errors.full_messages)
     else
       Rails.logger.debug "update_version #{druid} called and druid in Catalog"
       upd_results = with_active_record_rescue do
+        if endpoint.endpoint_type.endpoint_class == 'online'
+          results.concat update_online_version
+        elsif endpoint.endpoint_type.endpoint_class == 'archive'
+        end
+      end
+      results.concat(upd_results)
+    end
+
+    log_results(results)
+    results
+  end
+
+  def update_version
+    results = []
+    if invalid?
+      results << result_hash(INVALID_ARGUMENTS, errors.full_messages)
+    else
+      Rails.logger.debug "update_version #{druid} called and druid in Catalog"
+      upd_results = with_active_record_rescue(true) do
         if endpoint.endpoint_type.endpoint_class == 'online'
           results.concat update_online_version
         elsif endpoint.endpoint_type.endpoint_class == 'archive'
@@ -171,14 +199,20 @@ class PreservedObjectHandler
     end
     results
   end
-
-  def with_active_record_rescue
+#ADDED IF ELSE STATEMENT TO CALL CREATE WITH A FLAG
+  def with_active_record_rescue(validates=false)
     results = []
     begin
       yield
     rescue ActiveRecord::RecordNotFound => e
       results << result_hash(OBJECT_DOES_NOT_EXIST, e.inspect)
-      create_with_validation
+      if validates
+        p "I'm in create with validation"
+        create_with_validation
+      else
+        p "hello :)"
+        create
+      end
     rescue ActiveRecord::ActiveRecordError => e
       results << result_hash(DB_UPDATE_FAILED, "#{e.inspect} #{e.message} #{e.backtrace.inspect}")
     end

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -371,6 +371,26 @@ RSpec.describe PreservedObjectHandler do
     it_behaves_like 'druid not in catalog', :update_version
 
     it_behaves_like 'PreservedCopy does not exist', :update_version
+
+    context 'not in Catalog' do
+      let(:druid) { 'bj102hs9687' }
+      let(:incoming_version) { 3 }
+      let(:incoming_size) { 666 }
+      let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
+      let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
+      let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
+
+      it 'creates preserved object if not found' do
+        expect(PreservedObject.where(druid: druid)).not_to exist
+        po_handler.update_version
+        expect(PreservedObject.where(druid: druid)).to exist
+      end
+      it 'creates preserved copy if not found' do
+        expect(PreservedCopy.where(preserved_object: PreservedObject.find_by(druid: druid))).not_to exist
+        po_handler.update_version
+        expect(PreservedCopy.where(preserved_object: PreservedObject.find_by(druid: druid))).to exist
+      end
+    end
   end
 
   describe '#confirm_version' do

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -70,8 +70,14 @@ RSpec.shared_examples "attributes validated" do |method_sym|
 end
 
 RSpec.shared_examples 'druid not in catalog' do |method_sym|
-  let(:druid) { 'rr111rr1111' }
+  let(:druid) { 'bj102hs9687' }
+  let(:version) { 3 }
+  let(:size) { 666 }
+  let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
+  let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
+  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{version}, #{size}, #{ep})" }
   let(:exp_msg) { "#{exp_msg_prefix} #<ActiveRecord::RecordNotFound: Couldn't find PreservedObject> db object does not exist" }
+  let(:po_handler) { described_class.new(druid, version, size, ep) }
   let(:results) do
     allow(Rails.logger).to receive(:log)
     # FIXME: couldn't figure out how to put next line into its own test


### PR DESCRIPTION
- Had to changed the RSpec Shared Example po_handle to a valid druid that could be created w/ create_with_validation otherwise tests weren't passing.



connects #285