### PR TITLE
PreservedObjectHandler: refactored results and logging into separate class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,7 @@ Layout/SpaceAroundEqualsInParameterDefault:
 Layout/SpaceInsideBrackets:
   Exclude:
     - 'config/environments/production.rb' # that's how Rails generates it
+    - 'app/services/preserved_object_handler.rb' # line 126 is clearer with the spaces
 
 # --- Lint ---
 Lint/HandleExceptions:
@@ -71,13 +72,15 @@ Metrics/ClassLength:
 
 Metrics/CyclomaticComplexity:
   Exclude:
-    - 'app/services/preserved_object_handler.rb' # a method that is simply a case statement
+    - 'app/services/preserved_object_handler.rb' # update_online_version (shameless green)
+    - 'app/services/preserved_object_handler_results.rb' # logger_severity_level is simply a case statement
 
 # because this isn't 1994
 Metrics/LineLength:
   Max: 120
   Exclude:
-    - 'app/services/preserved_object_handler.rb' # 1 lines 125
+    - 'app/services/preserved_object_handler.rb' # line 269 is 121
+    - 'app/services/preserved_object_handler_results.rb' # line 35 is 121
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # 1 line 126
     - 'spec/services/preserved_object_handler_create_spec.rb'
     - 'spec/services/preserved_object_handler_spec.rb'
@@ -183,6 +186,10 @@ Style/FormatString:
 
 Style/FormatStringToken:
   EnforcedStyle: template # using interpolated strings in PreservedObjectHandler
+
+Style/GuardClause:
+  Exclude:
+    - app/services/preserved_object_handler.rb # update_status method easy to read as is
 
 Style/PercentLiteralDelimiters:
   Exclude:

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -188,7 +188,7 @@ class PreservedObjectHandler
       end
     end
 
-    handler_results.remove_db_updated_result unless transaction_ok
+    handler_results.remove_db_updated_results unless transaction_ok
   end
 
   def confirm_version_in_catalog
@@ -198,7 +198,7 @@ class PreservedObjectHandler
       confirm_version_on_db_object(po_db_object, :current_version)
       confirm_version_on_db_object(pc_db_object, :version)
     end
-    handler_results.remove_db_updated_result unless transaction_ok
+    handler_results.remove_db_updated_results unless transaction_ok
   end
 
   # performs passed code wrapped in ActiveRecord transaction via yield

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -149,16 +149,16 @@ class PreservedObjectHandler
     object_dir = "#{storage_location}/#{DruidTools::Druid.new(druid).tree.join('/')}"
     moab = Moab::StorageObject.new(druid, object_dir)
     object_validator = Stanford::StorageObjectValidator.new(moab)
-    errors = object_validator.validation_errors(Settings.moab.allow_content_subdirs)
-    if errors.any?
+    moab_errors = object_validator.validation_errors(Settings.moab.allow_content_subdirs)
+    if moab_errors.any?
       moab_error_msg_list = []
-      errors.each do |error_hash|
+      moab_errors.each do |error_hash|
         error_hash.each_value { |moab_error_msgs| moab_error_msg_list << moab_error_msgs }
       end
       results << result_hash(INVALID_MOAB, moab_error_msg_list)
       log_results(results)
     end
-    errors
+    moab_errors
   end
 
   def create_db_objects(status, validated=false)

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -42,7 +42,7 @@ class PreservedObjectHandler
       create_db_objects(PreservedCopy.statuses[:invalid_moab], true)
     end
 
-    handler_results.log_my_results
+    handler_results.log_results
     handler_results.result_array
   end
 
@@ -55,7 +55,7 @@ class PreservedObjectHandler
       create_db_objects(PreservedCopy::DEFAULT_STATUS)
     end
 
-    handler_results.log_my_results
+    handler_results.log_results
     handler_results.result_array
   end
 
@@ -67,7 +67,7 @@ class PreservedObjectHandler
       confirm_version_in_catalog
     end
 
-    handler_results.log_my_results
+    handler_results.log_results
     handler_results.result_array
   end
 
