### PR TITLE
Add puts statement

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,7 @@ task :drop, [:storage_root] => [:environment] do |_t, args|
     puts "You're about to erase all the data for #{root}. Are you sure you want to continue? [y/N]"
     input = STDIN.gets.chomp
     if input.casecmp("y").zero? # rubocop prefers casecmp because it is faster than '.downcase =='
+      puts "Starting to drop the db for #{root}"
       MoabToCatalog.drop_endpoint(root)
       puts "You have successfully deleted all the data from #{root}"
     else
@@ -59,6 +60,7 @@ task :populate, [:storage_root] => [:environment] do |_t, args|
     puts "You're about to populate all the data for #{root}. Are you sure you want to continue? [y/N]"
     input = STDIN.gets.chomp
     if input.casecmp("y").zero? # rubocop prefers casecmp because it is faster than '.downcase =='
+      puts "Starting to populate db for #{root}"
       MoabToCatalog.populate_endpoint(root)
       puts "You have successfully populated all the data for #{root}"
     else


### PR DESCRIPTION
closes #391 (branch name is wrong 👎 )
When I started the prod run yesterday I thought it would be more clear if I got a statement saying that the "Seeding has started" for those especially large roots

before:
``` 
preservation_core_catalog 353-add-statement ⚡  rake populate[fixture_sr1]                        
You're about to populate all the data for fixture_sr1. Are you sure you want to continue? [y/N]
y
You have successfully populated all the data for fixture_sr1
```

after:
```
preservation_core_catalog 353-add-statement ⚡  rake populate[fixture_sr1]                        
You're about to populate all the data for fixture_sr1. Are you sure you want to continue? [y/N]
y
Starting to populate db for fixture_sr1
You have successfully populated all the data for fixture_sr1
```