### PR TITLE
enums touchups

### DIFF
--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -1,16 +1,22 @@
 ##
 # PreservedCopy represents a concrete instance of a PreservedObject, in physical storage on some node.
 class PreservedCopy < ApplicationRecord
-  enum status: {
-    ok: 0,
-    invalid_moab: 1,
-    invalid_checksum: 2,
-    online_moab_not_found: 3,
-    expected_version_not_found_on_storage: 4,
-    fixity_check_failed: 5
-  }
+  OK_STATUS = 'ok'.freeze
+  INVALID_MOAB_STATUS = 'invalid_moab'.freeze
+  INVALID_CHECKSUM_STATUS = 'invalid_checksum'.freeze
+  ONLINE_MOAB_NOT_FOUND_STATUS = 'online_moab_not_found'.freeze
+  EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS = 'expected_vers_not_found_on_storage'.freeze
+  FIXITY_CHECK_FAILED_STATUS = 'fixity_check_failed'.freeze
+  DEFAULT_STATUS = OK_STATUS
 
-  DEFAULT_STATUS = 'ok'.freeze
+  enum status: {
+    OK_STATUS => 0,
+    INVALID_MOAB_STATUS => 1,
+    INVALID_CHECKSUM_STATUS => 2,
+    ONLINE_MOAB_NOT_FOUND_STATUS => 3,
+    EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS => 4,
+    FIXITY_CHECK_FAILED_STATUS => 5
+  }
 
   belongs_to :preserved_object
   belongs_to :endpoint

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -1,15 +1,6 @@
 ##
 # PreservedCopy represents a concrete instance of a PreservedObject, in physical storage on some node.
 class PreservedCopy < ApplicationRecord
-  belongs_to :preserved_object
-  belongs_to :endpoint
-
-  validates :preserved_object, presence: true
-  validates :endpoint, presence: true
-  validates :version, presence: true
-
-  # NOTE: size here is approximate and not used for fixity checking
-  validates :size, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   enum status: {
     ok: 0,
     invalid_moab: 1,
@@ -18,6 +9,16 @@ class PreservedCopy < ApplicationRecord
     expected_version_not_found_online: 4,
     fixity_check_failed: 5
   }
+
   DEFAULT_STATUS = statuses[:ok].freeze
+
+  belongs_to :preserved_object
+  belongs_to :endpoint
+
+  validates :endpoint, presence: true
+  validates :preserved_object, presence: true
+  # NOTE: size here is approximate and not used for fixity checking
+  validates :size, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   validates :status, inclusion: { in: statuses.keys }
+  validates :version, presence: true
 end

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -10,7 +10,7 @@ class PreservedCopy < ApplicationRecord
     fixity_check_failed: 5
   }
 
-  DEFAULT_STATUS = statuses[:ok].freeze
+  DEFAULT_STATUS = 'ok'.freeze
 
   belongs_to :preserved_object
   belongs_to :endpoint

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -6,7 +6,7 @@ class PreservedCopy < ApplicationRecord
     invalid_moab: 1,
     invalid_checksum: 2,
     online_moab_not_found: 3,
-    expected_version_not_found_online: 4,
+    expected_version_not_found_on_storage: 4,
     fixity_check_failed: 5
   }
 

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -264,7 +264,7 @@ class PreservedObjectHandler
       increase_version(db_object)
     else
       # TODO: needs manual intervention until automatic recovery services implemented
-      update_status(db_object, 'expected_version_not_found_online') if db_object.is_a?(PreservedCopy)
+      update_status(db_object, 'expected_version_not_found_on_storage') if db_object.is_a?(PreservedCopy)
       handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT, db_object.class.name)
     end
     update_db_object(db_object)

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -39,7 +39,7 @@ class PreservedObjectHandler
     elsif moab_validation_errors.empty?
       create_db_objects(PreservedCopy::DEFAULT_STATUS, true)
     else
-      create_db_objects(PreservedCopy.statuses[:invalid_moab], true)
+      create_db_objects('invalid_moab', true)
     end
 
     handler_results.log_results
@@ -79,9 +79,9 @@ class PreservedObjectHandler
       if endpoint.endpoint_type.endpoint_class == 'online'
         # NOTE: we deal with active record transactions in update_online_version, not here
         if moab_validation_errors.empty?
-          update_online_version(true, PreservedCopy.statuses[:ok])
+          update_online_version(true, 'ok')
         else
-          update_online_version(true, PreservedCopy.statuses[:invalid_moab])
+          update_online_version(true, 'invalid_moab')
         end
       elsif endpoint.endpoint_type.endpoint_class == 'archive'
         # TODO: perform archive object validation; then create a new PC record for the new
