### PR TITLE
Moab to catalog touchups

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,7 +49,7 @@ Layout/SpaceInsideBrackets:
 Metrics/AbcSize:
   Exclude:
     - 'app/services/preserved_object_handler.rb' # 2 methods but they seem readable
-    - 'lib/audit/moab_to_catalog.rb' # #seed_from_disk is decidedly readable
+    - 'lib/audit/moab_to_catalog.rb' # .seed_from_disk is decidedly readable
 
 Metrics/BlockLength:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -47,24 +47,25 @@ For more info on postgres commands, see https://www.postgresql.org/docs/
 
 ### Seed the catalog
 
-Seeding the catalog presumes an empty or nearly empty database -- otherwise running the seed task will throw `druid NOT expected to exist in catalog but was found` errors for each found object. You can monitor the progress of the seed task by tailing `log/production.log`. The seed task can take a while -- check [the repo wiki for stats](https://github.com/sul-dlss/preservation_catalog/wiki/Stats) on the timing of past runs, and you can expect profiling runs will add overhead. The following rake tasks should be run from the root directory of the project, with whatever `RAILS_ENVIRONMENT` is appropriate. Because the task can take days when run over each storage root, consider running it in a [screen session](http://thingsilearned.com/2009/05/26/gnu-screen-super-basic-tutorial/).
+Seeding the catalog presumes an empty or nearly empty database -- otherwise running the seed task will throw `druid NOT expected to exist in catalog but was found` errors for each found object. You can monitor the progress of the seed task by tailing `log/production.log`, or by querying the database from Rails console using ActiveRecord. The seed task can take a while -- check [the repo wiki for stats](https://github.com/sul-dlss/preservation_catalog/wiki/Stats) on the timing of past runs (and some suggested overview queries). You can expect profiling runs will add overhead. The following rake tasks should be run from the root directory of the project, with whatever `RAILS_ENV` is appropriate. Because the task can take days when run over all storage roots, consider running it in a [screen session](http://thingsilearned.com/2009/05/26/gnu-screen-super-basic-tutorial/).
 
 Without profiling:
 ```ruby
-RAILS_ENVIRONMENT=production bundle exec rake seed_catalog
+RAILS_ENV=production bundle exec rake seed_catalog
 ```
 
 With profiling:
 ```ruby
-RAILS_ENVIRONMENT=production bundle exec rake seed_catalog[profile]
+RAILS_ENV=production bundle exec rake seed_catalog[profile]
 ```
+this will generate a log at, for example, `log/seed_from_disk2017-11-13T13:57:01.log`
+
 As an alternative to `screen`, you can also run the task, with or without profiling, in the background under `nohup`. For example:
 
 ```ruby
-RAILS_ENVIRONMENT=production bundle exec nohup rake seed_catalog &
+RAILS_ENV=production nohup bundle exec rake seed_catalog &
 ```
-
-this will generate a log at, for example, `log/seed_from_disk2017-11-13T13:57:01.log`
+By invoking commands via`nohup`, the invoked command doesn't get the kill signal when the terminal session that started it exits.  Output that would've gone to stdout is instead redirected to a file called `nohup.out` in the location from which the command was executed (here, the project root).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ With profiling:
 ```ruby
 RAILS_ENV=production bundle exec rake seed_catalog[profile]
 ```
-this will generate a log at, for example, `log/seed_from_disk2017-11-13T13:57:01.log`
+this will generate a log at, for example, `log/profile-flat-seed_from_disk2017-11-13T13:57:01.log`
 
 As an alternative to `screen`, you can also run the task, with or without profiling, in the background under `nohup`. For example:
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ RAILS_ENV=production nohup bundle exec rake seed_catalog &
 ```
 By invoking commands via`nohup`, the invoked command doesn't get the kill signal when the terminal session that started it exits.  Output that would've gone to stdout is instead redirected to a file called `nohup.out` in the location from which the command was executed (here, the project root).
 
+#### Reset the catalog for re-seeding
+
+WARNING! this will erase the catalog, and thus require re-seeding from scratch.  It is mostly intended for development purposes, and it is unlikely that you'll need to run this against production once the catalog is in regular use.
+
+* Deploy the branch of the code with which you wish to seed, to the instance which you wish to seed (e.g. master to stage).
+* Reset the database for that instance.  E.g., on production or stage:  `RAILS_ENV=production bundle exec rake db:reset`
+  * note that if you do this in an env that sees itself as production (i.e. production or stage), you'll get a scary warning along the lines of:
+  ```
+  ActiveRecord::ProtectedEnvironmentError: You are attempting to run a destructive action against your 'production' database.
+  If you are sure you want to continue, run the same command with the environment variable:
+  DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+  ```
+  Basically an especially inconvenient confirmation dialogue.  For safety's sake, the full command that skips that warning can be constructed by the user as needed, so as to prevent unintentional copy/paste dismissal when the user might be administering multiple deployment environments simultaneously.  Inadvertent database wipes are no fun.
+  * `db:reset` will make sure db is migrated and seeded.  If you want to be extra sure: `RAILS_ENV=[environment] bundle exec rake db:migrate db:seed`
+
+
 ## Development
 
 ### Running Tests

--- a/Rakefile
+++ b/Rakefile
@@ -21,13 +21,13 @@ task :seed_catalog, [:profile] => [:environment] do |_t, args|
     p "Usage: rake seed_catalog || rake seed_catalog[profile]"
     exit
   end
-  m2c = MoabToCatalog.new
+
   puts "#{Time.now.utc.iso8601} Seeding the database from all storage roots..."
   if args[:profile] == 'profile'
     puts 'When done, check log/profile-flat-seed_from_disk[TIMESTAMP].log for profiling details'
-    m2c.seed_from_disk_with_profiling
+    MoabToCatalog.seed_from_disk_with_profiling
   elsif args[:profile].nil?
-    m2c.seed_from_disk
+    MoabToCatalog.seed_from_disk
   end
   puts "#{Time.now.utc.iso8601} Done"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task :travis_setup_postgres do
   sh("psql -U postgres -f db/scripts/pres_test_setup.sql")
 end
 
-require_relative 'lib/audit/moab_to_catalog'
+require 'audit/moab_to_catalog.rb'
 desc 'populate the catalog with the contents of the online storage roots'
 task :seed_catalog, [:profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ task :seed_catalog, [:profile] => [:environment] do |_t, args|
   m2c = MoabToCatalog.new
   puts "#{Time.now.utc.iso8601} Seeding the database from all storage roots..."
   if args[:profile] == 'profile'
-    puts 'When done, check log/seed_from_disk[TIMESTAMP].log for profiling details'
+    puts 'When done, check log/profile-flat-seed_from_disk[TIMESTAMP].log for profiling details'
     m2c.seed_from_disk_with_profiling
   elsif args[:profile].nil?
     m2c.seed_from_disk

--- a/Rakefile
+++ b/Rakefile
@@ -23,11 +23,14 @@ task :seed_catalog, [:profile] => [:environment] do |_t, args|
   end
 
   puts "#{Time.now.utc.iso8601} Seeding the database from all storage roots..."
+  $stdout.flush # sometimes above doesn't end up getting flushed to STDOUT till the last puts when the run finishes
   if args[:profile] == 'profile'
     puts 'When done, check log/profile-flat-seed_from_disk[TIMESTAMP].log for profiling details'
+    $stdout.flush
     MoabToCatalog.seed_from_disk_with_profiling
   elsif args[:profile].nil?
     MoabToCatalog.seed_from_disk
   end
   puts "#{Time.now.utc.iso8601} Done"
+  $stdout.flush
 end

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -54,7 +54,7 @@ class MoabToCatalog
   def seed_from_disk_with_profiling
     profiler = Profiler.new
     profiler.prof { seed_from_disk }
-    profiler.print_results_flat('seed_from_disk')
+    profiler.print_results_flat('profile-flat-seed_from_disk')
   end
 
   # Shameless green. Code duplication with seed_from_disk

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -40,12 +40,12 @@ class MoabToCatalog
 
   # Shameless green. In order to run several seed "jobs" in parallel, we would have to refactor.
   def self.seed_from_disk
-    Settings.moab.storage_roots.each do |storage_root|
-      start_msg = "#{Time.now.utc.iso8601} Seeding starting for #{storage_root}"
+    Settings.moab.storage_roots.each do |strg_root_name, strg_root_location|
+      start_msg = "#{Time.now.utc.iso8601} Seeding starting for '#{strg_root_name}' at #{strg_root_location}"
       puts start_msg
       Rails.logger.info start_msg
-      seed_catalog("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
-      end_msg = "#{Time.now.utc.iso8601} Seeding ended for #{storage_root}"
+      seed_catalog("#{strg_root_location}/#{Settings.moab.storage_trunk}")
+      end_msg = "#{Time.now.utc.iso8601} Seeding ended for '#{strg_root_name}' at #{strg_root_location}"
       puts end_msg
       Rails.logger.info end_msg
     end
@@ -59,12 +59,12 @@ class MoabToCatalog
 
   # Shameless green. Code duplication with seed_from_disk
   def self.check_existence_from_disk
-    Settings.moab.storage_roots.each do |storage_root|
-      start_msg = "#{Time.now.utc.iso8601} Check_existence starting for #{storage_root}"
+    Settings.moab.storage_roots.each do |strg_root_name, strg_root_location|
+      start_msg = "#{Time.now.utc.iso8601} Check_existence starting for '#{strg_root_name}' at #{strg_root_location}"
       puts start_msg
       Rails.logger.info start_msg
-      check_existence("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
-      end_msg = "#{Time.now.utc.iso8601} Check_existence ended for #{storage_root}"
+      check_existence("#{strg_root_location}/#{Settings.moab.storage_trunk}")
+      end_msg = "#{Time.now.utc.iso8601} Check_existence ended for '#{strg_root_name}' at #{strg_root_location}"
       puts end_msg
       Rails.logger.info end_msg
     end

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -39,31 +39,31 @@ class MoabToCatalog
   end
 
   # Shameless green. In order to run several seed "jobs" in parallel, we would have to refactor.
-  def seed_from_disk
+  def self.seed_from_disk
     Settings.moab.storage_roots.each do |storage_root|
       start_msg = "#{Time.now.utc.iso8601} Seeding starting for #{storage_root}"
       puts start_msg
       Rails.logger.info start_msg
-      self.class.seed_catalog("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
+      seed_catalog("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
       end_msg = "#{Time.now.utc.iso8601} Seeding ended for #{storage_root}"
       puts end_msg
       Rails.logger.info end_msg
     end
   end
 
-  def seed_from_disk_with_profiling
+  def self.seed_from_disk_with_profiling
     profiler = Profiler.new
     profiler.prof { seed_from_disk }
     profiler.print_results_flat('profile-flat-seed_from_disk')
   end
 
   # Shameless green. Code duplication with seed_from_disk
-  def check_existence_from_disk
+  def self.check_existence_from_disk
     Settings.moab.storage_roots.each do |storage_root|
       start_msg = "#{Time.now.utc.iso8601} Check_existence starting for #{storage_root}"
       puts start_msg
       Rails.logger.info start_msg
-      self.class.check_existence("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
+      check_existence("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
       end_msg = "#{Time.now.utc.iso8601} Check_existence ended for #{storage_root}"
       puts end_msg
       Rails.logger.info end_msg

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -1,3 +1,5 @@
+require 'profiler.rb'
+
 ##
 # finds Moab objects on a single Moab storage_dir and interacts with Catalog (db)
 #   according to method called

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -9,40 +9,40 @@ RSpec.describe MoabToCatalog do
     PreservationPolicy.seed_from_config
   end
 
-  describe "#check_existence_from_disk" do
-    let(:m2c) { described_class.new }
+  describe ".check_existence_from_disk" do
+    let(:subject) { described_class.check_existence_from_disk }
 
     it 'calls check_existence once per storage root' do
       expect(described_class).to receive(:check_existence).exactly(Settings.moab.storage_roots.count).times
-      m2c.check_existence_from_disk
+      subject
     end
 
     it 'calls check_existence with the right arguments' do
       Settings.moab.storage_roots.each do |storage_root|
         expect(described_class).to receive(:check_existence).with("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
       end
-      m2c.check_existence_from_disk
+      subject
     end
   end
 
-  describe "#seed_from_disk" do
-    let(:m2c) { described_class.new }
+  describe ".seed_from_disk" do
+    let(:subject) { described_class.seed_from_disk }
 
     it 'calls seed_catalog once per storage root' do
       expect(described_class).to receive(:seed_catalog).exactly(Settings.moab.storage_roots.count).times
-      m2c.seed_from_disk
+      subject
     end
 
     it 'calls seed_catalog with the right arguments' do
       Settings.moab.storage_roots.each do |storage_root|
         expect(described_class).to receive(:seed_catalog).with("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
       end
-      m2c.seed_from_disk
+      subject
     end
   end
 
-  describe "#seed_from_disk_with_profiling" do
-    let(:m2c) { described_class.new }
+  describe ".seed_from_disk_with_profiling" do
+    let(:subject) { described_class.seed_from_disk_with_profiling }
 
     it "spins up a profiler, calling profiling and printing methods on it" do
       mock_profiler = instance_double(Profiler)
@@ -51,7 +51,7 @@ RSpec.describe MoabToCatalog do
       expect(mock_profiler).to receive(:prof)
       expect(mock_profiler).to receive(:print_results_flat)
 
-      m2c.seed_from_disk_with_profiling
+      subject
     end
   end
 


### PR DESCRIPTION
this contains some unticketed touchups that seemed like the right thing to do while i was in there, and felt like they wouldn't be conflict-y with the WIP based on the waffle board when i was looking at it this afternoon.  hopefully not too controversial, happy to break up into something more conservative if people would prefer.  broke into logical commits, but also hopefully not too painful to review all at once.

* minor fixes for accuracy to catalog seeding documentation (#332)
* fix require statements (#333)
* slightly more descriptive name for seeding profiling log file
* turn MoabToCatalog instance methods into class methods to make it all consistent across the class
  * clearer names for loop vars
* rake seed_catalog task: flush output to stdout in a more timely fashion
*  instructions for resetting the database, e.g. for use in rebuilding the catalog from scratch (#332)

closes #332
closes #333