@@ -89,7 +89,7 @@ class PreservedObjectHandler
       end
     end
 
-    handler_results.log_my_results
+    handler_results.log_results
     handler_results.result_array
   end
 
@@ -106,7 +106,7 @@ class PreservedObjectHandler
       end
     end
 
-    handler_results.log_my_results
+    handler_results.log_results
     handler_results.result_array
   end
 
@@ -122,9 +122,7 @@ class PreservedObjectHandler
       moab_errors.each do |error_hash|
         error_hash.each_value { |msg| moab_error_msgs << msg }
       end
-      PreservedObjectHandlerResults.log_results(
-        [ handler_results.result_hash(PreservedObjectHandlerResults::INVALID_MOAB, moab_error_msgs) ]
-      )
+      handler_results.add_result(PreservedObjectHandlerResults::INVALID_MOAB, moab_error_msgs)
     end
     moab_errors
   end

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -237,7 +237,7 @@ class PreservedObjectHandler
     elsif incoming_version < db_object.send(version_symbol)
       handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT, db_object.class.name)
     elsif incoming_version > db_object.send(version_symbol)
-      handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT, db_object.class.name)
+      handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT, db_object.class.name)
     end
   end
 

--- a/app/services/preserved_object_handler_results.rb
+++ b/app/services/preserved_object_handler_results.rb
@@ -85,7 +85,7 @@ class PreservedObjectHandlerResults
   end
 
   # used when updates wrapped in transaction fail, and there is a need to ensure there is no db updated result
-  def remove_db_updated_result
+  def remove_db_updated_results
     result_array.delete_if { |res_hash| DB_UPDATED_CODES.include?(res_hash.keys.first) }
   end
 

