### PR TITLE
turn off provenance logging for development

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,4 +45,4 @@ statuses:
 default_status: ok
 
 provlog:
-  enable: true
+  enable: false


### PR DESCRIPTION
we don't need it clogging up space (and grep results) on our local implementation, IMHO.