### PR TITLE
transactionality in POH: rename with_active_record_rescue to with_active_record_transaction_and_rescue, have it wrap its yield in a transaction

### DIFF
--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -91,7 +91,7 @@ class PreservedObjectHandler
     if invalid?
       results << result_hash(INVALID_ARGUMENTS, errors.full_messages)
     else
-      Rails.logger.debug "confirm_version #{druid} called and object exists"
+      Rails.logger.debug "confirm_version #{druid} called"
       confirm_results = with_active_record_rescue do
         po_db_object = PreservedObject.find_by!(druid: druid)
         results.concat(confirm_version_on_db_object(po_db_object, :current_version))
@@ -110,7 +110,7 @@ class PreservedObjectHandler
     if invalid?
       results << result_hash(INVALID_ARGUMENTS, errors.full_messages)
     else
-      Rails.logger.debug "update_version #{druid} called and druid in Catalog"
+      Rails.logger.debug "update_version #{druid} called"
       upd_results = with_active_record_rescue do
         if endpoint.endpoint_type.endpoint_class == 'online'
           results.concat update_online_version

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,11 @@
 
 # it should be safe to run this repeatedly, as the methods it calls only add new entries from the configs,
 # and leave existing entries untouched.
-ApplicationRecord.transaction do
+# this should be run very infrequently, and lots of other data relies on what's seeded here, and PG is pretty
+# efficient about locking strategy, so use the strictest transaction isolation level (serializable):
+# http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/DatabaseStatements.html#method-i-transaction
+# https://www.postgresql.org/docs/current/static/transaction-iso.html
+ApplicationRecord.transaction(isolation: :serializable) do
   PreservationPolicy.seed_from_config
   EndpointType.seed_from_config
   Endpoint.seed_storage_root_endpoints_from_config(

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -71,6 +71,13 @@ RSpec.describe PreservedObjectHandler do
           end
         end
       end
+
+      it "rolls back pres object creation if the pres copy can't be created (e.g. due to DB constraint violation)" do
+        # so that pres copy creation fails with a constraint violation, since status can't be nil
+        allow(Status).to receive(:default_status).and_return(nil)
+        po_handler.create
+        expect(PreservedObject.where(druid: druid)).not_to exist
+      end
     end
 
     context 'returns' do

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -335,4 +335,35 @@ RSpec.describe PreservedObjectHandler do
 
     it_behaves_like 'PreservedCopy does not exist', :confirm_version
   end
+
+  describe '#with_active_record_transaction_and_rescue' do
+    context 'bogus endpoint' do
+      let(:wrong_ep) do
+        Endpoint.create!(
+          endpoint_name: 'wrong_endpoint',
+          endpoint_type: Endpoint.default_storage_root_endpoint_type,
+          endpoint_node: 'localhost',
+          storage_location: 'blah',
+          recovery_cost: 1
+        )
+      end
+      let(:bad_po_handler) { described_class.new(druid, 6, incoming_size, wrong_ep) }
+
+      before do
+        po = PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
+        PreservedCopy.create!(
+          preserved_object: po, # TODO: see if we got the preserved object that we expected
+          version: po.current_version,
+          size: 1,
+          endpoint: ep,
+          status: Status.default_status
+        )
+      end
+
+      it '#confirm_version rolls back preserved object if the preserved copy cannot be found' do
+        bad_po_handler.confirm_version
+        expect(PreservedObject.find_by(druid: druid).current_version).to eq 2
+      end
+    end
+  end
 end

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe PreservedObjectHandler do
         expect(pc).to have_received(:touch)
       end
       it 'logs a debug message' do
-        msg = "confirm_version #{druid} called and object exists"
+        msg = "confirm_version #{druid} called"
         allow(Rails.logger).to receive(:debug)
         po_handler.confirm_version
         expect(Rails.logger).to have_received(:debug).with(msg)

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe PreservedObjectHandler do
       end
 
       it 'logs a debug message' do
-        msg = "update_version #{druid} called and druid in Catalog"
+        msg = "update_version #{druid} called"
         allow(Rails.logger).to receive(:debug)
         po_handler.update_version
         expect(Rails.logger).to have_received(:debug).with(msg)


### PR DESCRIPTION
since that method is already wrapping high-level groups of DB operations which go together to form what should be a single atomic update

test transactions by forcing one part of the database updating to fail, after the prior step has succeeded, and check that the prior step was rolled back.

* the first commit is just a bit of log message clean up that i couldn't resist
* the second adds transactionality to the initial database seeding of endpoints etc
* the third is a bit of refactoring that sets up
* the fourth, which just adds transactionality to the method that already wraps high-level sets of DB operations

my plan is to put up a follow-on PR that maybe fleshes out the tests for this a bit more (#324), as well as adding a `db/README.md` (#281) which gives a bit of basic guidance about when and how to wrap sets of operations in transactions, etc.

closes #203