--- a/app/services/preserved_object_handler_results.rb
+++ b/app/services/preserved_object_handler_results.rb
@@ -1,0 +1,112 @@
+# PreservedObjectHandler results are an array of hash objects, like so:
+#   results = [result1, result2]
+#   result1 = {response_code => msg}
+#   result2 = {response_code => msg}
+#
+# This class extracts out the result specific logic from PreservedObjectHandler to make the code more readable
+class PreservedObjectHandlerResults
+
+  INVALID_ARGUMENTS = 1
+  VERSION_MATCHES = 2
+  ARG_VERSION_GREATER_THAN_DB_OBJECT = 3
+  ARG_VERSION_LESS_THAN_DB_OBJECT = 4
+  UPDATED_DB_OBJECT = 5
+  UPDATED_DB_OBJECT_TIMESTAMP_ONLY = 6
+  CREATED_NEW_OBJECT = 7
+  DB_UPDATE_FAILED = 8
+  OBJECT_ALREADY_EXISTS = 9
+  OBJECT_DOES_NOT_EXIST = 10
+  PC_STATUS_CHANGED = 11
+  UNEXPECTED_VERSION = 12
+  INVALID_MOAB = 13
+
+  RESPONSE_CODE_TO_MESSAGES = {
+    INVALID_ARGUMENTS => "encountered validation error(s): %{addl}",
+    VERSION_MATCHES => "incoming version (%{incoming_version}) matches %{addl} db version",
+    ARG_VERSION_GREATER_THAN_DB_OBJECT => "incoming version (%{incoming_version}) greater than %{addl} db version",
+    ARG_VERSION_LESS_THAN_DB_OBJECT => "incoming version (%{incoming_version}) less than %{addl} db version; ERROR!",
+    UPDATED_DB_OBJECT => "%{addl} db object updated",
+    UPDATED_DB_OBJECT_TIMESTAMP_ONLY => "%{addl} updated db timestamp only",
+    CREATED_NEW_OBJECT => "added object to db as it did not exist",
+    DB_UPDATE_FAILED => "db update failed: %{addl}",
+    OBJECT_ALREADY_EXISTS => "%{addl} db object already exists",
+    OBJECT_DOES_NOT_EXIST => "%{addl} db object does not exist",
+    PC_STATUS_CHANGED => "PreservedCopy status changed from %{old_status} to %{new_status}",
+    UNEXPECTED_VERSION => "incoming version (%{incoming_version}) has unexpected relationship to %{addl} db version; ERROR!",
+    INVALID_MOAB => "Invalid moab, validation errors: %{addl}"
+  }.freeze
+
+  DB_UPDATED_CODES = [
+    UPDATED_DB_OBJECT,
+    UPDATED_DB_OBJECT_TIMESTAMP_ONLY,
+    CREATED_NEW_OBJECT,
+    PC_STATUS_CHANGED
+  ].freeze
+
+  # results = [result1, result2]
+  # result1 = {response_code => msg}
+  # result2 = {response_code => msg}
+  def self.log_results(results)
+    results.each do |r|
+      severity = logger_severity_level(r.keys.first)
+      msg = r.values.first
+      Rails.logger.log(severity, msg)
+    end
+  end
+
+  def self.logger_severity_level(result_code)
+    case result_code
+    when INVALID_ARGUMENTS then Logger::ERROR
+    when VERSION_MATCHES then Logger::INFO
+    when ARG_VERSION_GREATER_THAN_DB_OBJECT then Logger::INFO
+    when ARG_VERSION_LESS_THAN_DB_OBJECT then Logger::ERROR
+    when UPDATED_DB_OBJECT then Logger::INFO
+    when UPDATED_DB_OBJECT_TIMESTAMP_ONLY then Logger::INFO
+    when CREATED_NEW_OBJECT then Logger::INFO
+    when DB_UPDATE_FAILED then Logger::ERROR
+    when OBJECT_ALREADY_EXISTS then Logger::ERROR
+    when OBJECT_DOES_NOT_EXIST then Logger::ERROR
+    when PC_STATUS_CHANGED then Logger::INFO
+    when UNEXPECTED_VERSION then Logger::ERROR
+    when INVALID_MOAB then Logger::ERROR
+    end
+  end
+
+  attr_reader :result_array, :incoming_version, :msg_prefix
+
+  def initialize(druid, incoming_version, incoming_size, endpoint)
+    @incoming_version = incoming_version
+    @msg_prefix = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{endpoint})"
+    @result_array = []
+  end
+
+  def add_result(code, msg_args=nil)
+    result_array << result_hash(code, msg_args)
+  end
+
+  # used when updates wrapped in transaction fail, and there is a need to ensure there is no db updated result
+  def remove_db_updated_result
+    result_array.delete_if { |res_hash| DB_UPDATED_CODES.include?(res_hash.keys.first) }
+  end
+
+  def result_hash(code, msg_args=nil)
+    { code => result_code_msg(code, msg_args) }
+  end
+
+  def log_my_results
+    self.class.log_results(result_array)
+  end
+
+  private
+
+  def result_code_msg(code, addl=nil)
+    arg_hash = { incoming_version: incoming_version }
+    if addl.is_a?(Hash)
+      arg_hash.merge!(addl)
+    else
+      arg_hash[:addl] = addl
+    end
+
+    "#{msg_prefix} #{RESPONSE_CODE_TO_MESSAGES[code] % arg_hash}"
+  end
+end

--- a/app/services/preserved_object_handler_results.rb
+++ b/app/services/preserved_object_handler_results.rb
@@ -43,17 +43,6 @@ class PreservedObjectHandlerResults
     PC_STATUS_CHANGED
   ].freeze
 
-  # results = [result1, result2]
-  # result1 = {response_code => msg}
-  # result2 = {response_code => msg}
-  def self.log_results(results)
-    results.each do |r|
-      severity = logger_severity_level(r.keys.first)
-      msg = r.values.first
-      Rails.logger.log(severity, msg)
-    end
-  end
-
   def self.logger_severity_level(result_code)
     case result_code
     when INVALID_ARGUMENTS then Logger::ERROR
@@ -93,8 +82,15 @@ class PreservedObjectHandlerResults
     { code => result_code_msg(code, msg_args) }
   end
 
