### PR TITLE
rename seeding and check_existence methods to be clearer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,7 +49,7 @@ Layout/SpaceInsideBrackets:
 Metrics/AbcSize:
   Exclude:
     - 'app/services/preserved_object_handler.rb' # 2 methods but they seem readable
-    - 'lib/audit/moab_to_catalog.rb' # .seed_from_disk is decidedly readable
+    - 'lib/audit/moab_to_catalog.rb' # .seed_catalog_for_all_storage_roots is decidedly readable
 
 Metrics/BlockLength:
   Exclude:
@@ -67,7 +67,8 @@ Metrics/CyclomaticComplexity:
 Metrics/LineLength:
   Max: 120
   Exclude:
-    - 'app/services/preserved_object_handler.rb' # 2 lines 121
+    - 'app/services/preserved_object_handler.rb' # 1 lines 125
+    - 'spec/lib/audit/moab_to_catalog_spec.rb' # 1 line 126
     - 'spec/services/preserved_object_handler_create_spec.rb'
     - 'spec/services/preserved_object_handler_spec.rb'
     - 'spec/services/preserved_object_handler_update_version_spec.rb'

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ With profiling:
 ```ruby
 RAILS_ENV=production bundle exec rake seed_catalog[profile]
 ```
-this will generate a log at, for example, `log/profile-flat-seed_from_disk2017-11-13T13:57:01.log`
+this will generate a log at, for example, `log/profile_flat_seed_catalog_for_all_storage_roots2017-11-13T13:57:01.log`
 
 As an alternative to `screen`, you can also run the task, with or without profiling, in the background under `nohup`. For example:
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,11 +25,11 @@ task :seed_catalog, [:profile] => [:environment] do |_t, args|
   puts "#{Time.now.utc.iso8601} Seeding the database from all storage roots..."
   $stdout.flush # sometimes above doesn't end up getting flushed to STDOUT till the last puts when the run finishes
   if args[:profile] == 'profile'
-    puts 'When done, check log/profile-flat-seed_from_disk[TIMESTAMP].log for profiling details'
+    puts 'When done, check log/profile_flat_seed_catalog_for_all_storage_roots[TIMESTAMP].log for profiling details'
     $stdout.flush
-    MoabToCatalog.seed_from_disk_with_profiling
+    MoabToCatalog.seed_catalog_for_all_storage_roots_profiled
   elsif args[:profile].nil?
-    MoabToCatalog.seed_from_disk
+    MoabToCatalog.seed_catalog_for_all_storage_roots
   end
   puts "#{Time.now.utc.iso8601} Done"
   $stdout.flush

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -8,7 +8,7 @@ class CatalogToMoab
   #    step 1: ensure load_fixtures_helper works with very rough code here
   # FIXME:  temporarily turning off rubocop
   # rubocop:disable all
-  def self.check_existence
+  def self.check_existence_on_dir
     PreservedCopy.find_each do |pc|
       id = pc.preserved_object.druid
       version = pc.current_version

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -5,8 +5,8 @@ require 'profiler.rb'
 #   according to method called
 class MoabToCatalog
 
-  # NOTE: shameless green! code duplication with seed_catalog
-  def self.check_existence(storage_dir, expect_to_create=false)
+  # NOTE: shameless green! code duplication with seed_catalog_for_dir
+  def self.check_existence_for_dir(storage_dir, expect_to_create=false)
     results = []
     endpoint = Endpoint.find_by!(storage_location: storage_dir)
     Stanford::MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
@@ -22,8 +22,8 @@ class MoabToCatalog
     results
   end
 
-  # NOTE: shameless green! code duplication with check_existence
-  def self.seed_catalog(storage_dir)
+  # NOTE: shameless green! code duplication with check_existence_for_dir
+  def self.seed_catalog_for_dir(storage_dir)
     results = []
     endpoint = Endpoint.find_by!(storage_location: storage_dir)
     Stanford::MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
@@ -39,31 +39,31 @@ class MoabToCatalog
   end
 
   # Shameless green. In order to run several seed "jobs" in parallel, we would have to refactor.
-  def self.seed_from_disk
+  def self.seed_catalog_for_all_storage_roots
     Settings.moab.storage_roots.each do |strg_root_name, strg_root_location|
       start_msg = "#{Time.now.utc.iso8601} Seeding starting for '#{strg_root_name}' at #{strg_root_location}"
       puts start_msg
       Rails.logger.info start_msg
-      seed_catalog("#{strg_root_location}/#{Settings.moab.storage_trunk}")
+      seed_catalog_for_dir("#{strg_root_location}/#{Settings.moab.storage_trunk}")
       end_msg = "#{Time.now.utc.iso8601} Seeding ended for '#{strg_root_name}' at #{strg_root_location}"
       puts end_msg
       Rails.logger.info end_msg
     end
   end
 
