### PR TITLE
[WIP] Check existence skips bad status

### DIFF
--- a/app/services/preserved_object_handler_results.rb
+++ b/app/services/preserved_object_handler_results.rb
@@ -20,6 +20,7 @@ class PreservedObjectHandlerResults
   UNEXPECTED_VERSION = 12
   INVALID_MOAB = 13
   PC_PO_VERSION_MISMATCH = 14
+  PC_STATUS_ALREADY_NOT_OK = 15
 
   RESPONSE_CODE_TO_MESSAGES = {
     INVALID_ARGUMENTS => "encountered validation error(s): %{addl}",
@@ -35,7 +36,8 @@ class PreservedObjectHandlerResults
     PC_STATUS_CHANGED => "PreservedCopy status changed from %{old_status} to %{new_status}",
     UNEXPECTED_VERSION => "incoming version (%{incoming_version}) has unexpected relationship to %{addl} db version; ERROR!",
     INVALID_MOAB => "Invalid moab, validation errors: %{addl}",
-    PC_PO_VERSION_MISMATCH => "PreservedCopy online moab version %{pc_version} does not match PreservedObject current_version %{po_version}"
+    PC_PO_VERSION_MISMATCH => "PreservedCopy online moab version %{pc_version} does not match PreservedObject current_version %{po_version}",
+    PC_STATUS_ALREADY_NOT_OK => "PreservedCopy version %{pc_version} already has '%{status}' status; further checking skipped until PreservedCopy is remediated and marked #{PreservedCopy::OK_STATUS}."
   }.freeze
 
   DB_UPDATED_CODES = [
@@ -61,6 +63,7 @@ class PreservedObjectHandlerResults
     when UNEXPECTED_VERSION then Logger::ERROR
     when INVALID_MOAB then Logger::ERROR
     when PC_PO_VERSION_MISMATCH then Logger::ERROR
+    when PC_STATUS_ALREADY_NOT_OK then Logger::ERROR
     end
   end
 

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -162,12 +162,6 @@ RSpec.describe PreservedObjectHandler do
                 po_handler.check_existence
                 expect(pc.reload.updated_at).to be > orig
               end
-              it 'status becomes "ok" if it was invalid_moab (b/c after validation)' do
-                pc.status = PreservedCopy::INVALID_MOAB_STATUS
-                pc.save!
-                po_handler.check_existence
-                expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
-              end
             end
             context 'unchanged' do
               before do
@@ -314,12 +308,6 @@ RSpec.describe PreservedObjectHandler do
               end
               it 'ensures status becomes invalid_moab from ok' do
                 invalid_pc.status = PreservedCopy::OK_STATUS
-                invalid_pc.save!
-                invalid_po_handler.check_existence
-                expect(invalid_pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
-              end
-              it 'ensures status becomes invalid_moab from expected_vers_not_found_on_storage' do
-                invalid_pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
                 invalid_pc.save!
                 invalid_po_handler.check_existence
                 expect(invalid_pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
@@ -477,6 +465,7 @@ RSpec.describe PreservedObjectHandler do
         allow(po).to receive(:current_version).and_return(1)
         allow(po).to receive(:touch)
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
+        allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
         allow(pc).to receive(:version).and_return(1)
         allow(pc).to receive(:last_audited=)
         allow(pc).to receive(:last_checked_on_storage=)

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -180,15 +180,8 @@ RSpec.describe PreservedObjectHandler do
                 expect(pc.reload.size).to eq orig
               end
             end
-            it 'what about other statuses????' do
-              skip 'need to know what to do when status does NOT start as ok or invalid moab'
-              pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
-              pc.save!
-              po_handler.check_existence
-              expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
-              # TODO: not clear what to do here;  it's not OK_STATUS if we didn't validate ...
-              expect(pc.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
-            end
+
+            it_behaves_like 'status already not ok', :check_existence
           end
           context 'PreservedObject' do
             context 'changed' do

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe PreservedObjectHandler do
             pc = instance_double("PreservedCopy")
             allow(PreservedCopy).to receive(:find_by).and_return(pc)
             allow(pc).to receive(:version).and_return(2)
-            allow(pc).to receive(:status)
+            allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
             allow(pc).to receive(:last_audited=)
             allow(pc).to receive(:last_checked_on_storage=)
             allow(pc).to receive(:changed?).and_return(true)
@@ -298,12 +298,12 @@ RSpec.describe PreservedObjectHandler do
       it 'calls PreservedCopy.save! (but not PreservedObject.save!) if the existing record is altered' do
         po = instance_double(PreservedObject)
         pc = instance_double(PreservedCopy)
-        status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+        status = PreservedCopy::OK_STATUS
         allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-        allow(po).to receive(:current_version).and_return(1)
+        allow(po).to receive(:current_version).and_return(6)
         allow(po).to receive(:save!)
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
-        allow(pc).to receive(:version).and_return(1)
+        allow(pc).to receive(:version).and_return(6)
         allow(pc).to receive(:status).and_return(status)
         allow(pc).to receive(:last_audited=)
         allow(pc).to receive(:last_checked_on_storage=)
@@ -322,6 +322,7 @@ RSpec.describe PreservedObjectHandler do
         allow(po).to receive(:touch)
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
         allow(pc).to receive(:version).and_return(1)
+        allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
         allow(pc).to receive(:last_audited=)
         allow(pc).to receive(:last_checked_on_storage=)
         allow(pc).to receive(:changed?).and_return(false)

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -337,6 +337,8 @@ RSpec.describe PreservedObjectHandler do
         po_handler.confirm_version
         expect(Rails.logger).to have_received(:debug).with(msg)
       end
+
+      it_behaves_like 'status already not ok', :confirm_version
     end
 
     it_behaves_like 'druid not in catalog', :confirm_version


### PR DESCRIPTION
we should merge #437, then #439, and then rebase this, which is one of the reasons for the WIP tag (the other is the open question below).

* standardize and refactor common version mismatch error code to helper method (see below)
* fix what seemed like copypasta in a shared spec invocation
* have `PreservedObjectHandler` `#check_existence` and `#confirm_version` deal with items that already have a bad status

includes has some tangentially related clean-up work.  might be easier to review by commit.  one of the bits of refactoring is duplicative of some work in #437 (and should just get dropped from this PR if that one's merged first).  though some work for this PR adopts the same pattern for a similar bit of functionality.
https://github.com/sul-dlss/preservation_catalog/pull/437/files#diff-db66cd3a51226f58d609af9d477eda0cR74
https://github.com/sul-dlss/preservation_catalog/commit/91793244594d751c2f456298723569b9e43bb43e#diff-db66cd3a51226f58d609af9d477eda0cR74
https://github.com/sul-dlss/preservation_catalog/commit/cb33e5ad8ac3834fcfe5294d343452f4c7226924#diff-db66cd3a51226f58d609af9d477eda0cR74

fine for the team to take over in my absence to get this finished, should be pretty straight-forward if this is generally in the right direction.

my question:  does any non-ok status stop further work from happening?  that's the approach i went with.  the conversation w/ @ndushay and @julianmorley that sparked this work was initially about version mismatch errors (between pres copy and pres obj).  but since what we ended up deciding was that M2C shouldn't detect when an object goes "good" (status should be set to OK as part of remediation, which is already manual for the time being), i just had things halt at anything that wasn't already ok.  should be easy enough to relax that a bit, hopefully.

edit 2017-12-22, a couple things we should probably do before closing this:
[ ] update the audit document to capture this?  something more permanent?  seems like the intent here should be captured somewhere?
[ ] file a ticket indicating that we may have to revisit this when dealing with archive copies, and/or when automating more of the remediation process.

closes #431