@@ -247,7 +247,7 @@ class PreservedObjectHandler
     handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT, db_object.class.name)
     if db_object.is_a?(PreservedCopy)
       update_preserved_copy_version_etc(db_object, incoming_version, incoming_size)
-      update_status(db_object, PreservedCopy.statuses[:ok])
+      update_status(db_object, 'ok')
     elsif db_object.is_a?(PreservedObject)
       db_object.current_version = incoming_version
     end
@@ -257,24 +257,24 @@ class PreservedObjectHandler
   # TODO: revisit naming
   def confirm_version_on_db_object(db_object, version_symbol)
     if incoming_version == db_object.send(version_symbol)
-      update_status(db_object, PreservedCopy.statuses[:ok]) if db_object.is_a?(PreservedCopy)
+      update_status(db_object, 'ok') if db_object.is_a?(PreservedCopy)
       handler_results.add_result(PreservedObjectHandlerResults::VERSION_MATCHES, db_object.class.name)
     elsif incoming_version > db_object.send(version_symbol)
       # FIXME: this needs to use the same methods as update_version_after_validation
       increase_version(db_object)
     else
       # TODO: needs manual intervention until automatic recovery services implemented
-      update_status(db_object, PreservedCopy.statuses[:expected_version_not_found_online]) if db_object.is_a?(PreservedCopy)
+      update_status(db_object, 'expected_version_not_found_online') if db_object.is_a?(PreservedCopy)
       handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT, db_object.class.name)
     end
     update_db_object(db_object)
   end
 
   def update_status(preserved_copy, new_status)
-    if new_status != PreservedCopy.statuses[preserved_copy.status]
+    if new_status != preserved_copy.status
       handler_results.add_result(
         PreservedObjectHandlerResults::PC_STATUS_CHANGED,
-        { old_status: PreservedCopy.statuses[preserved_copy.status], new_status: new_status }
+        { old_status: preserved_copy.status, new_status: new_status }
       )
       preserved_copy.status = new_status
     end

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -39,7 +39,7 @@ class PreservedObjectHandler
     elsif moab_validation_errors.empty?
       create_db_objects(PreservedCopy::DEFAULT_STATUS, true)
     else
-      create_db_objects('invalid_moab', true)
+      create_db_objects(PreservedCopy::INVALID_MOAB_STATUS, true)
     end
 
     handler_results.log_results
@@ -79,9 +79,9 @@ class PreservedObjectHandler
       if endpoint.endpoint_type.endpoint_class == 'online'
         # NOTE: we deal with active record transactions in update_online_version, not here
         if moab_validation_errors.empty?
-          update_online_version(true, 'ok')
+          update_online_version(true, PreservedCopy::OK_STATUS)
         else
-          update_online_version(true, 'invalid_moab')
+          update_online_version(true, PreservedCopy::INVALID_MOAB_STATUS)
         end
       elsif endpoint.endpoint_type.endpoint_class == 'archive'
         # TODO: perform archive object validation; then create a new PC record for the new
@@ -247,7 +247,7 @@ class PreservedObjectHandler
     handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT, db_object.class.name)
     if db_object.is_a?(PreservedCopy)
       update_preserved_copy_version_etc(db_object, incoming_version, incoming_size)
-      update_status(db_object, 'ok')
+      update_status(db_object, PreservedCopy::OK_STATUS)
     elsif db_object.is_a?(PreservedObject)
       db_object.current_version = incoming_version
     end
@@ -257,14 +257,14 @@ class PreservedObjectHandler
   # TODO: revisit naming
   def confirm_version_on_db_object(db_object, version_symbol)
     if incoming_version == db_object.send(version_symbol)
-      update_status(db_object, 'ok') if db_object.is_a?(PreservedCopy)
+      update_status(db_object, PreservedCopy::OK_STATUS) if db_object.is_a?(PreservedCopy)
       handler_results.add_result(PreservedObjectHandlerResults::VERSION_MATCHES, db_object.class.name)
     elsif incoming_version > db_object.send(version_symbol)
       # FIXME: this needs to use the same methods as update_version_after_validation
       increase_version(db_object)
     else
       # TODO: needs manual intervention until automatic recovery services implemented
-      update_status(db_object, 'expected_version_not_found_on_storage') if db_object.is_a?(PreservedCopy)
+      update_status(db_object, PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS) if db_object.is_a?(PreservedCopy)
       handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT, db_object.class.name)
     end
     update_db_object(db_object)

--- a/db/README.md
+++ b/db/README.md
@@ -63,10 +63,10 @@ ORDER BY endpoint_name asc
 [["storage_root2", 2017-11-18 05:49:54 UTC, 2017-11-18 06:06:50 UTC, "00:16:55.845987", 9122, 0.3132092573e10]]
 ```
 
-#### how many moabs on each storage root are in a status other than 'ok'?
+#### how many moabs on each storage root are in a status other than PreservedCopy::OK_STATUS?
 ```ruby
 # example AR query
