### PR TITLE
 rake task to drop specific storage root

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,16 @@ Layout/SpaceInsideBrackets:
   Exclude:
     - 'config/environments/production.rb' # that's how Rails generates it
 
+# --- Lint ---
+Lint/HandleExceptions:
+  Exclude:
+    - 'spec/lib/audit/moab_to_catalog_spec.rb' # So method does not stop executing and can test the correct case
+
+Lint/RescueWithoutErrorClass:
+  Exclude:
+    - 'spec/lib/audit/moab_to_catalog_spec.rb' # So method does not stop executing and can test the correct case
+
+
 # --- Metrics ---
 
 Metrics/AbcSize:

--- a/Rakefile
+++ b/Rakefile
@@ -34,3 +34,19 @@ task :seed_catalog, [:profile] => [:environment] do |_t, args|
   puts "#{Time.now.utc.iso8601} Done"
   $stdout.flush
 end
+
+desc "Delete single endpoint db data"
+task :drop, [:storage_root] => [:environment] do |_t, args|
+  if args[:storage_root]
+    root = args[:storage_root]
+    puts "You're about to erase all the data for #{root}. Are you sure you want to continue? [y/N]"
+    input = STDIN.gets.chomp
+    if input.casecmp("y").zero? # rubocop prefers casecmp because it is faster than '.downcase =='
+      MoabToCatalog.drop_endpoint(root)
+    else
+      puts "You canceled erasing data from #{root}"
+    end
+  else
+    puts "You need to enter a specific storage root"
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ task :drop, [:storage_root] => [:environment] do |_t, args|
     input = STDIN.gets.chomp
     if input.casecmp("y").zero? # rubocop prefers casecmp because it is faster than '.downcase =='
       MoabToCatalog.drop_endpoint(root)
+      puts "You have successfully deleted all the data from #{root}"
     else
       puts "You canceled erasing data from #{root}"
     end

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -65,4 +65,14 @@ class MoabToCatalog
       Rails.logger.info end_msg
     end
   end
+
+  def self.drop_endpoint(endpoint_name)
+    ApplicationRecord.transaction do
+      PreservedCopy.joins(:endpoint).where(
+        "endpoints.endpoint_name = :endpoint_name",
+        endpoint_name: endpoint_name.to_s
+      ).destroy_all
+      PreservedObject.left_outer_joins(:preserved_copies).where(preserved_copies: { id: nil }).destroy_all
+    end
+  end
 end


### PR DESCRIPTION
- I'm deleting all PreservedCopies that have an endpoint_name of whatever you specify
- Then i'm deleting the rest of the orphan PreservedObejcts

- Had to do this weird syntax in `moab_to_catalog_spec.rb` lines 259-264
```
begin
  subject
rescue
end
```
If anyone knows how to get around this, I would like to know!

- Also, should I add a `puts` statement that says something like `Congrats you deleted all the data off #{endpoint_name}` ?


closes #342 