### PR TITLE
Validity unknown status

### DIFF
--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -7,15 +7,18 @@ class PreservedCopy < ApplicationRecord
   ONLINE_MOAB_NOT_FOUND_STATUS = 'online_moab_not_found'.freeze
   EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS = 'expected_vers_not_found_on_storage'.freeze
   FIXITY_CHECK_FAILED_STATUS = 'fixity_check_failed'.freeze
-  DEFAULT_STATUS = OK_STATUS
+  VALIDITY_UNKNOWN_STATUS = 'validity_unknown'.freeze
 
+  # NOTE:  DO NOT change the underlying constants for enum values that have been merged to
+  # master/used in prod db (or at least, consider the necessary migration)
   enum status: {
     OK_STATUS => 0,
     INVALID_MOAB_STATUS => 1,
     INVALID_CHECKSUM_STATUS => 2,
     ONLINE_MOAB_NOT_FOUND_STATUS => 3,
     EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS => 4,
-    FIXITY_CHECK_FAILED_STATUS => 5
+    FIXITY_CHECK_FAILED_STATUS => 5,
+    VALIDITY_UNKNOWN_STATUS => 6
   }
 
   belongs_to :preserved_object

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -37,7 +37,7 @@ class PreservedObjectHandler
     elsif PreservedObject.exists?(druid: druid)
       handler_results.add_result(PreservedObjectHandlerResults::OBJECT_ALREADY_EXISTS, 'PreservedObject')
     elsif moab_validation_errors.empty?
-      create_db_objects(PreservedCopy::DEFAULT_STATUS, true)
+      create_db_objects(PreservedCopy::OK_STATUS, true)
     else
       create_db_objects(PreservedCopy::INVALID_MOAB_STATUS, true)
     end
@@ -52,7 +52,7 @@ class PreservedObjectHandler
     elsif PreservedObject.exists?(druid: druid)
       handler_results.add_result(PreservedObjectHandlerResults::OBJECT_ALREADY_EXISTS, 'PreservedObject')
     else
-      create_db_objects(PreservedCopy::DEFAULT_STATUS)
+      create_db_objects(PreservedCopy::VALIDITY_UNKNOWN_STATUS)
     end
 
     handler_results.log_results
@@ -109,7 +109,7 @@ class PreservedObjectHandler
     else
       handler_results.add_result(PreservedObjectHandlerResults::OBJECT_DOES_NOT_EXIST, 'PreservedObject')
       if moab_validation_errors.empty?
-        create_db_objects(PreservedCopy::DEFAULT_STATUS, true)
+        create_db_objects(PreservedCopy::OK_STATUS, true)
       else
         create_db_objects(PreservedCopy::INVALID_MOAB_STATUS, true)
       end

--- a/spec/load_fixtures_helper.rb
+++ b/spec/load_fixtures_helper.rb
@@ -40,7 +40,7 @@ def load_fixture_moabs
       PreservedCopy.create(preserved_object_id: po.id,
                            endpoint_id: @storage_dir_to_endpoint_id[storage_dir],
                            current_version: version,
-                           status: PreservedCopy::DEFAULT_STATUS)
+                           status: PreservedCopy::VALIDITY_UNKNOWN_STATUS)
     end
   end
 end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PreservedCopy, type: :model do
     policy_id = PreservationPolicy.default_policy.id
     PreservedObject.create!(druid: 'ab123cd4567', current_version: 1, preservation_policy_id: policy_id)
   end