-  def log_my_results
-    self.class.log_results(result_array)
+  # result_array = [result1, result2]
+  # result1 = {response_code => msg}
+  # result2 = {response_code => msg}
+  def log_results
+    result_array.each do |r|
+      severity = self.class.logger_severity_level(r.keys.first)
+      msg = r.values.first
+      Rails.logger.log(severity, msg)
+    end
   end
 
   private

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -40,13 +40,14 @@ RSpec.describe PreservedObjectHandler do
       it 'logs an error' do
         po_handler.create
         expect(Rails.logger).to receive(:log).with(Logger::ERROR, exp_msg)
-        po_handler.create
+        new_po_handler = described_class.new(druid, incoming_version, incoming_size, ep)
+        new_po_handler.create
       end
     end
 
     context 'db update error' do
       context 'ActiveRecordError' do
-        let(:result_code) { PreservedObjectHandler::DB_UPDATE_FAILED }
+        let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
         let(:results) do
           allow(Rails.logger).to receive(:log)
           # FIXME: couldn't figure out how to put next line into its own test
@@ -70,7 +71,7 @@ RSpec.describe PreservedObjectHandler do
             expect(results).to include(a_hash_including(result_code => a_string_matching('foo')))
           end
           it 'does NOT get CREATED_NEW_OBJECT message' do
-            expect(results).not_to include(hash_including(PreservedObjectHandler::CREATED_NEW_OBJECT))
+            expect(results).not_to include(hash_including(PreservedObjectHandlerResults::CREATED_NEW_OBJECT))
           end
         end
       end
@@ -91,7 +92,7 @@ RSpec.describe PreservedObjectHandler do
         expect(result.size).to eq 1
       end
       it 'CREATED_NEW_OBJECT result' do
-        code = PreservedObjectHandler::CREATED_NEW_OBJECT
+        code = PreservedObjectHandlerResults::CREATED_NEW_OBJECT
         expect(result).to include(a_hash_including(code => exp_msg))
       end
     end
@@ -193,7 +194,7 @@ RSpec.describe PreservedObjectHandler do
 
       context 'db update error' do
         context 'ActiveRecordError' do
-          let(:result_code) { PreservedObjectHandler::DB_UPDATE_FAILED }
+          let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
           let(:results) do
             allow(Rails.logger).to receive(:log)
             # FIXME: couldn't figure out how to put next line into its own test
@@ -256,7 +257,7 @@ RSpec.describe PreservedObjectHandler do
         expect(result.size).to eq 1
       end
       it 'CREATED_NEW_OBJECT result' do
-        code = PreservedObjectHandler::CREATED_NEW_OBJECT
+        code = PreservedObjectHandlerResults::CREATED_NEW_OBJECT
         expect(result).to include(a_hash_including(code => exp_msg))
       end
     end

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe PreservedObjectHandler do
         PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
         po_handler = described_class.new(druid, 3, incoming_size, diff_ep)
         results = po_handler.confirm_version
-        expect(results).to include(a_hash_including(PreservedObjectHandler::OBJECT_DOES_NOT_EXIST => a_string_matching("ActiveRecord::RecordNotFound: Couldn't find PreservedCopy> db object does not exist")))
+        expect(results).to include(a_hash_including(PreservedObjectHandlerResults::OBJECT_DOES_NOT_EXIST => a_string_matching("ActiveRecord::RecordNotFound: Couldn't find PreservedCopy> db object does not exist")))
         expect(PreservedObject.find_by(druid: druid).current_version).to eq 2
       end
 
@@ -135,12 +135,12 @@ RSpec.describe PreservedObjectHandler do
             expect(results.size).to eq 4
           end
           it 'VERSION_MATCHES results' do
-            code = PreservedObjectHandler::VERSION_MATCHES
+            code = PreservedObjectHandlerResults::VERSION_MATCHES
             expect(results).to include(a_hash_including(code => version_matches_pc_msg))
             expect(results).to include(a_hash_including(code => version_matches_po_msg))
           end
           it 'UPDATED_DB_OBJECT_TIMESTAMP_ONLY results' do
