### PR TITLE
use moab-versioning v3.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
-    moab-versioning (2.5.1)
+    moab-versioning (3.0.0)
       confstruct
       druid-tools (>= 1.0.0)
       json


### PR DESCRIPTION
this will hopefully allow us to get past the objects considered invalid due to versions missing content directories.