### PR TITLE
fix M2C.check_exist bug when disk version < catalog version

### DIFF
--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -382,7 +382,10 @@ RSpec.describe PreservedObjectHandler do
       end
 
       context 'incoming version < db version' do
-        it_behaves_like 'unexpected version', 1
+        let(:druid) { 'bp628nk4868' }
+        let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root02/moab_storage_trunk') }
+
+        it_behaves_like 'unexpected version with validation', :check_existence, 1, PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
       end
 
       context 'PreservedCopy version does NOT match PreservedObject current_version (online Moab)' do


### PR DESCRIPTION
At the moment, this is the ultimate in shameless green implementation.
Do we want to:
- merge it as is and make a separate ticket to refactor?
- refactor check_exist as part of this PR?
- move on to more pressing concerns?

Resolves #424

Review advice:   look at the commits separately