-  let!(:status) { described_class::DEFAULT_STATUS }
+  let!(:status) { described_class::VALIDITY_UNKNOWN_STATUS }
   let!(:preserved_copy) do
     PreservedCopy.create!(
       preserved_object_id: preserved_object.id,
@@ -36,7 +36,8 @@ RSpec.describe PreservedCopy, type: :model do
       PreservedCopy::INVALID_CHECKSUM_STATUS => 2,
       PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS => 3,
       PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS => 4,
-      PreservedCopy::FIXITY_CHECK_FAILED_STATUS => 5
+      PreservedCopy::FIXITY_CHECK_FAILED_STATUS => 5,
+      PreservedCopy::VALIDITY_UNKNOWN_STATUS => 6
     )
   end
 

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PreservedObjectHandler do
       before do
         po = PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
         PreservedCopy.create!(
-          preserved_object: po, # TODO: see if we got the preserved object that we expected
+          preserved_object: po,
           version: po.current_version,
           size: 1,
           endpoint: ep,
@@ -539,7 +539,7 @@ RSpec.describe PreservedObjectHandler do
           end
           it 'PreservedCopy created' do
             pc_args = {
-              preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object we expected
+              preserved_object: an_instance_of(PreservedObject), # TODO: ensure we got the preserved object we expected
               version: incoming_version,
               size: incoming_size,
               endpoint: ep,
@@ -653,7 +653,7 @@ RSpec.describe PreservedObjectHandler do
               preservation_policy_id: PreservationPolicy.default_policy_id
             }
             pc_args = {
-              preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object we expected
+              preserved_object: an_instance_of(PreservedObject), # TODO: ensure we got the preserved object we expected
               version: incoming_version,
               size: incoming_size,
               endpoint: ep,

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PreservedObjectHandler do
           version: po.current_version,
           size: 1,
           endpoint: ep,
-          status: PreservedCopy::DEFAULT_STATUS
+          status: PreservedCopy::OK_STATUS # NOTE: we are pretending we checked for moab validation errs
         )
       end
 
@@ -284,7 +284,7 @@ RSpec.describe PreservedObjectHandler do
               version: invalid_po.current_version,
               size: 1,
               endpoint: invalid_ep,
-              status: PreservedCopy::OK_STATUS,
+              status: PreservedCopy::OK_STATUS, # NOTE: we are pretending we checked for moab validation errs
               last_audited: Time.current.to_i,
               last_checked_on_storage: Time.current
             )
@@ -543,7 +543,7 @@ RSpec.describe PreservedObjectHandler do
               version: incoming_version,
               size: incoming_size,
               endpoint: ep,
-              status: PreservedCopy::OK_STATUS, # NOTE this particular status
+              status: PreservedCopy::OK_STATUS, # NOTE: ensuring this particular status
               last_audited: an_instance_of(Integer),
               last_checked_on_storage: an_instance_of(ActiveSupport::TimeWithZone)
             }
@@ -657,7 +657,7 @@ RSpec.describe PreservedObjectHandler do
               version: incoming_version,
               size: incoming_size,
               endpoint: ep,
-              status: PreservedCopy::INVALID_MOAB_STATUS, # NOTE this particular status
+              status: PreservedCopy::INVALID_MOAB_STATUS, # NOTE ensuring this particular status
               last_audited: an_instance_of(Integer),
               last_checked_on_storage: an_instance_of(ActiveSupport::TimeWithZone)
             }

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PreservedObjectHandler do
           version: po.current_version,
           size: 1,
           endpoint: ep,
-          status: PreservedCopy::DEFAULT_STATUS
+          status: PreservedCopy::OK_STATUS # NOTE: we are pretending we checked for moab validation errs
         )
       end
 

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PreservedObjectHandler do
       before do
         po = PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
         PreservedCopy.create!(
-          preserved_object: po, # TODO: see if we got the preserved object that we expected
+          preserved_object: po,
           version: po.current_version,
           size: 1,
           endpoint: ep,

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PreservedObjectHandler do
         preservation_policy_id: PreservationPolicy.default_policy_id
       }
       pc_args = {
-        preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object that we expected
+        preserved_object: an_instance_of(PreservedObject), # TODO: ensure we got the preserved object that we expected
         version: incoming_version,
         size: incoming_size,
         endpoint: ep,
@@ -132,7 +132,7 @@ RSpec.describe PreservedObjectHandler do
         preservation_policy_id: PreservationPolicy.default_policy_id
       }
       pc_args = {
-        preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object that we expected
+        preserved_object: an_instance_of(PreservedObject), # TODO: ensure we got the preserved object that we expected
         version: incoming_version,
         size: incoming_size,
         endpoint: ep,
@@ -178,7 +178,7 @@ RSpec.describe PreservedObjectHandler do
           preservation_policy_id: PreservationPolicy.default_policy_id
         }
         pc_args = {
-          preserved_object: an_instance_of(PreservedObject), # TODO: see if we got the preserved object that we expected
+          preserved_object: an_instance_of(PreservedObject), # TODO: ensure we got the preserved object that we expected
           version: incoming_version,
           size: incoming_size,
           endpoint: ep,

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe PreservedObjectHandler do
         version: incoming_version,
         size: incoming_size,
         endpoint: ep,
-        status: PreservedCopy::DEFAULT_STATUS # NOTE this particular status
-        # NOTE lack of validation timestamps here
+        status: PreservedCopy::VALIDITY_UNKNOWN_STATUS # NOTE: ensuring this particular status
+        # NOTE: lack of validation timestamps here
       }
 
       expect(PreservedObject).to receive(:create!).with(po_args).and_call_original