-[12] pry(main)> PreservedCopy.joins(:preserved_object, :endpoint).where.not(status: :ok).group(:status, :storage_location).order('preserved_copies.status asc, endpoints.storage_location asc').pluck('preserved_copies.status, endpoints.storage_location, count(preserved_objects.druid)')
+[12] pry(main)> PreservedCopy.joins(:preserved_object, :endpoint).where.not(status: PreservedCopy::OK_STATUS).group(:status, :storage_location).order('preserved_copies.status asc, endpoints.storage_location asc').pluck('preserved_copies.status, endpoints.storage_location, count(preserved_objects.druid)')
 ```
 ```sql
 -- example sql produced by above AR query

--- a/db/README.md
+++ b/db/README.md
@@ -29,21 +29,20 @@ General advice:
 #### which objects aren't in a good state?
 ```ruby
 # example AR query
-[25] pry(main)> PreservedCopy.joins(:preserved_object, :endpoint, :status).where("statuses.status_text != 'ok'").order('statuses.status_text').pluck('statuses.status_text, preserved_objects.druid, endpoints.storage_location')
+[25] pry(main)> PreservedCopy.joins(:preserved_object, :endpoint).where.not(status: :ok).order('preserved_copies.status asc, endpoints.storage_location asc').pluck(:status, :storage_location, :druid)
 ```
 ```sql
 -- example sql produced by above AR query
-SELECT statuses.status_text, preserved_objects.druid, endpoints.storage_location
+SELECT "preserved_copies"."status", "storage_location", "druid"
 FROM "preserved_copies"
 INNER JOIN "preserved_objects" ON "preserved_objects"."id" = "preserved_copies"."preserved_object_id"
 INNER JOIN "endpoints" ON "endpoints"."id" = "preserved_copies"."endpoint_id"
-INNER JOIN "statuses" ON "statuses"."id" = "preserved_copies"."status_id"
-WHERE (statuses.status_text != 'ok')
-ORDER BY statuses.status_text
+WHERE ("preserved_copies"."status" != $1)
+ORDER BY preserved_copies.status asc, endpoints.storage_location asc
 ```
 ```ruby
 # example result, one bad object on disk 2
-[["invalid_moab", "ab123cd456", "/storage_root2/storage_trunk"]]
+[["invalid_moab", "/storage_root2/storage_trunk", "ab123cd456"]]
 ```
 
 #### catalog seeding just ran for the first time.  how long did it take to crawl each storage root, how many moabs does each have, what's the average moab size?
