### PR TITLE
default PreservationPolicy caching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -128,7 +128,9 @@ RSpec/AnyInstance:
 
 RSpec/BeforeAfterAll:
   Exclude:
-    - 'spec/load_fixtures_helper.rb' # being careful to avoid state leakage
+    # we use after(:all) specifically to prevent state leakage
+    - 'spec/load_fixtures_helper.rb'
+    - 'spec/models/preservation_policy_spec.rb'
 
 RSpec/ExampleLength:
   Max: 50

--- a/app/models/preservation_policy.rb
+++ b/app/models/preservation_policy.rb
@@ -28,12 +28,15 @@ class PreservationPolicy < ApplicationRecord
     end
   end
 
-  def self.default_preservation_policy
+  def self.default_policy
     find_by!(preservation_policy_name: Settings.preservation_policies.default_policy_name)
   end
 
-  def self.cached_default_preservation_policy_id
-    id_cache[:default_preservation_policy_id] ||= default_preservation_policy.id
+  # note that this is cached.  prefer calling this method over .default_policy if an id
+  # will suffice (e.g., you only need the id, not the whole object, to set an association
+  # to a pres policy on another ActiveRecord object).
+  def self.default_policy_id
+    id_cache[:default_policy_id] ||= default_policy.id
   end
 
   private_class_method def self.id_cache

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -163,11 +163,11 @@ class PreservedObjectHandler
 
   def create_db_objects(status, validated=false)
     results = []