@@ -136,7 +136,7 @@ RSpec.describe PreservedObjectHandler do
         version: incoming_version,
         size: incoming_size,
         endpoint: ep,
-        status: PreservedCopy::OK_STATUS, # NOTE this particular status
+        status: PreservedCopy::OK_STATUS, # NOTE ensuring this particular status
         last_audited: an_instance_of(Integer),
         last_checked_on_storage: an_instance_of(ActiveSupport::TimeWithZone)
       }
@@ -182,7 +182,7 @@ RSpec.describe PreservedObjectHandler do
           version: incoming_version,
           size: incoming_size,
           endpoint: ep,
-          status: PreservedCopy::INVALID_MOAB_STATUS, # NOTE this particular status
+          status: PreservedCopy::INVALID_MOAB_STATUS, # NOTE ensuring this particular status
           last_audited: an_instance_of(Integer),
           last_checked_on_storage: an_instance_of(ActiveSupport::TimeWithZone)
         }

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe PreservedObjectHandler do
         version: po.current_version,
         size: 1,
         endpoint: ep,
-        status: PreservedCopy::DEFAULT_STATUS
+        status: PreservedCopy::VALIDITY_UNKNOWN_STATUS
       )
       bad_po_handler = described_class.new(druid, 6, incoming_size, ep)
       allow(pc).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError)

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe PreservedObjectHandler do
       before do
         po = PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
         @pc = PreservedCopy.create!(
-          preserved_object: po, # TODO: see if we got the preserved object that we expected
+          preserved_object: po,
           version: po.current_version,
           size: 1,
           endpoint: ep,
@@ -282,7 +282,7 @@ RSpec.describe PreservedObjectHandler do
         let(:po) { PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy) }
         let(:pc) do
           PreservedCopy.create!(
-            preserved_object: po, # TODO: see if we got the preserved object that we expected
+            preserved_object: po,
             version: po.current_version,
             size: 1,
             endpoint: ep,
@@ -334,7 +334,7 @@ RSpec.describe PreservedObjectHandler do
           # these need to be in before loop so it happens before each context below
           PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
           PreservedCopy.create!(
-            preserved_object: po, # TODO: see if we got the preserved object that we expected
+            preserved_object: po,
             version: po.current_version,
             size: 1,
             endpoint: ep,

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe PreservedObjectHandler do
             version: po.current_version,
             size: 1,
             endpoint: ep,
-            status: PreservedCopy::OK_STATUS,
+            status: PreservedCopy::OK_STATUS, # NOTE: pretending we checked for moab validation errs at create time
             last_audited: Time.current.to_i,
             last_checked_on_storage: Time.current
           )
@@ -338,7 +338,7 @@ RSpec.describe PreservedObjectHandler do
             version: po.current_version,
             size: 1,
             endpoint: ep,
-            status: PreservedCopy::OK_STATUS,
+            status: PreservedCopy::OK_STATUS, # NOTE: pretending we checked for moab validation errs at create time
             last_audited: Time.current.to_i,
             last_checked_on_storage: Time.current
           )


### PR DESCRIPTION
Since the "default" status in PreservedCopy was essentially a stand in for "validity unknown", I revised the code to have a distinct status for "validity unknown" and removed the "default" status.

Note that no db migration needed because a value was added to the status enum, but no existing values were changed.

- Resolves #409 (status when creating missing catalog entry)
- Resolves #371 (add scary warning about changes to PreservedCopy.status enum)
- bonus: gets rid of a copy pasta comment that annoyed @tingulfsen 