### PR TITLE
remove duplicate PreservedObject.exists? from M2C.seed_catalog_for_dir

### DIFF
--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -29,11 +29,7 @@ class MoabToCatalog
     Stanford::MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
       moab = Moab::StorageObject.new(druid, path)
       po_handler = PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, endpoint)
-      if PreservedObject.exists?(druid: druid)
-        Rails.logger.error "druid: #{druid} NOT expected to exist in catalog but was found"
-      else
-        results << po_handler.create_after_validation
-      end
+      results << po_handler.create_after_validation
     end
     results
   end

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe MoabToCatalog do
       subject
     end
 
-    context "(creates or errors)" do
+    context "(creates after validation)" do
       let(:expected_argument_list) do
         [
           { druid: 'bj102hs9687', storage_root_current_version: 3 },
@@ -207,19 +207,9 @@ RSpec.describe MoabToCatalog do
           ).and_return(po_handler)
         end
       end
-      it "call #create_after_validation if object does not exist" do
+      it "call #create_after_validation" do
         expected_argument_list.each do |arg_hash|
-          expect(PreservedObject).to receive(:exists?).with(druid: arg_hash[:druid]).and_return(false)
           expect(arg_hash[:po_handler]).to receive(:create_after_validation)
-        end
-        subject
-      end
-      it "error if object exists" do
-        expected_argument_list.each do |arg_hash|
-          allow(PreservedObject).to receive(:exists?).with(druid: arg_hash[:druid]).and_return(true)
-          exp_msg = "druid: #{arg_hash[:druid]} NOT expected to exist in catalog but was found"
-          expect(Rails.logger).to receive(:error).with(exp_msg)
-          expect(arg_hash[:po_handler]).not_to receive(:create_after_validation)
         end
         subject
       end


### PR DESCRIPTION
- Removed ``` PreservedObject.exists?(druid: druid) ``` from ```MoabToCatalog.seed_catalog_for_dir(storage_dir) ``` because ``` PreservedObject.exists?(druid: druid) ``` is called in ``` PreservedObjectHandler#create_after_validation ``` 
- Removed / changed corresponding spec tests
- connects #311