-    pp_default = PreservationPolicy.default_preservation_policy
+    pp_default_id = PreservationPolicy.cached_default_preservation_policy_id
     transaction_results = with_active_record_transaction_and_rescue do
       po = PreservedObject.create!(druid: druid,
                                    current_version: incoming_version,
-                                   preservation_policy: pp_default)
+                                   preservation_policy_id: pp_default_id)
       pc_attrs = {
         preserved_object: po,
         version: incoming_version,

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -163,7 +163,7 @@ class PreservedObjectHandler
 
   def create_db_objects(status, validated=false)
     results = []
-    pp_default_id = PreservationPolicy.cached_default_preservation_policy_id
+    pp_default_id = PreservationPolicy.default_policy_id
     transaction_results = with_active_record_transaction_and_rescue do
       po = PreservedObject.create!(druid: druid,
                                    current_version: incoming_version,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,7 @@ ApplicationRecord.transaction(isolation: :serializable) do
   PreservationPolicy.seed_from_config
   EndpointType.seed_from_config
   Endpoint.seed_storage_root_endpoints_from_config(
-    Endpoint.default_storage_root_endpoint_type, [PreservationPolicy.default_preservation_policy]
+    Endpoint.default_storage_root_endpoint_type, [PreservationPolicy.default_policy]
   )
 end
 

--- a/spec/load_fixtures_helper.rb
+++ b/spec/load_fixtures_helper.rb
@@ -36,7 +36,7 @@ def load_fixture_moabs
       po = PreservedObject.create(druid: druid,
                                   current_version: version,
                                   size: size,
-                                  preservation_policy: PreservationPolicy.default_preservation_policy)
+                                  preservation_policy: PreservationPolicy.default_policy)
       PreservedCopy.create(preserved_object_id: po.id,
                            endpoint_id: @storage_dir_to_endpoint_id[storage_dir],
                            current_version: version,

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Endpoint, type: :model do
     # would cause this `let` to be evaluated eagerly instead of lazily, and the EndpointType we want in this section
     # doesn't exist till the before block runs.
     let(:strg_rt_endpoint_type) { Endpoint.default_storage_root_endpoint_type }
-    let(:default_pres_policies) { [PreservationPolicy.default_preservation_policy] }
+    let(:default_pres_policies) { [PreservationPolicy.default_policy] }
 
     it 'creates a local online endpoint for each storage root' do
       Settings.moab.storage_roots.each do |storage_root_name, storage_root_location|

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe PreservedCopy, type: :model do
   let!(:endpoint) { Endpoint.first }
   let!(:preserved_object) do
-    policy_id = PreservationPolicy.default_preservation_policy.id
+    policy_id = PreservationPolicy.default_policy.id
     PreservedObject.create!(druid: 'ab123cd4567', current_version: 1, preservation_policy_id: policy_id)
   end
   let!(:status) { described_class::DEFAULT_STATUS }

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe PreservedObject, type: :model do
-  let!(:preservation_policy) { PreservationPolicy.default_preservation_policy }
+  let!(:preservation_policy) { PreservationPolicy.default_policy }
 
   let(:required_attributes) do
     {

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -166,7 +166,6 @@ RSpec.describe PreservedObjectHandler do
           endpoint.endpoint_node = Settings.endpoints.storage_root_defaults.endpoint_node
           endpoint.storage_location = storage_dir
           endpoint.recovery_cost = Settings.endpoints.storage_root_defaults.recovery_cost
-          # endpoint.preservation_policies = PreservationPolicy.default_preservation_policy
         end
       end
 

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PreservedObjectHandler do
       po_args = {
         druid: druid,
         current_version: incoming_version,
-        preservation_policy_id: PreservationPolicy.cached_default_preservation_policy_id
+        preservation_policy_id: PreservationPolicy.default_policy_id
       }
       pc_args = {
         preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object that we expected
@@ -127,7 +127,7 @@ RSpec.describe PreservedObjectHandler do
       po_args = {
         druid: valid_druid,
         current_version: incoming_version,
-        preservation_policy_id: PreservationPolicy.cached_default_preservation_policy_id
+        preservation_policy_id: PreservationPolicy.default_policy_id
       }
       pc_args = {
         preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object that we expected
@@ -173,7 +173,7 @@ RSpec.describe PreservedObjectHandler do
         po_args = {
           druid: invalid_druid,
           current_version: incoming_version,
-          preservation_policy_id: PreservationPolicy.cached_default_preservation_policy_id
+          preservation_policy_id: PreservationPolicy.default_policy_id
         }
         pc_args = {
           preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object that we expected

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PreservedObjectHandler do
       po_args = {
         druid: druid,
         current_version: incoming_version,
-        preservation_policy: PreservationPolicy.default_preservation_policy
+        preservation_policy_id: PreservationPolicy.cached_default_preservation_policy_id
       }
       pc_args = {
         preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object that we expected
@@ -127,7 +127,7 @@ RSpec.describe PreservedObjectHandler do
       po_args = {
         druid: valid_druid,
         current_version: incoming_version,
-        preservation_policy: PreservationPolicy.default_preservation_policy
+        preservation_policy_id: PreservationPolicy.cached_default_preservation_policy_id
       }
       pc_args = {
         preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object that we expected
@@ -174,7 +174,7 @@ RSpec.describe PreservedObjectHandler do
         po_args = {
           druid: invalid_druid,
           current_version: incoming_version,
-          preservation_policy: PreservationPolicy.default_preservation_policy
+          preservation_policy_id: PreservationPolicy.cached_default_preservation_policy_id
         }
         pc_args = {
           preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object that we expected

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PreservedObjectHandler do
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }
-  let!(:default_prez_policy) { PreservationPolicy.default_preservation_policy }
+  let!(:default_prez_policy) { PreservationPolicy.default_policy }
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
   let(:pc) { PreservedCopy.find_by(preserved_object: po, endpoint: ep) }

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PreservedObjectHandler do
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }
-  let!(:default_prez_policy) { PreservationPolicy.default_preservation_policy }
+  let!(:default_prez_policy) { PreservationPolicy.default_policy }
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
   let(:pc) { PreservedCopy.find_by(preserved_object: po, endpoint: ep) }

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -408,7 +408,6 @@ RSpec.describe PreservedObjectHandler do
             endpoint.endpoint_node = Settings.endpoints.storage_root_defaults.endpoint_node
             endpoint.storage_location = storage_dir
             endpoint.recovery_cost = Settings.endpoints.storage_root_defaults.recovery_cost
-            # endpoint.preservation_policies = PreservationPolicy.default_preservation_policy
           end
           # these need to be in before loop so it happens before each context below
           PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)


### PR DESCRIPTION
i went with caching the id for the default preservation policy, instead of caching the whole active record object.  this felt safer to me -- my gut feeling left me slightly leery of caching a whole AR object, i know ActiveJob advises users to pass around job IDs instead of job objects (which are often activerecord objects underneath if e.g. delayed_job is used), and users on stack exchange etc advised against caching active record objects.  we only need the id anyway, since either the id or the object can be used to set the association.  as a bonus, this is a slightly lighter thing to cache, but i'd guess that's pretty negligible.

the cache eviction is naive, as pointed out in the comments, but i think it'll be performant enough, with as infrequently as we'd expect to add pres policies.

#347 suggested also caching `endpoint_type` lookups, but this seems unnecessary in practice for `PreservedObjectHandler`:  right now, in our usage of `PreservedObjectHandler`, all its instances get passed the same `endpoint` instance, and active record does a lazy lookup to get the associated `endpoint_type` the first time, and then caches the result on the object.  example from pry, notice only one `SELECT` on `endpoint_types`:
```ruby
[1] pry(main)> 
[2] pry(main)> ep = Endpoint.first
  Endpoint Load (2.0ms)  SELECT  "endpoints".* FROM "endpoints" ORDER BY "endpoints"."id" ASC LIMIT $1  [["LIMIT", 1]]
=> #<Endpoint:0x00007fd7cdc3dc08
 id: 1,
 endpoint_name: "fixture_sr1",
 created_at: Tue, 05 Dec 2017 21:26:47 UTC +00:00,
 updated_at: Tue, 05 Dec 2017 21:26:47 UTC +00:00,
 endpoint_node: "localhost",
 storage_location: "spec/fixtures/storage_root01/moab_storage_trunk",
 recovery_cost: 1,
 access_key: nil,
 endpoint_type_id: 1>
[3] pry(main)> 
[4] pry(main)> ep.endpoint_type.endpoint_class
  EndpointType Load (1.0ms)  SELECT  "endpoint_types".* FROM "endpoint_types" WHERE "endpoint_types"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
=> "online"
[5] pry(main)> 
[6] pry(main)> ep.endpoint_type.endpoint_class
=> "online"
[7] pry(main)> 
[8] pry(main)> ep.endpoint_type               
=> #<EndpointType:0x00007fd7d4110568
 id: 1,
 type_name: "online_nfs",
 endpoint_class: "online",
 created_at: Tue, 05 Dec 2017 21:26:47 UTC +00:00,
 updated_at: Tue, 05 Dec 2017 21:26:47 UTC +00:00>
[9] pry(main)> 
```

as such, i felt like we were best off punting on that caching for now, since we're getting that for free in our current usage.

closes #347