-  def self.seed_from_disk_with_profiling
+  def self.seed_catalog_for_all_storage_roots_profiled
     profiler = Profiler.new
-    profiler.prof { seed_from_disk }
-    profiler.print_results_flat('profile-flat-seed_from_disk')
+    profiler.prof { seed_catalog_for_all_storage_roots }
+    profiler.print_results_flat('profile_flat_seed_catalog_for_all_storage_roots')
   end
 
-  # Shameless green. Code duplication with seed_from_disk
-  def self.check_existence_from_disk
+  # Shameless green. Code duplication with seed_catalog_for_all_storage_roots
+  def self.check_existence_for_all_storage_roots
     Settings.moab.storage_roots.each do |strg_root_name, strg_root_location|
       start_msg = "#{Time.now.utc.iso8601} Check_existence starting for '#{strg_root_name}' at #{strg_root_location}"
       puts start_msg
       Rails.logger.info start_msg
-      check_existence("#{strg_root_location}/#{Settings.moab.storage_trunk}")
+      check_existence_for_dir("#{strg_root_location}/#{Settings.moab.storage_trunk}")
       end_msg = "#{Time.now.utc.iso8601} Check_existence ended for '#{strg_root_name}' at #{strg_root_location}"
       puts end_msg
       Rails.logger.info end_msg

--- a/lib/benchmarking/moab_to_catalog_testing.rb
+++ b/lib/benchmarking/moab_to_catalog_testing.rb
@@ -36,8 +36,8 @@ Stanford::StorageServices.storage_roots.each do |storage_root|
   time_to_check_existence = Benchmark.realtime do
     logger.info "Check for output"
     # RubyProf.start
-    # when creating add true parameter, and if updating leave blank
-    MoabToCatalog.check_existence(File.join(storage_root, Moab::Config.storage_trunk))
+    # when expect_to_create add true parameter
+    MoabToCatalog.check_existence_for_dir(File.join(storage_root, Moab::Config.storage_trunk))
     # TODO: haven't actually tested this, but looks to me like this will only get profiling info for the last
     # storage root that was checked.  one way to collect for everything would be to use the start/pause/resume
     # approach described in the RubyProf docs, presumably with a start/pause above this loop, resume/pause in

--- a/lib/profiler.rb
+++ b/lib/profiler.rb
@@ -3,7 +3,7 @@
 # stops the profiler and returns the results of the profiling.
 # example usage:
 #  profiler = Profiler.new
-#  profiler.prof { MoabToCatalog.seed_catalog(storage_dir) }
+#  profiler.prof { MoabToCatalog.seed_catalog_for_dir(storage_dir) }
 #  profiler.print_results_flat(out_file_id)
 class Profiler
 

--- a/spec/lib/audit/catalog_to_moab_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_spec.rb
@@ -3,11 +3,11 @@ require_relative '../../load_fixtures_helper.rb'
 
 RSpec.describe CatalogToMoab do
   include_context 'fixture moabs in db'
-  describe '.check_existence' do
+  describe '.check_existence_on_dir' do
     # NOTE: this is at the chicken scratches stage
     #  step 1: ensure load_fixtures_helper works
-    it 'test_of_load_fixtures_helper (eventually will be testing code for .check_existence)' do
-      described_class.check_existence
+    it 'test_of_load_fixtures_helper (eventually will be testing code for .check_existence_on_dir)' do
+      described_class.check_existence_on_dir
     end
   end
 end

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -9,40 +9,40 @@ RSpec.describe MoabToCatalog do
     PreservationPolicy.seed_from_config
   end
 
-  describe ".check_existence_from_disk" do
-    let(:subject) { described_class.check_existence_from_disk }
+  describe ".check_existence_for_all_storage_roots" do
+    let(:subject) { described_class.check_existence_for_all_storage_roots }
 
-    it 'calls check_existence once per storage root' do
-      expect(described_class).to receive(:check_existence).exactly(Settings.moab.storage_roots.count).times
+    it 'calls check_existence_for_dir once per storage root' do
+      expect(described_class).to receive(:check_existence_for_dir).exactly(Settings.moab.storage_roots.count).times
       subject
     end
 
-    it 'calls check_existence with the right arguments' do
+    it 'calls check_existence_for_dir with the right arguments' do
       Settings.moab.storage_roots.each do |storage_root|
