### PR TITLE
Refactor migration to allow it to run when the table is populated

### DIFF
--- a/db/migrate/20171204215532_add_status_to_preserved_copies.rb
+++ b/db/migrate/20171204215532_add_status_to_preserved_copies.rb
@@ -1,6 +1,11 @@
 class AddStatusToPreservedCopies < ActiveRecord::Migration[5.1]
-  def change
-    add_column :preserved_copies, :status, :int, null: false
+  def up
+    add_column :preserved_copies, :status, :int
+    change_column_null :preserved_copies, :status, false
     add_index :preserved_copies, :status
+  end
+
+  def down
+    remove_column :preserved_copies, :status, :int
   end
 end


### PR DESCRIPTION
The problem and solution this addresses is documented here: https://www.viget.com/articles/adding-a-not-null-column-to-an-existing-table

The migration would run locally (because of an empty table), but wouldn't run on prod during a capistrano deployment, because the table was populated.

Fixes #376 