### PR TITLE
have Profiler#print_results_flat be responsible for prefixing the filename with 'profile_', fix corresponding test, improve MoabToCatalog tests slightly

### DIFF
--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -25,7 +25,7 @@ class MoabToCatalog
   def self.check_existence_for_dir_profiled(storage_dir)
     profiler = Profiler.new
     profiler.prof { check_existence_for_dir(storage_dir) }
-    profiler.print_results_flat('profiler_check_existence_for_dir')
+    profiler.print_results_flat('check_existence_for_dir')
   end
 
   # NOTE: shameless green! code duplication with check_existence_for_dir
@@ -56,7 +56,7 @@ class MoabToCatalog
   def self.seed_catalog_for_all_storage_roots_profiled
     profiler = Profiler.new
     profiler.prof { seed_catalog_for_all_storage_roots }
-    profiler.print_results_flat('profile_seed_catalog_for_all_storage_roots')
+    profiler.print_results_flat('seed_catalog_for_all_storage_roots')
   end
 
   # Shameless green. Code duplication with seed_catalog_for_all_storage_roots
@@ -75,7 +75,7 @@ class MoabToCatalog
   def self.check_existence_for_all_storage_roots_profiled
     profiler = Profiler.new
     profiler.prof { check_existence_for_all_storage_roots }
-    profiler.print_results_flat('profile_check_existence_for_all_storage_roots')
+    profiler.print_results_flat('check_existence_for_all_storage_roots')
   end
 
   def self.drop_endpoint(endpoint_name)

--- a/lib/profiler.rb
+++ b/lib/profiler.rb
@@ -16,7 +16,7 @@ class Profiler
   end
 
   def print_results_flat(out_file_id)
-    File.open "log/#{out_file_id}#{Time.current.localtime.strftime('%FT%T')}-flat.txt", 'w' do |file|
+    File.open "log/profile_#{out_file_id}#{Time.current.localtime.strftime('%FT%T')}-flat.txt", 'w' do |file|
       RubyProf::FlatPrinterWithLineNumbers.new(@results).print(file)
     end
   end

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe MoabToCatalog do
       mock_profiler = instance_double(Profiler)
       expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat)
+      expect(mock_profiler).to receive(:print_results_flat).with('check_existence_for_all_storage_roots')
 
       subject
     end
@@ -63,7 +63,7 @@ RSpec.describe MoabToCatalog do
 
       expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat)
+      expect(mock_profiler).to receive(:print_results_flat).with('seed_catalog_for_all_storage_roots')
 
       subject
     end
@@ -176,7 +176,7 @@ RSpec.describe MoabToCatalog do
       mock_profiler = instance_double(Profiler)
       expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat)
+      expect(mock_profiler).to receive(:print_results_flat).with('check_existence_for_dir')
 
       subject
     end

--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Profiler do
     it 'returns the printer and prints to the path we pass in' do
       printer = instance_double(RubyProf::FlatPrinterWithLineNumbers)
       profiler.prof { 'we just want #prof to run' }
-      expected_filepath = "log/test#{Time.current.localtime.strftime('%FT%T')}-flat.txt"
+      expected_filepath = "log/profile_test#{Time.current.localtime.strftime('%FT%T')}-flat.txt"
       expect(RubyProf::FlatPrinterWithLineNumbers).to receive(:new).with(profiler.results).and_return(printer)
       expect(printer).to receive(:print) do |file|
         # this expectation might need to relax


### PR DESCRIPTION
slight touchup to #411, felt quicker to put up this PR than to leave comments