-        expect(described_class).to receive(:check_existence).with("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
+        expect(described_class).to receive(:check_existence_for_dir).with("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
       end
       subject
     end
   end
 
-  describe ".seed_from_disk" do
-    let(:subject) { described_class.seed_from_disk }
+  describe ".seed_catalog_for_all_storage_roots" do
+    let(:subject) { described_class.seed_catalog_for_all_storage_roots }
 
-    it 'calls seed_catalog once per storage root' do
-      expect(described_class).to receive(:seed_catalog).exactly(Settings.moab.storage_roots.count).times
+    it 'calls seed_catalog_for_dir once per storage root' do
+      expect(described_class).to receive(:seed_catalog_for_dir).exactly(Settings.moab.storage_roots.count).times
       subject
     end
 
-    it 'calls seed_catalog with the right arguments' do
+    it 'calls seed_catalog_for_dir with the right arguments' do
       Settings.moab.storage_roots.each do |storage_root|
-        expect(described_class).to receive(:seed_catalog).with("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
+        expect(described_class).to receive(:seed_catalog_for_dir).with("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
       end
       subject
     end
   end
 
-  describe ".seed_from_disk_with_profiling" do
-    let(:subject) { described_class.seed_from_disk_with_profiling }
+  describe ".seed_catalog_for_all_storage_roots_profiled" do
+    let(:subject) { described_class.seed_catalog_for_all_storage_roots_profiled }
 
     it "spins up a profiler, calling profiling and printing methods on it" do
       mock_profiler = instance_double(Profiler)
@@ -55,8 +55,8 @@ RSpec.describe MoabToCatalog do
     end
   end
 
-  describe ".check_existence" do
-    let(:subject) { described_class.check_existence(storage_dir, true) }
+  describe ".check_existence_for_dir" do
+    let(:subject) { described_class.check_existence_for_dir(storage_dir, true) }
 
     it "calls 'find_moab_paths' with appropriate argument" do
       expect(Stanford::MoabStorageDirectory).to receive(:find_moab_paths).with(storage_dir)
@@ -117,7 +117,7 @@ RSpec.describe MoabToCatalog do
             expect(Rails.logger).to receive(:error).with(exp_msg)
             expect(arg_hash[:po_handler]).to receive(:create)
           end
-          described_class.check_existence(storage_dir, true)
+          described_class.check_existence_for_dir(storage_dir, true)
         end
         it 'does not call #create when expect_to_create is false' do
           expected_argument_list.each do |arg_hash|
@@ -126,7 +126,7 @@ RSpec.describe MoabToCatalog do
             expect(Rails.logger).to receive(:error).with(exp_msg)
             expect(arg_hash[:po_handler]).not_to receive(:create)
           end
-          described_class.check_existence(storage_dir) # expect_to_create is false by default
+          described_class.check_existence_for_dir(storage_dir) # expect_to_create is false by default
         end
       end
 
@@ -144,18 +144,18 @@ RSpec.describe MoabToCatalog do
     end
     it "storage directory doesn't exist (misspelling, read write permissions)" do
       allow(Endpoint).to receive(:find_by!).and_return(instance_double(Endpoint))
-      expect { described_class.check_existence('spec/fixtures/moab_strge_root') }.to raise_error(
+      expect { described_class.check_existence_for_dir('spec/fixtures/moab_strge_root') }.to raise_error(
         SystemCallError, /No such file or directory/
       )
     end
     it "storage directory exists but it is empty" do
       storage_dir = 'spec/fixtures/empty/moab_storage_trunk'
-      expect(described_class.check_existence(storage_dir)).to eq []
+      expect(described_class.check_existence_for_dir(storage_dir)).to eq []
     end
   end
 
-  describe ".seed_catalog" do
-    let(:subject) { described_class.seed_catalog(storage_dir) }
+  describe ".seed_catalog_for_dir" do
+    let(:subject) { described_class.seed_catalog_for_dir(storage_dir) }
 
     it "calls 'find_moab_paths' with appropriate argument" do
       expect(Stanford::MoabStorageDirectory).to receive(:find_moab_paths).with(storage_dir)
@@ -230,13 +230,13 @@ RSpec.describe MoabToCatalog do
     end
     it "storage directory doesn't exist (misspelling, read write permissions)" do
       allow(Endpoint).to receive(:find_by!).and_return(instance_double(Endpoint))
-      expect { described_class.check_existence('spec/fixtures/moab_strge_root') }.to raise_error(
+      expect { described_class.check_existence_for_dir('spec/fixtures/moab_strge_root') }.to raise_error(
         SystemCallError, /No such file or directory/
       )
     end
     it "storage directory exists but it is empty" do
       storage_dir = 'spec/fixtures/empty/moab_storage_trunk'
-      expect(described_class.check_existence(storage_dir)).to eq []
+      expect(described_class.check_existence_for_dir(storage_dir)).to eq []
     end
   end
 end


### PR DESCRIPTION
our moab_to_catalog method names were almost the opposite of what I expected.  Do folks think this is an improvement?