-            code = PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY
+            code = PreservedObjectHandlerResults::UPDATED_DB_OBJECT_TIMESTAMP_ONLY
             expect(results).to include(a_hash_including(code => updated_pc_db_timestamp_msg))
             expect(results).to include(a_hash_including(code => updated_po_db_timestamp_msg))
           end
@@ -189,12 +189,12 @@ RSpec.describe PreservedObjectHandler do
             expect(results.size).to eq 4
           end
           it 'ARG_VERSION_GREATER_THAN_DB_OBJECT results' do
-            code = PreservedObjectHandler::ARG_VERSION_GREATER_THAN_DB_OBJECT
+            code = PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT
             expect(results).to include(a_hash_including(code => version_gt_pc_msg))
             expect(results).to include(a_hash_including(code => version_gt_po_msg))
           end
           it 'UPDATED_DB_OBJECT results' do
-            code = PreservedObjectHandler::UPDATED_DB_OBJECT
+            code = PreservedObjectHandlerResults::UPDATED_DB_OBJECT
             expect(results).to include(a_hash_including(code => updated_pc_db_msg))
             expect(results).to include(a_hash_including(code => updated_po_db_msg))
           end
@@ -243,28 +243,28 @@ RSpec.describe PreservedObjectHandler do
             expect(results.size).to eq 5
           end
           it 'ARG_VERSION_LESS_THAN_DB_OBJECT results' do
-            code = PreservedObjectHandler::ARG_VERSION_LESS_THAN_DB_OBJECT
+            code = PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT
             expect(results).to include(a_hash_including(code => version_less_than_pc_msg))
             expect(results).to include(a_hash_including(code => version_less_than_po_msg))
           end
           # FIXME: do we want to update timestamp if we found an error (ARG_VERSION_LESS_THAN_DB_OBJECT)
           it "PreservedObject UPDATED_DB_OBJECT_TIMESTAMP_ONLY result" do
-            code = PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY
+            code = PreservedObjectHandlerResults::UPDATED_DB_OBJECT_TIMESTAMP_ONLY
             expect(results).to include(a_hash_including(code => updated_po_db_timestamp_msg))
           end
           it "PreservedCopy UPDATED_DB_OBJECT result" do
-            code = PreservedObjectHandler::UPDATED_DB_OBJECT
+            code = PreservedObjectHandlerResults::UPDATED_DB_OBJECT
             expect(results).to include(a_hash_including(code => updated_pc_db_obj_msg))
           end
           it "PreservedCopy PC_STATUS_CHANGED result" do
-            code = PreservedObjectHandler::PC_STATUS_CHANGED
+            code = PreservedObjectHandlerResults::PC_STATUS_CHANGED
             expect(results).to include(a_hash_including(code => updated_pc_db_status_msg))
           end
         end
       end
       context 'db update error' do
         context 'ActiveRecordError' do
-          let(:result_code) { PreservedObjectHandler::DB_UPDATE_FAILED }
+          let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
           let(:results) do
             allow(Rails.logger).to receive(:log)
             # FIXME: couldn't figure out how to put next line into its own test

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -96,12 +96,12 @@ RSpec.describe PreservedObjectHandler do
             expect(results.size).to eq 4
           end
           it 'ARG_VERSION_GREATER_THAN_DB_OBJECT results' do
-            code = PreservedObjectHandler::ARG_VERSION_GREATER_THAN_DB_OBJECT
+            code = PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT
             expect(results).to include(a_hash_including(code => version_gt_pc_msg))
             expect(results).to include(a_hash_including(code => version_gt_po_msg))
           end
           it "UPDATED_DB_OBJECT results" do
-            code = PreservedObjectHandler::UPDATED_DB_OBJECT
+            code = PreservedObjectHandlerResults::UPDATED_DB_OBJECT
             expect(results).to include(a_hash_including(code => updated_pc_db_msg))
             expect(results).to include(a_hash_including(code => updated_po_db_msg))
           end
@@ -163,14 +163,14 @@ RSpec.describe PreservedObjectHandler do
             expect(results.size).to eq 3
           end
           it 'UNEXPECTED_VERSION result' do