@@ -67,18 +66,17 @@ ORDER BY endpoint_name asc
 #### how many moabs on each storage root are in a status other than 'ok'?
 ```ruby
 # example AR query
-[12] pry(main)> PreservedCopy.joins(:preserved_object, :endpoint, :status).where("statuses.status_text != 'ok'").group('statuses.status_text, endpoints.storage_location').order('statuses.status_text asc, endpoints.storage_location asc').pluck('statuses.status_text, endpoints.storage_location, count(preserved_objects.druid)')
+[12] pry(main)> PreservedCopy.joins(:preserved_object, :endpoint).where.not(status: :ok).group(:status, :storage_location).order('preserved_copies.status asc, endpoints.storage_location asc').pluck('preserved_copies.status, endpoints.storage_location, count(preserved_objects.druid)')
 ```
 ```sql
 -- example sql produced by above AR query
-SELECT statuses.status_text, endpoints.storage_location, count(preserved_objects.druid)
+SELECT preserved_copies.status, endpoints.storage_location, count(preserved_objects.druid)
 FROM "preserved_copies"
 INNER JOIN "preserved_objects" ON "preserved_objects"."id" = "preserved_copies"."preserved_object_id"
 INNER JOIN "endpoints" ON "endpoints"."id" = "preserved_copies"."endpoint_id"
-INNER JOIN "statuses" ON "statuses"."id" = "preserved_copies"."status_id"
-WHERE (statuses.status_text != 'ok')
-GROUP BY statuses.status_text, endpoints.storage_location
-ORDER BY statuses.status_text asc, endpoints.storage_location asc
+WHERE ("preserved_copies"."status" != $1)
+GROUP BY "preserved_copies"."status", "storage_location"
+ORDER BY preserved_copies.status asc, endpoints.storage_location asc
 ```
 ```ruby
 # example result, some moabs that failed structural validation

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe PreservedCopy, type: :model do
 
   it 'defines a status enum with the expected values' do
     is_expected.to define_enum_for(:status).with(
-      ok: 0,
-      invalid_moab: 1,
-      invalid_checksum: 2,
-      online_moab_not_found: 3,
-      expected_version_not_found_on_storage: 4,
-      fixity_check_failed: 5
+      PreservedCopy::OK_STATUS => 0,
+      PreservedCopy::INVALID_MOAB_STATUS => 1,
+      PreservedCopy::INVALID_CHECKSUM_STATUS => 2,
+      PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS => 3,
+      PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS => 4,
+      PreservedCopy::FIXITY_CHECK_FAILED_STATUS => 5
     )
   end
 
@@ -74,7 +74,7 @@ RSpec.describe PreservedCopy, type: :model do
         size: 1
       )
       expect(pc.status).to be_a(String)
-      expect(pc.status).to eq 'invalid_moab'
+      expect(pc.status).to eq PreservedCopy::INVALID_MOAB_STATUS
     end
   end
 

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -40,16 +40,42 @@ RSpec.describe PreservedCopy, type: :model do
     )
   end
 
-  it 'is not valid without an existing status' do
-    expect {
-      PreservedCopy.new(
+  context '#status=' do
+    it "validation rejects an int value that's not actually used by the enum" do
+      expect {
+        PreservedCopy.new(
+          preserved_object_id: preserved_object.id,
+          endpoint_id: endpoint.id,
+          version: 0,
+          status: 654,
+          size: 1
+        )
+      }.to raise_error(ArgumentError, "'654' is not a valid status")
+    end
+
+    it "validation rejects a value if it isn't one of the defined enum identifiers" do
+      expect {
+        PreservedCopy.new(
+          preserved_object_id: preserved_object.id,
+          endpoint_id: endpoint.id,
+          version: 0,
+          status: 'INVALID_MOAB',
+          size: 1
+        )
+      }.to raise_error(ArgumentError, "'INVALID_MOAB' is not a valid status")
+    end
+
+    it "will accept a symbol, but will always return a string" do
+      pc = PreservedCopy.new(
         preserved_object_id: preserved_object.id,
         endpoint_id: endpoint.id,
         version: 0,
-        status: 6,
+        status: :invalid_moab,
         size: 1
       )
-    }.to raise_error(ArgumentError, "'6' is not a valid status")
+      expect(pc.status).to be_a(String)
+      expect(pc.status).to eq 'invalid_moab'
+    end
   end
 
   it { is_expected.to belong_to(:endpoint) }

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe PreservedCopy, type: :model do
       invalid_moab: 1,
       invalid_checksum: 2,
       online_moab_not_found: 3,
-      expected_version_not_found_online: 4,
+      expected_version_not_found_on_storage: 4,
       fixity_check_failed: 5
     )
   end

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe PreservedObjectHandler do
           version: incoming_version,
           size: incoming_size,
           endpoint: ep,
-          status: 'invalid_moab',
+          status: PreservedCopy::INVALID_MOAB_STATUS,
           last_audited: an_instance_of(Integer),
           last_checked_on_storage: an_instance_of(ActiveSupport::TimeWithZone)
         }

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe PreservedObjectHandler do
           version: incoming_version,
           size: incoming_size,
           endpoint: ep,
-          status: PreservedCopy.statuses[:invalid_moab],
+          status: 'invalid_moab',
           last_audited: an_instance_of(Integer),
           last_checked_on_storage: an_instance_of(ActiveSupport::TimeWithZone)
         }

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe PreservedObjectHandler do
         let(:updated_po_db_timestamp_msg) { "#{exp_msg_prefix} PreservedObject updated db timestamp only" }
         let(:updated_pc_db_obj_msg) { "#{exp_msg_prefix} PreservedCopy db object updated" }
         let(:updated_pc_db_status_msg) do
-          "#{exp_msg_prefix} PreservedCopy status changed from #{PreservedCopy.statuses[:ok]} to #{PreservedCopy.statuses[:expected_version_not_found_online]}"
+          "#{exp_msg_prefix} PreservedCopy status changed from ok to expected_version_not_found_online"
         end
 
         it "entry version stays the same" do
@@ -297,7 +297,7 @@ RSpec.describe PreservedObjectHandler do
       it 'calls PreservedObject.save! and PreservedCopy.save! if the existing record is altered' do
         po = instance_double(PreservedObject)
         pc = instance_double(PreservedCopy)
-        status = PreservedCopy.statuses[:ok]
+        status = 'ok'
         # bad object-oriented form!  type checking like this is to be avoided.  but also, wouldn't
         # it be nice if an rspec double returned `true` when asked if it was an instance or kind of
         # the object type being mocked?  i think that'd be nice.  but that's not what doubles do.

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe PreservedObjectHandler do
         let(:updated_po_db_timestamp_msg) { "#{exp_msg_prefix} PreservedObject updated db timestamp only" }
         let(:updated_pc_db_obj_msg) { "#{exp_msg_prefix} PreservedCopy db object updated" }
         let(:updated_pc_db_status_msg) do
-          "#{exp_msg_prefix} PreservedCopy status changed from ok to expected_version_not_found_on_storage"
+          "#{exp_msg_prefix} PreservedCopy status changed from ok to expected_vers_not_found_on_storage"
         end
 
         it "entry version stays the same" do
@@ -297,7 +297,7 @@ RSpec.describe PreservedObjectHandler do
       it 'calls PreservedObject.save! and PreservedCopy.save! if the existing record is altered' do
         po = instance_double(PreservedObject)
         pc = instance_double(PreservedCopy)
-        status = 'ok'
+        status = PreservedCopy::OK_STATUS
         # bad object-oriented form!  type checking like this is to be avoided.  but also, wouldn't
         # it be nice if an rspec double returned `true` when asked if it was an instance or kind of
         # the object type being mocked?  i think that'd be nice.  but that's not what doubles do.

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe PreservedObjectHandler do
         let(:updated_po_db_timestamp_msg) { "#{exp_msg_prefix} PreservedObject updated db timestamp only" }
         let(:updated_pc_db_obj_msg) { "#{exp_msg_prefix} PreservedCopy db object updated" }
         let(:updated_pc_db_status_msg) do
-          "#{exp_msg_prefix} PreservedCopy status changed from ok to expected_version_not_found_online"
+          "#{exp_msg_prefix} PreservedCopy status changed from ok to expected_version_not_found_on_storage"
         end
 
         it "entry version stays the same" do

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PreservedObjectHandler do
           version: po.current_version,
           size: 1,
           endpoint: ep,
-          status: PreservedCopy.statuses[:expected_version_not_found_online]
+          status: 'expected_version_not_found_online'
         )
       end
 
@@ -62,9 +62,9 @@ RSpec.describe PreservedObjectHandler do
         end
         it 'does not update status of PreservedCopy' do
           # TODO: not clear what to do here;  it's not 'ok' if we didn't validate ...
-          expect(PreservedCopy.statuses[pc.status]).to eq PreservedCopy.statuses[:expected_version_not_found_online]
+          expect(pc.status).to eq 'expected_version_not_found_online'
           po_handler.update_version
-          expect(PreservedCopy.statuses[pc.reload.status]).to eq PreservedCopy.statuses[:expected_version_not_found_online]
+          expect(pc.reload.status).to eq 'expected_version_not_found_online'
         end
         it 'does not update PreservedCopy last_audited field' do
           orig_timestamp = pc.last_audited
@@ -222,7 +222,7 @@ RSpec.describe PreservedObjectHandler do
               allow(pc).to receive(:version).and_return(1)
               allow(pc).to receive(:version=)
               allow(pc).to receive(:size=)
-              allow(pc).to receive(:status).and_return(PreservedCopy.statuses[:ok])
+              allow(pc).to receive(:status).and_return('ok')
               allow(pc).to receive(:status=)
               allow(pc).to receive(:changed?).and_return(true)
               allow(pc).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
@@ -264,7 +264,7 @@ RSpec.describe PreservedObjectHandler do
               allow(pc).to receive(:version).and_return(5)
               allow(pc).to receive(:version=).with(incoming_version)
               allow(pc).to receive(:size=).with(incoming_size)
-              allow(pc).to receive(:status).and_return(PreservedCopy.statuses[:ok])
+              allow(pc).to receive(:status).and_return('ok')
               allow(pc).to receive(:status=)
               allow(pc).to receive(:changed?).and_return(true)
               allow(pc).to receive(:save!)
@@ -303,7 +303,7 @@ RSpec.describe PreservedObjectHandler do
         allow(pc).to receive(:version=).with(incoming_version)
         allow(pc).to receive(:size=).with(incoming_size)
         allow(pc).to receive(:endpoint).with(ep)
-        allow(pc).to receive(:status).and_return(PreservedCopy.statuses[:ok])
+        allow(pc).to receive(:status).and_return('ok')
         allow(pc).to receive(:status=)
         allow(pc).to receive(:changed?).and_return(true)
         allow(pc).to receive(:save!)
@@ -365,7 +365,7 @@ RSpec.describe PreservedObjectHandler do
             version: po.current_version,
             size: 1,
             endpoint: ep,
-            status: PreservedCopy.statuses[:ok],
+            status: 'ok',
             last_audited: Time.current.to_i,
             last_checked_on_storage: Time.current
           )
@@ -383,17 +383,17 @@ RSpec.describe PreservedObjectHandler do
           expect(pc.reload.last_checked_on_storage).to be > orig_timestamp
         end
 
-        it 'calls #update_online_version with validated = true and PreservedCopy.statuses[:ok]' do
-          expect(po_handler).to receive(:update_online_version).with(true, PreservedCopy.statuses[:ok]).and_call_original
+        it 'calls #update_online_version with validated = true and status = "ok"' do
+          expect(po_handler).to receive(:update_online_version).with(true, 'ok').and_call_original
           po_handler.update_version_after_validation
           skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
         end
 
         it 'updates PreservedCopy status to "ok" if it was "moab_invalid"' do
-          pc.status = PreservedCopy.statuses[:invalid_moab]
+          pc.status = 'invalid_moab'
           pc.save!
           po_handler.update_version_after_validation
-          expect(PreservedCopy.statuses[pc.reload.status]).to eq PreservedCopy.statuses[:ok]
+          expect(pc.reload.status).to eq 'ok'
         end
       end
 
@@ -417,7 +417,7 @@ RSpec.describe PreservedObjectHandler do
             version: po.current_version,
             size: 1,
             endpoint: ep,
-            status: PreservedCopy.statuses[:ok],
+            status: 'ok',
             last_audited: Time.current.to_i,
             last_checked_on_storage: Time.current
           )
@@ -435,10 +435,10 @@ RSpec.describe PreservedObjectHandler do
           expect(pc.reload.last_checked_on_storage).to be > orig_timestamp
         end
         it 'ensures PreservedCopy status is invalid' do
-          pc.status = PreservedCopy.statuses[:ok]
+          pc.status = 'ok'
           pc.save!
           po_handler.update_version_after_validation
-          expect(PreservedCopy.statuses[pc.reload.status]).to eq PreservedCopy.statuses[:invalid_moab]
+          expect(pc.reload.status).to eq 'invalid_moab'
         end
 
         it 'logs a debug message' do
@@ -461,7 +461,7 @@ RSpec.describe PreservedObjectHandler do
           allow(pc).to receive(:version=).with(incoming_version)
           allow(pc).to receive(:size=).with(incoming_size)
           allow(pc).to receive(:endpoint).with(ep)
-          allow(pc).to receive(:status).and_return(PreservedCopy.statuses[:ok])
+          allow(pc).to receive(:status).and_return('ok')
           allow(pc).to receive(:status=)
           allow(pc).to receive(:last_audited=)
           allow(pc).to receive(:last_checked_on_storage=)
@@ -484,7 +484,7 @@ RSpec.describe PreservedObjectHandler do
           allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
           allow(pc).to receive(:version).and_return(1)
           allow(pc).to receive(:endpoint).with(ep)
-          allow(pc).to receive(:status).and_return(PreservedCopy.statuses[:ok])
+          allow(pc).to receive(:status).and_return('ok')
           allow(pc).to receive(:status=)
           allow(pc).to receive(:last_audited=)
           allow(pc).to receive(:last_checked_on_storage=)
@@ -496,8 +496,8 @@ RSpec.describe PreservedObjectHandler do
         end
 
         context 'incoming version newer than catalog versions (both) (happy path)' do
-          it 'calls #update_online_version with validated = true and PreservedCopy.statuses[:invalid_moab]' do
-            expect(po_handler).to receive(:update_online_version).with(true, PreservedCopy.statuses[:invalid_moab]).and_call_original
+          it 'calls #update_online_version with validated = true and status = "invalid_moab"' do
+            expect(po_handler).to receive(:update_online_version).with(true, 'invalid_moab').and_call_original
             po_handler.update_version_after_validation
             skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
           end
@@ -536,10 +536,10 @@ RSpec.describe PreservedObjectHandler do
             expect(pc.reload.last_checked_on_storage).to be > orig_timestamp
           end
           it 'ensures status of PreservedCopy is invalid' do
-            pc.status = PreservedCopy.statuses[:ok]
+            pc.status = 'ok'
             pc.save!
             po_handler.update_version_after_validation
-            expect(PreservedCopy.statuses[pc.reload.status]).to eq PreservedCopy.statuses[:invalid_moab]
+            expect(pc.reload.status).to eq 'invalid_moab'
           end
           it "logs at error level" do
             expect(Rails.logger).to receive(:log).with(Logger::ERROR, unexpected_version_msg)
@@ -618,7 +618,7 @@ RSpec.describe PreservedObjectHandler do
                 allow(PreservedCopy).to receive(:find_by!).with(preserved_object: po, endpoint: ep).and_return(pc)
                 allow(pc).to receive(:version).and_return(1)
                 allow(pc).to receive(:version=)
-                allow(pc).to receive(:status).and_return(PreservedCopy.statuses[:ok])
+                allow(pc).to receive(:status).and_return('ok')
                 allow(pc).to receive(:status=)
                 allow(pc).to receive(:last_audited=)
                 allow(pc).to receive(:last_checked_on_storage=)
@@ -661,7 +661,7 @@ RSpec.describe PreservedObjectHandler do
                 allow(pc).to receive(:size=).with(incoming_size)
                 allow(pc).to receive(:last_audited=)
                 allow(pc).to receive(:last_checked_on_storage=)
-                allow(pc).to receive(:status).and_return(PreservedCopy.statuses[:ok])
+                allow(pc).to receive(:status).and_return('ok')
                 allow(pc).to receive(:status=)
                 allow(pc).to receive(:changed?).and_return(true)
                 allow(pc).to receive(:save!)

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PreservedObjectHandler do
           version: po.current_version,
           size: 1,
           endpoint: ep,
-          status: 'expected_version_not_found_online'
+          status: 'expected_version_not_found_on_storage'
         )
       end
 
@@ -62,9 +62,9 @@ RSpec.describe PreservedObjectHandler do
         end
         it 'does not update status of PreservedCopy' do
           # TODO: not clear what to do here;  it's not 'ok' if we didn't validate ...
-          expect(pc.status).to eq 'expected_version_not_found_online'
+          expect(pc.status).to eq 'expected_version_not_found_on_storage'
           po_handler.update_version
-          expect(pc.reload.status).to eq 'expected_version_not_found_online'
+          expect(pc.reload.status).to eq 'expected_version_not_found_on_storage'
         end
         it 'does not update PreservedCopy last_audited field' do
           orig_timestamp = pc.last_audited

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PreservedObjectHandler do
           version: po.current_version,
           size: 1,
           endpoint: ep,
-          status: 'expected_version_not_found_on_storage'
+          status: PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
         )
       end
 
@@ -61,10 +61,10 @@ RSpec.describe PreservedObjectHandler do
           expect(pc.reload.size).to eq 1
         end
         it 'does not update status of PreservedCopy' do
-          # TODO: not clear what to do here;  it's not 'ok' if we didn't validate ...
-          expect(pc.status).to eq 'expected_version_not_found_on_storage'
+          # TODO: not clear what to do here;  it's not OK_STATUS if we didn't validate ...
+          expect(pc.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
           po_handler.update_version
-          expect(pc.reload.status).to eq 'expected_version_not_found_on_storage'
+          expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
         end
         it 'does not update PreservedCopy last_audited field' do
           orig_timestamp = pc.last_audited
@@ -222,7 +222,7 @@ RSpec.describe PreservedObjectHandler do
               allow(pc).to receive(:version).and_return(1)
               allow(pc).to receive(:version=)
               allow(pc).to receive(:size=)
-              allow(pc).to receive(:status).and_return('ok')
+              allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
               allow(pc).to receive(:status=)
               allow(pc).to receive(:changed?).and_return(true)
               allow(pc).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
@@ -264,7 +264,7 @@ RSpec.describe PreservedObjectHandler do
               allow(pc).to receive(:version).and_return(5)
               allow(pc).to receive(:version=).with(incoming_version)
               allow(pc).to receive(:size=).with(incoming_size)
-              allow(pc).to receive(:status).and_return('ok')
+              allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
               allow(pc).to receive(:status=)
               allow(pc).to receive(:changed?).and_return(true)
               allow(pc).to receive(:save!)
@@ -303,7 +303,7 @@ RSpec.describe PreservedObjectHandler do
         allow(pc).to receive(:version=).with(incoming_version)
         allow(pc).to receive(:size=).with(incoming_size)
         allow(pc).to receive(:endpoint).with(ep)
-        allow(pc).to receive(:status).and_return('ok')
+        allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
         allow(pc).to receive(:status=)
         allow(pc).to receive(:changed?).and_return(true)
         allow(pc).to receive(:save!)
@@ -365,7 +365,7 @@ RSpec.describe PreservedObjectHandler do
             version: po.current_version,
             size: 1,
             endpoint: ep,
-            status: 'ok',
+            status: PreservedCopy::OK_STATUS,
             last_audited: Time.current.to_i,
             last_checked_on_storage: Time.current
           )
@@ -384,16 +384,16 @@ RSpec.describe PreservedObjectHandler do
         end
 
         it 'calls #update_online_version with validated = true and status = "ok"' do
-          expect(po_handler).to receive(:update_online_version).with(true, 'ok').and_call_original
+          expect(po_handler).to receive(:update_online_version).with(true, PreservedCopy::OK_STATUS).and_call_original
           po_handler.update_version_after_validation
           skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
         end
 
         it 'updates PreservedCopy status to "ok" if it was "moab_invalid"' do
-          pc.status = 'invalid_moab'
+          pc.status = PreservedCopy::INVALID_MOAB_STATUS
           pc.save!
           po_handler.update_version_after_validation
-          expect(pc.reload.status).to eq 'ok'
+          expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
         end
       end
 
@@ -417,7 +417,7 @@ RSpec.describe PreservedObjectHandler do
             version: po.current_version,
             size: 1,
             endpoint: ep,
-            status: 'ok',
+            status: PreservedCopy::OK_STATUS,
             last_audited: Time.current.to_i,
             last_checked_on_storage: Time.current
           )
@@ -435,10 +435,10 @@ RSpec.describe PreservedObjectHandler do
           expect(pc.reload.last_checked_on_storage).to be > orig_timestamp
         end
         it 'ensures PreservedCopy status is invalid' do
-          pc.status = 'ok'
+          pc.status = PreservedCopy::OK_STATUS
           pc.save!
           po_handler.update_version_after_validation
-          expect(pc.reload.status).to eq 'invalid_moab'
+          expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
         end
 
         it 'logs a debug message' do
@@ -461,7 +461,7 @@ RSpec.describe PreservedObjectHandler do
           allow(pc).to receive(:version=).with(incoming_version)
           allow(pc).to receive(:size=).with(incoming_size)
           allow(pc).to receive(:endpoint).with(ep)
-          allow(pc).to receive(:status).and_return('ok')
+          allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
           allow(pc).to receive(:status=)
           allow(pc).to receive(:last_audited=)
           allow(pc).to receive(:last_checked_on_storage=)
@@ -484,7 +484,7 @@ RSpec.describe PreservedObjectHandler do
           allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
           allow(pc).to receive(:version).and_return(1)
           allow(pc).to receive(:endpoint).with(ep)
-          allow(pc).to receive(:status).and_return('ok')
+          allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
           allow(pc).to receive(:status=)
           allow(pc).to receive(:last_audited=)
           allow(pc).to receive(:last_checked_on_storage=)
@@ -497,7 +497,7 @@ RSpec.describe PreservedObjectHandler do
 
         context 'incoming version newer than catalog versions (both) (happy path)' do
           it 'calls #update_online_version with validated = true and status = "invalid_moab"' do
-            expect(po_handler).to receive(:update_online_version).with(true, 'invalid_moab').and_call_original
+            expect(po_handler).to receive(:update_online_version).with(true, PreservedCopy::INVALID_MOAB_STATUS).and_call_original
             po_handler.update_version_after_validation
             skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
           end
@@ -536,10 +536,10 @@ RSpec.describe PreservedObjectHandler do
             expect(pc.reload.last_checked_on_storage).to be > orig_timestamp
           end
           it 'ensures status of PreservedCopy is invalid' do
-            pc.status = 'ok'
+            pc.status = PreservedCopy::OK_STATUS
             pc.save!
             po_handler.update_version_after_validation
-            expect(pc.reload.status).to eq 'invalid_moab'
+            expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
           end
           it "logs at error level" do
             expect(Rails.logger).to receive(:log).with(Logger::ERROR, unexpected_version_msg)
@@ -618,7 +618,7 @@ RSpec.describe PreservedObjectHandler do
                 allow(PreservedCopy).to receive(:find_by!).with(preserved_object: po, endpoint: ep).and_return(pc)
                 allow(pc).to receive(:version).and_return(1)
                 allow(pc).to receive(:version=)
-                allow(pc).to receive(:status).and_return('ok')
+                allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
                 allow(pc).to receive(:status=)
                 allow(pc).to receive(:last_audited=)
                 allow(pc).to receive(:last_checked_on_storage=)
@@ -661,7 +661,7 @@ RSpec.describe PreservedObjectHandler do
                 allow(pc).to receive(:size=).with(incoming_size)
                 allow(pc).to receive(:last_audited=)
                 allow(pc).to receive(:last_checked_on_storage=)
-                allow(pc).to receive(:status).and_return('ok')
+                allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
                 allow(pc).to receive(:status=)
                 allow(pc).to receive(:changed?).and_return(true)
                 allow(pc).to receive(:save!)


### PR DESCRIPTION
~~NOTE: this is WIP, because we should merge #369 first, and then rebase this on master.  though i have rebased this on the branch used by #369, under the assumption that it'll get merged in something pretty similar to its current form.~~

* a bit of re-arrangement so that like things are grouped contiguously
* a slightly more conventional approach to enum usage
* db/README.md: fix for accuracy now that PreservedCopy.status is an enum
* slightly more thorough #status validation tests

closes #373