### PR TITLE
Install and configure honeybadger

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -11,6 +11,7 @@ require "capistrano/bundler"
 # require "capistrano/rails/assets"
 require "capistrano/rails/migrations"
 require "capistrano/passenger"
+require "capistrano/honeybadger"
 require "dlss/capistrano"
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'puma', '~> 3.7'
 gem 'rails', '~> 5.1.3'
 # Use newrelic for performance monitoring
 gem 'newrelic_rpm'
+# Use honeybadger for error reporting
+gem 'honeybadger'
 
 # Stanford gems
 gem 'moab-versioning' # work with Moab Objects

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       activesupport (>= 4.2.0)
     hashie (3.5.6)
     hirb (0.7.3)
+    honeybadger (3.2.0)
     i18n (0.8.6)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -262,6 +263,7 @@ DEPENDENCIES
   dlss-capistrano
   druid-tools
   hirb
+  honeybadger
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   moab-versioning

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -26,6 +26,8 @@ append :linked_files, "config/database.yml" # , "config/secrets.yml"
 # Default value for linked_dirs is []
 append :linked_dirs, "log", "config/settings" # , "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
 
+set :honeybadger_env, fetch(:stage)
+
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }
 


### PR DESCRIPTION
HONEYBADGER_API_KEY and HONEYBADGER_ENV are configured in puppet as environment variables, to save us from maintaining an extra shared config file

Fixes #32 