-            code = PreservedObjectHandler::UNEXPECTED_VERSION
+            code = PreservedObjectHandlerResults::UNEXPECTED_VERSION
             expect(results).to include(a_hash_including(code => unexpected_version_msg))
           end
           it 'specific version results' do
             codes = [
-              PreservedObjectHandler::VERSION_MATCHES,
-              PreservedObjectHandler::ARG_VERSION_GREATER_THAN_DB_OBJECT,
-              PreservedObjectHandler::ARG_VERSION_LESS_THAN_DB_OBJECT
+              PreservedObjectHandlerResults::VERSION_MATCHES,
+              PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT,
+              PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT
             ]
             obj_version_results = results.select { |r| codes.include?(r.keys.first) }
             msgs = obj_version_results.map { |r| r.values.first }
@@ -178,10 +178,10 @@ RSpec.describe PreservedObjectHandler do
             expect(msgs).to include(a_string_matching("PreservedCopy"))
           end
           it "no UPDATED_DB_OBJECT_TIMESTAMP_ONLY results" do
-            expect(results).not_to include(a_hash_including(PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY))
+            expect(results).not_to include(a_hash_including(PreservedObjectHandlerResults::UPDATED_DB_OBJECT_TIMESTAMP_ONLY))
           end
           it 'no PC_STATUS_CHANGED result' do
-            expect(results).not_to include(a_hash_including(PreservedObjectHandler::PC_STATUS_CHANGED))
+            expect(results).not_to include(a_hash_including(PreservedObjectHandlerResults::PC_STATUS_CHANGED))
           end
         end
       end
@@ -204,7 +204,7 @@ RSpec.describe PreservedObjectHandler do
       end
 
       context 'db update error' do
-        let(:result_code) { PreservedObjectHandler::DB_UPDATE_FAILED }
+        let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
 
         context 'PreservedCopy' do
           context 'ActiveRecordError' do
@@ -239,8 +239,8 @@ RSpec.describe PreservedObjectHandler do
                 expect(results).to include(a_hash_including(result_code => a_string_matching('foo')))
               end
               it 'does NOT get UPDATED_DB_OBJECT message' do
-                expect(results).not_to include(hash_including(PreservedObjectHandler::UPDATED_DB_OBJECT))
-                expect(results).not_to include(hash_including(PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY))
+                expect(results).not_to include(hash_including(PreservedObjectHandlerResults::UPDATED_DB_OBJECT))
+                expect(results).not_to include(hash_including(PreservedObjectHandlerResults::UPDATED_DB_OBJECT_TIMESTAMP_ONLY))
               end
             end
           end
@@ -281,8 +281,8 @@ RSpec.describe PreservedObjectHandler do
                 expect(results).to include(a_hash_including(result_code => a_string_matching('foo')))
               end
               it 'does NOT get UPDATED_DB_OBJECT message' do
-                expect(results).not_to include(hash_including(PreservedObjectHandler::UPDATED_DB_OBJECT))
-                expect(results).not_to include(hash_including(PreservedObjectHandler::UPDATED_DB_OBJECT_TIMESTAMP_ONLY))
+                expect(results).not_to include(hash_including(PreservedObjectHandlerResults::UPDATED_DB_OBJECT))
+                expect(results).not_to include(hash_including(PreservedObjectHandlerResults::UPDATED_DB_OBJECT_TIMESTAMP_ONLY))
               end
             end
           end
@@ -559,14 +559,14 @@ RSpec.describe PreservedObjectHandler do
               expect(results.size).to eq 5
             end
             it 'UNEXPECTED_VERSION result' do
-              code = PreservedObjectHandler::UNEXPECTED_VERSION
+              code = PreservedObjectHandlerResults::UNEXPECTED_VERSION
               expect(results).to include(a_hash_including(code => unexpected_version_msg))
             end
             it 'specific version results' do
               codes = [
-                PreservedObjectHandler::VERSION_MATCHES,
-                PreservedObjectHandler::ARG_VERSION_GREATER_THAN_DB_OBJECT,
-                PreservedObjectHandler::ARG_VERSION_LESS_THAN_DB_OBJECT
+                PreservedObjectHandlerResults::VERSION_MATCHES,
+                PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT,
+                PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT
               ]
               obj_version_results = results.select { |r| codes.include?(r.keys.first) }
               msgs = obj_version_results.map { |r| r.values.first }
@@ -574,11 +574,11 @@ RSpec.describe PreservedObjectHandler do
               expect(msgs).to include(a_string_matching("PreservedCopy"))
             end
             it "PreservedCopy UPDATED_DB_OBJECT results" do
-              code = PreservedObjectHandler::UPDATED_DB_OBJECT
+              code = PreservedObjectHandlerResults::UPDATED_DB_OBJECT
               expect(results).to include(a_hash_including(code => updated_pc_db_msg))
             end
             it 'PC_STATUS_CHANGED result' do
-              expect(results).to include(a_hash_including(PreservedObjectHandler::PC_STATUS_CHANGED => updated_status_msg_regex))
+              expect(results).to include(a_hash_including(PreservedObjectHandlerResults::PC_STATUS_CHANGED => updated_status_msg_regex))
             end
           end
         end
@@ -601,7 +601,7 @@ RSpec.describe PreservedObjectHandler do
         end
 
         context 'db update error' do
-          let(:result_code) { PreservedObjectHandler::DB_UPDATE_FAILED }
+          let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
 
           context 'PreservedCopy' do
             context 'ActiveRecordError' do

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe PreservedObjectHandler do
             expect(results).to include(a_hash_including(code => unexpected_version_msg))
           end
           it 'specific version results' do
+            # NOTE this is not checking that we have the CORRECT specific code
             codes = [
               PreservedObjectHandlerResults::VERSION_MATCHES,
               PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT,

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -555,9 +555,9 @@ RSpec.describe PreservedObjectHandler do
             # results = [result1, result2]
             # result1 = {response_code: msg}
             # result2 = {response_code: msg}
-            it '5 results' do
+            it '6 results' do
               expect(results).to be_an_instance_of Array
-              expect(results.size).to eq 5
+              expect(results.size).to eq 6
             end
             it 'UNEXPECTED_VERSION result' do
               code = PreservedObjectHandlerResults::UNEXPECTED_VERSION

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -19,10 +19,10 @@ RSpec.shared_examples "attributes validated" do |method_sym|
       expect(result.size).to eq 1
     end
     it 'INVALID_ARGUMENTS' do
-      expect(result).to include(a_hash_including(PreservedObjectHandler::INVALID_ARGUMENTS))
+      expect(result).to include(a_hash_including(PreservedObjectHandlerResults::INVALID_ARGUMENTS))
     end
     context 'result message includes' do
-      let(:msg) { result.first[PreservedObjectHandler::INVALID_ARGUMENTS] }
+      let(:msg) { result.first[PreservedObjectHandlerResults::INVALID_ARGUMENTS] }
       let(:exp_msg_prefix) { "PreservedObjectHandler(#{bad_druid}, #{bad_version}, #{bad_size}, #{bad_endpoint})" }
 
       it "prefix" do
@@ -80,7 +80,7 @@ RSpec.shared_examples 'druid not in catalog' do |method_sym|
   end
 
   it 'OBJECT_DOES_NOT_EXIST error' do
-    code = PreservedObjectHandler::OBJECT_DOES_NOT_EXIST
+    code = PreservedObjectHandlerResults::OBJECT_DOES_NOT_EXIST
     expect(results).to include(a_hash_including(code => exp_msg))
   end
 end
@@ -106,7 +106,7 @@ RSpec.shared_examples 'PreservedCopy does not exist' do |method_sym|
   end
 
   it 'OBJECT_DOES_NOT_EXIST error' do
-    code = PreservedObjectHandler::OBJECT_DOES_NOT_EXIST
+    code = PreservedObjectHandlerResults::OBJECT_DOES_NOT_EXIST
     expect(results).to include(a_hash_including(code => exp_msg))
   end
 end


### PR DESCRIPTION
This shortens PreservedObjectHandler by about 100 lines (from about 400 to about 300).

Closes #327