### PR TITLE
Improve audit timestamps

### DIFF
--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -80,24 +80,24 @@ class PreservedObjectHandler
           elsif incoming_version > pres_copy.version
             handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT, pres_copy.class.name)
             handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT, pres_object.class.name)
+            ran_moab_validation = true
             if moab_validation_errors.empty?
-              update_preserved_copy_version_etc(pres_copy, incoming_version, incoming_size, false)
+              update_preserved_copy_version_etc(pres_copy, incoming_version, incoming_size, ran_moab_validation)
               update_status(pres_copy, PreservedCopy::OK_STATUS)
               pres_object.current_version = incoming_version
               update_db_object(pres_object)
             else
               update_status(pres_copy, PreservedCopy::INVALID_MOAB_STATUS)
             end
-            ran_moab_validation = true
           else # incoming_version < pres_copy.version
             handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT, pres_copy.class.name)
             handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT, pres_object.class.name)
+            ran_moab_validation = true
             if moab_validation_errors.empty?
               update_status(pres_copy, PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS)
             else
               update_status(pres_copy, PreservedCopy::INVALID_MOAB_STATUS)
             end
-            ran_moab_validation = true
           end
           update_pc_audit_timestamps(pres_copy, ran_moab_validation, true)
           update_db_object(pres_copy)

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -73,6 +73,7 @@ class PreservedObjectHandler
 
           raise_rollback_if_pc_po_version_mismatch(pres_copy.version, pres_object.current_version)
 
+          moab_validated = false
           if incoming_version == pres_copy.version
             handler_results.add_result(PreservedObjectHandlerResults::VERSION_MATCHES, pres_copy.class.name)
             handler_results.add_result(PreservedObjectHandlerResults::VERSION_MATCHES, pres_object.class.name)
@@ -87,6 +88,7 @@ class PreservedObjectHandler
             else
               update_status(pres_copy, PreservedCopy::INVALID_MOAB_STATUS)
             end
+            moab_validated = true
           else # incoming_version < pres_copy.version
             handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT, pres_copy.class.name)
             handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT, pres_object.class.name)
@@ -95,8 +97,9 @@ class PreservedObjectHandler
             else
               update_status(pres_copy, PreservedCopy::INVALID_MOAB_STATUS)
             end
+            moab_validated = true
           end
-          update_pc_validation_timestamps(pres_copy)
+          update_pc_audit_timestamps(pres_copy, moab_validated, true)
           update_db_object(pres_copy)
         end
         handler_results.remove_db_updated_results unless transaction_ok
@@ -203,8 +206,8 @@ class PreservedObjectHandler
       }
       if moab_validated
         t = Time.current
-        pc_attrs[:last_audited] = t.to_i # time as an integer number of seconds since the Epoch
-        pc_attrs[:last_checked_on_storage] = t
+        pc_attrs[:last_version_audit] = t
+        pc_attrs[:last_moab_validation] = t
       end
       PreservedCopy.create!(pc_attrs)
     end
@@ -219,8 +222,7 @@ class PreservedObjectHandler
       pres_object = PreservedObject.find_by!(druid: druid)
       pres_copy = PreservedCopy.find_by!(preserved_object: pres_object, endpoint: endpoint) if pres_object
 
-      # TODO: add this later with audit timestamp updates
-      # raise_rollback_if_pc_po_version_mismatch(pres_copy.version, pres_object.current_version)
+      raise_rollback_if_pc_po_version_mismatch(pres_copy.version, pres_object.current_version)
 
       # FIXME: what if there is more than one associated pres_copy?
       if incoming_version > pres_copy.version && pres_copy.version == pres_object.current_version
@@ -256,8 +258,8 @@ class PreservedObjectHandler
     version_comparison_results(pres_object, :current_version)
 
     update_status(pres_copy, new_status) if new_status
-    update_pc_validation_timestamps(pres_copy) if moab_validated
-    update_db_object(pres_copy) if pres_copy.changed?
+    update_pc_audit_timestamps(pres_copy, moab_validated, true)
+    update_db_object(pres_copy)
   end
 
   # shameless green implementation
@@ -276,7 +278,7 @@ class PreservedObjectHandler
         handler_results.add_result(PreservedObjectHandlerResults::UNEXPECTED_VERSION, pres_copy.class.name)
         update_status(pres_copy, PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS)
       end
-      update_pc_validation_timestamps(pres_copy)
+      update_pc_audit_timestamps(pres_copy, false, true)
       update_db_object(pres_copy)
     end
     handler_results.remove_db_updated_results unless transaction_ok
@@ -302,13 +304,13 @@ class PreservedObjectHandler
   def update_preserved_copy_version_etc(pres_copy, new_version, new_size, moab_validated=false)
     pres_copy.version = new_version
     pres_copy.size = new_size if new_size
-    update_pc_validation_timestamps(pres_copy) if moab_validated
+    update_pc_audit_timestamps(pres_copy, moab_validated, true)
   end
 
-  def update_pc_validation_timestamps(pres_copy)
+  def update_pc_audit_timestamps(pres_copy, moab_validated, version_audited)
     t = Time.current
-    pres_copy.last_audited = t.to_i
-    pres_copy.last_checked_on_storage = t
+    pres_copy.last_moab_validation = t if moab_validated
+    pres_copy.last_version_audit = t if version_audited
   end
 
   # expects @incoming_version to be numeric

--- a/db/migrate/20171220010020_add_audit_timestamps_to_preserved_copies.rb
+++ b/db/migrate/20171220010020_add_audit_timestamps_to_preserved_copies.rb
@@ -1,0 +1,10 @@
+class AddAuditTimestampsToPreservedCopies < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :preserved_copies, :last_checked_on_storage, :last_moab_validation
+    add_index :preserved_copies, :last_moab_validation
+    add_column :preserved_copies, :last_version_audit, :datetime
+    add_index :preserved_copies, :last_version_audit
+    add_index :preserved_copies, :last_checksum_validation
+    remove_column :preserved_copies, :last_audited, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171204215532) do
+ActiveRecord::Schema.define(version: 20171220010020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,17 +53,19 @@ ActiveRecord::Schema.define(version: 20171204215532) do
 
   create_table "preserved_copies", force: :cascade do |t|
     t.integer "version", null: false
-    t.bigint "last_audited"
     t.bigint "preserved_object_id", null: false
     t.bigint "endpoint_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "last_checked_on_storage"
+    t.datetime "last_moab_validation"
     t.datetime "last_checksum_validation"
     t.bigint "size"
     t.integer "status", null: false
+    t.datetime "last_version_audit"
     t.index ["endpoint_id"], name: "index_preserved_copies_on_endpoint_id"
-    t.index ["last_audited"], name: "index_preserved_copies_on_last_audited"
+    t.index ["last_checksum_validation"], name: "index_preserved_copies_on_last_checksum_validation"
+    t.index ["last_moab_validation"], name: "index_preserved_copies_on_last_moab_validation"
+    t.index ["last_version_audit"], name: "index_preserved_copies_on_last_version_audit"
     t.index ["preserved_object_id"], name: "index_preserved_copies_on_preserved_object_id"
     t.index ["status"], name: "index_preserved_copies_on_status"
   end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -81,7 +81,9 @@ RSpec.describe PreservedCopy, type: :model do
 
   it { is_expected.to belong_to(:endpoint) }
   it { is_expected.to belong_to(:preserved_object) }
-  it { is_expected.to have_db_index(:last_audited) }
+  it { is_expected.to have_db_index(:last_version_audit) }
+  it { is_expected.to have_db_index(:last_moab_validation) }
+  it { is_expected.to have_db_index(:last_checksum_validation) }
   it { is_expected.to have_db_index(:endpoint_id) }
   it { is_expected.to have_db_index(:preserved_object_id) }
 end

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe PreservedObjectHandler do
           po.save!
         end
 
-        it_behaves_like 'PreservedObject current_version does not match online PC version', :update_version, 3, 2, 8
+        it_behaves_like 'PreservedObject current_version does not match online PC version', :check_existence, 3, 2, 8
       end
 
       context 'db update error' do

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -393,41 +393,8 @@ RSpec.describe PreservedObjectHandler do
           po.current_version = 8
           po.save!
         end
-        let(:version_mismatch_msg) { "#{exp_msg_prefix} PreservedCopy online moab version #{pc.version} does not match PreservedObject current_version #{po.current_version}" }
 
-        it "logs at error level" do
-          expect(Rails.logger).to receive(:log).with(Logger::ERROR, version_mismatch_msg)
-          po_handler.check_existence
-        end
-        it 'does not update PreservedCopy' do
-          orig_timestamp = pc.updated_at
-          po_handler.check_existence
-          expect(pc.reload.updated_at).to eq orig_timestamp
-        end
-        it 'does not update PreservedObject' do
-          orig_timestamp = po.reload.updated_at
-          po_handler.check_existence
-          expect(po.reload.updated_at).to eq orig_timestamp
-        end
-        context 'returns' do
-          let!(:results) { po_handler.check_existence }
-
-          # results = [result1, result2]
-          # result1 = {response_code: msg}
-          # result2 = {response_code: msg}
-          it '1 result' do
-            expect(results).to be_an_instance_of Array
-            expect(results.size).to eq 1
-          end
-          it 'PC_PO_VERSION_MISMATCH result' do
-            code = PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH
-            expect(results).to include(hash_including(code => version_mismatch_msg))
-          end
-          it 'does NOT get UPDATED_DB_OBJECT message' do
-            expect(results).not_to include(hash_including(PreservedObjectHandlerResults::UPDATED_DB_OBJECT))
-            expect(results).not_to include(hash_including(PreservedObjectHandlerResults::UPDATED_DB_OBJECT_TIMESTAMP_ONLY))
-          end
-        end
+        it_behaves_like 'PreservedObject current_version does not match online PC version', :update_version, 3, 2, 8
       end
 
       context 'db update error' do

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -55,20 +55,12 @@ RSpec.describe PreservedObjectHandler do
 
         context 'PreservedCopy' do
           context 'changed' do
-            it 'last_audited' do
-              orig = Time.current.to_i
-              pc.last_audited = orig
-              pc.save!
-              sleep 1 # last_audited is bigint, and granularity is second, not fraction thereof
-              po_handler.confirm_version
-              expect(pc.reload.last_audited).to be > orig
-            end
-            it 'last_checked_on_storage' do
+            it 'last_version_audit' do
               orig = Time.current
-              pc.last_checked_on_storage = orig
+              pc.last_version_audit = orig
               pc.save!
               po_handler.confirm_version
-              expect(pc.reload.last_checked_on_storage).to be > orig
+              expect(pc.reload.last_version_audit).to be > orig
             end
             it 'updated_at' do
               orig = pc.updated_at
@@ -91,6 +83,11 @@ RSpec.describe PreservedObjectHandler do
               orig = pc.size
               po_handler.confirm_version
               expect(pc.reload.size).to eq orig
+            end
+            it 'last_moab_validation' do
+              orig = pc.last_moab_validation
+              po_handler.confirm_version
+              expect(pc.reload.last_moab_validation).to eq orig
             end
           end
         end
@@ -145,20 +142,12 @@ RSpec.describe PreservedObjectHandler do
               po_handler.confirm_version
               expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
             end
-            it 'last_audited' do
-              orig = Time.current.to_i
-              pc.last_audited = orig
-              pc.save!
-              sleep 1 # last_audited is bigint, and granularity is second, not fraction thereof
-              po_handler.confirm_version
-              expect(pc.reload.last_audited).to be > orig
-            end
-            it 'last_checked_on_storage' do
+            it 'last_version_audit' do
               orig = Time.current
-              pc.last_checked_on_storage = orig
+              pc.last_version_audit = orig
               pc.save!
               po_handler.confirm_version
-              expect(pc.reload.last_checked_on_storage).to be > orig
+              expect(pc.reload.last_version_audit).to be > orig
             end
             it 'updated_at' do
               orig = pc.updated_at
@@ -176,6 +165,11 @@ RSpec.describe PreservedObjectHandler do
               orig = pc.size
               po_handler.confirm_version
               expect(pc.reload.size).to eq orig
+            end
+            it 'last_moab_validation' do
+              orig = pc.last_moab_validation
+              po_handler.confirm_version
+              expect(pc.reload.last_moab_validation).to eq orig
             end
           end
         end
@@ -240,8 +234,7 @@ RSpec.describe PreservedObjectHandler do
             allow(PreservedCopy).to receive(:find_by).and_return(pc)
             allow(pc).to receive(:version).and_return(2)
             allow(pc).to receive(:status)
-            allow(pc).to receive(:last_audited=)
-            allow(pc).to receive(:last_checked_on_storage=)
+            allow(pc).to receive(:last_version_audit=)
             allow(pc).to receive(:changed?).and_return(true)
             allow(pc).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
             allow(po).to receive(:current_version).and_return(2)
@@ -272,8 +265,7 @@ RSpec.describe PreservedObjectHandler do
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
         allow(pc).to receive(:version).and_return(1)
         allow(pc).to receive(:status).and_return(status)
-        allow(pc).to receive(:last_audited=)
-        allow(pc).to receive(:last_checked_on_storage=)
+        allow(pc).to receive(:last_version_audit=)
         allow(pc).to receive(:changed?).and_return(true)
         allow(pc).to receive(:save!)
         po_handler.confirm_version
@@ -289,8 +281,7 @@ RSpec.describe PreservedObjectHandler do
         allow(po).to receive(:touch)
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
         allow(pc).to receive(:version).and_return(1)
-        allow(pc).to receive(:last_audited=)
-        allow(pc).to receive(:last_checked_on_storage=)
+        allow(pc).to receive(:last_version_audit=)
         allow(pc).to receive(:changed?).and_return(false)
         allow(pc).to receive(:touch)
         po_handler.confirm_version

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe PreservedObjectHandler do
           po.save!
         end
 
-        it_behaves_like 'PreservedObject current_version does not match online PC version', :update_version, 3, 2, 8
+        it_behaves_like 'PreservedObject current_version does not match online PC version', :confirm_version, 3, 2, 8
       end
 
       context 'db update error' do

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -221,41 +221,8 @@ RSpec.describe PreservedObjectHandler do
           po.current_version = 8
           po.save!
         end
-        let(:version_mismatch_msg) { "#{exp_msg_prefix} PreservedCopy online moab version #{pc.version} does not match PreservedObject current_version #{po.current_version}" }
 
-        it "logs at error level" do
-          expect(Rails.logger).to receive(:log).with(Logger::ERROR, version_mismatch_msg)
-          po_handler.confirm_version
-        end
-        it 'does not update PreservedCopy' do
-          orig_timestamp = pc.updated_at
-          po_handler.confirm_version
-          expect(pc.reload.updated_at).to eq orig_timestamp
-        end
-        it 'does not update PreservedObject' do
-          orig_timestamp = po.reload.updated_at
-          po_handler.confirm_version
-          expect(po.reload.updated_at).to eq orig_timestamp
-        end
-        context 'returns' do
-          let!(:results) { po_handler.confirm_version }
-
-          # results = [result1, result2]
-          # result1 = {response_code: msg}
-          # result2 = {response_code: msg}
-          it '1 result' do
-            expect(results).to be_an_instance_of Array
-            expect(results.size).to eq 1
-          end
-          it 'PC_PO_VERSION_MISMATCH result' do
-            code = PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH
-            expect(results).to include(hash_including(code => version_mismatch_msg))
-          end
-          it 'does NOT get UPDATED_DB_OBJECT message' do
-            expect(results).not_to include(hash_including(PreservedObjectHandlerResults::UPDATED_DB_OBJECT))
-            expect(results).not_to include(hash_including(PreservedObjectHandlerResults::UPDATED_DB_OBJECT_TIMESTAMP_ONLY))
-          end
-        end
+        it_behaves_like 'PreservedObject current_version does not match online PC version', :update_version, 3, 2, 8
       end
 
       context 'db update error' do

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -117,11 +117,11 @@ RSpec.describe PreservedObjectHandler do
 
       before { results }
 
-      it "sets last_audited with Epoch time" do
-        expect(pc_db_obj.last_audited).to be_within(10).of(t.to_i)
+      it "sets last_moab_validation with current time" do
+        expect(pc_db_obj.last_moab_validation).to be_within(10).of(t)
       end
-      it "sets last_checked_on_storage with current time" do
-        expect(pc_db_obj.last_checked_on_storage).to be_within(10).of(t)
+      it "sets last_version_audit with current time" do
+        expect(pc_db_obj.last_version_audit).to be_within(10).of(t)
       end
     end
 
@@ -137,8 +137,8 @@ RSpec.describe PreservedObjectHandler do
         size: incoming_size,
         endpoint: ep,
         status: PreservedCopy::OK_STATUS, # NOTE ensuring this particular status
-        last_audited: an_instance_of(Integer),
-        last_checked_on_storage: an_instance_of(ActiveSupport::TimeWithZone)
+        last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
+        last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
       }
 
       expect(PreservedObject).to receive(:create!).with(po_args).and_call_original
@@ -183,8 +183,8 @@ RSpec.describe PreservedObjectHandler do
           size: incoming_size,
           endpoint: ep,
           status: PreservedCopy::INVALID_MOAB_STATUS, # NOTE ensuring this particular status
-          last_audited: an_instance_of(Integer),
-          last_checked_on_storage: an_instance_of(ActiveSupport::TimeWithZone)
+          last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
+          last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
         }
 
         expect(PreservedObject).to receive(:create!).with(po_args).and_call_original

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -32,49 +32,62 @@ RSpec.describe PreservedObjectHandler do
           version: po.current_version,
           size: 1,
           endpoint: ep,
-          status: PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          status: PreservedCopy::OK_STATUS, # pretending we checked for moab validation errs at create time
+          last_version_audit: Time.current,
+          last_moab_validation: Time.current
         )
       end
 
       context 'incoming version newer than catalog versions (both) (happy path)' do
-        it "updates PreservedCopy with incoming version" do
-          expect(pc.version).to eq 2
-          po_handler.update_version
-          expect(pc.reload.version).to be > 2
-          expect(pc.reload.version).to eq incoming_version
-        end
-        it "updates PreservedObject with incoming version" do
-          expect(po.current_version).to eq 2
-          po_handler.update_version
-          expect(po.reload.current_version).to be > 2
-          expect(po.reload.current_version).to eq incoming_version
-        end
-        it 'updates PreservedCopy size if supplied' do
-          expect(pc.size).to eq 1
-          po_handler.update_version
-          expect(pc.reload.size).to eq incoming_size
-        end
-        it 'PreservedCopy retains old size if incoming size is nil' do
-          expect(pc.size).to eq 1
-          po_handler = described_class.new(druid, incoming_version, nil, ep)
-          po_handler.update_version
-          expect(pc.reload.size).to eq 1
-        end
-        it 'does not update status of PreservedCopy' do
-          # TODO: not clear what to do here;  it's not OK_STATUS if we didn't validate ...
-          expect(pc.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
-          po_handler.update_version
-          expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
-        end
-        it 'does not update PreservedCopy last_audited field' do
-          orig_timestamp = pc.last_audited
-          po_handler.update_version
-          expect(pc.reload.last_audited).to eq orig_timestamp
-        end
-        it 'does not update PreservedCopy last_checked_on_storage' do
-          orig_timestamp = pc.last_checked_on_storage
-          po_handler.update_version
-          expect(pc.reload.last_checked_on_storage).to eq orig_timestamp
+        context 'PreservedCopy' do
+          context 'changed' do
+            it "version becomes incoming_version" do
+              orig = pc.version
+              po_handler.update_version
+              expect(pc.reload.version).to be > orig
+              expect(pc.version).to eq incoming_version
+            end
+            it 'last_version_audit' do
+              orig = pc.last_version_audit
+              po_handler.update_version
+              expect(pc.reload.last_version_audit).to be > orig
+            end
+            it 'size if supplied' do
+              orig = pc.size
+              po_handler.update_version
+              expect(pc.reload.size).to eq incoming_size
+              expect(pc.size).not_to eq orig
+            end
+          end
+          context 'unchanged' do
+            it 'size if incoming size is nil' do
+              orig = pc.size
+              po_handler = described_class.new(druid, incoming_version, nil, ep)
+              po_handler.update_version
+              expect(pc.reload.size).to eq orig
+            end
+            it 'status' do
+              orig = pc.status
+              po_handler.update_version
+              expect(pc.reload.status).to eq orig
+              skip 'is there a scenario when status should change here?  See #431'
+            end
+            it 'last_moab_validation' do
+              orig = pc.last_moab_validation
+              po_handler.update_version
+              expect(pc.reload.last_moab_validation).to eq orig
+            end
+          end
+          context 'PreservedObject' do
+            context 'changed' do
+              it "current_version becomes incoming version" do
+                orig = po.current_version
+                po_handler.update_version
+                expect(po.reload.current_version).to be > orig
+                expect(po.current_version).to eq incoming_version
+              end
+            end
+          end
         end
         it "logs at info level" do
           expect(Rails.logger).to receive(:log).with(Logger::INFO, version_gt_po_msg)
@@ -118,7 +131,7 @@ RSpec.describe PreservedObjectHandler do
       end
 
       context 'incoming version same as catalog versions (both)' do
-        it_behaves_like 'unexpected version', :update_version, 2
+        it_behaves_like 'unexpected version', :update_version, 2, PreservedCopy::OK_STATUS
       end
 
       context 'incoming version lower than catalog versions (both)' do
@@ -145,6 +158,7 @@ RSpec.describe PreservedObjectHandler do
               allow(pc).to receive(:size=)
               allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
               allow(pc).to receive(:status=)
+              allow(pc).to receive(:last_version_audit=)
               allow(pc).to receive(:changed?).and_return(true)
               allow(pc).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
               po_handler.update_version
@@ -187,6 +201,7 @@ RSpec.describe PreservedObjectHandler do
               allow(pc).to receive(:size=).with(incoming_size)
               allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
               allow(pc).to receive(:status=)
+              allow(pc).to receive(:last_version_audit=)
               allow(pc).to receive(:changed?).and_return(true)
               allow(pc).to receive(:save!)
               po_handler.update_version
@@ -211,7 +226,7 @@ RSpec.describe PreservedObjectHandler do
         end
       end
 
-      it 'calls PreservedObject.save! and PreservedCopy.save! if the existing record is altered' do
+      it 'calls PreservedObject.save! and PreservedCopy.save! if the records are altered' do
         po = instance_double(PreservedObject)
         allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
         allow(po).to receive(:current_version).and_return(1)
@@ -226,6 +241,7 @@ RSpec.describe PreservedObjectHandler do
         allow(pc).to receive(:endpoint).with(ep)
         allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
         allow(pc).to receive(:status=)
+        allow(pc).to receive(:last_version_audit=)
         allow(pc).to receive(:changed?).and_return(true)
         allow(pc).to receive(:save!)
         po_handler.update_version
@@ -233,22 +249,24 @@ RSpec.describe PreservedObjectHandler do
         expect(pc).to have_received(:save!)
       end
 
-      it 'does not call PreservedObject.touch or PreservedCopy.touch if the existing record is NOT altered' do
-        po_handler = described_class.new(druid, 1, 1, ep)
+      it 'does not call PreservedObject.touch when PreservedCopy only has timestamp updates' do
         po = instance_double(PreservedObject)
         allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
         allow(po).to receive(:current_version).and_return(1)
-        allow(po).to receive(:changed?).and_return(false)
         allow(po).to receive(:touch)
         pc = instance_double(PreservedCopy)
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
         allow(pc).to receive(:version).and_return(1)
         allow(pc).to receive(:endpoint).with(ep)
-        allow(pc).to receive(:changed?).and_return(false)
-        allow(pc).to receive(:touch)
+        allow(pc).to receive(:last_version_audit=)
+        allow(pc).to receive(:status)
+        allow(pc).to receive(:status=)
+        allow(pc).to receive(:changed?).and_return(true)
+        allow(pc).to receive(:save!)
+        po_handler = described_class.new(druid, 1, 1, ep)
         po_handler.update_version
         expect(po).not_to have_received(:touch)
-        expect(pc).not_to have_received(:touch)
+        expect(pc).to have_received(:save!)
       end
 
       it 'logs a debug message' do
@@ -279,29 +297,70 @@ RSpec.describe PreservedObjectHandler do
 
     context 'in Catalog' do
       context 'when moab is valid' do
-        let(:po) { PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy) }
-        let(:pc) do
+        before do
+          t = Time.current
           PreservedCopy.create!(
             preserved_object: po,
             version: po.current_version,
             size: 1,
             endpoint: ep,
             status: PreservedCopy::OK_STATUS, # NOTE: pretending we checked for moab validation errs at create time
-            last_audited: Time.current.to_i,
-            last_checked_on_storage: Time.current
+            last_version_audit: t,
+            last_moab_validation: t
           )
         end
+        let(:po) { PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy) }
+        let(:pc) { PreservedCopy.find_by!(preserved_object: po, endpoint: ep) }
 
-        it 'updates PreservedCopy last_audited' do
-          orig_timestamp = pc.last_audited
-          sleep 1 # last_audited is bigint, and granularity is second, not fraction thereof
-          po_handler.update_version_after_validation
-          expect(pc.reload.last_audited).to be > orig_timestamp
+        context 'PreservedCopy' do
+          context 'changed' do
+            it 'last_version_audit' do
+              orig = pc.last_version_audit
+              po_handler.update_version_after_validation
+              expect(pc.reload.last_version_audit).to be > orig
+            end
+            it 'last_moab_validation' do
+              orig = pc.last_moab_validation
+              po_handler.update_version_after_validation
+              expect(pc.reload.last_moab_validation).to be > orig
+            end
+            it 'version becomes incoming_version' do
+              orig = pc.version
+              po_handler.update_version_after_validation
+              expect(pc.reload.version).to be > orig
+              expect(pc.version).to eq incoming_version
+            end
+            it 'size if supplied' do
+              orig = pc.size
+              po_handler.update_version_after_validation
+              expect(pc.reload.size).to eq incoming_size
+              expect(pc.size).not_to eq orig
+            end
+          end
+          context 'unchanged' do
+            it 'size if incoming size is nil' do
+              orig = pc.size
+              po_handler = described_class.new(druid, incoming_version, nil, ep)
+              po_handler.update_version_after_validation
+              expect(pc.reload.size).to eq orig
+            end
+            it 'status' do
+              orig = pc.status
+              po_handler.update_version_after_validation
+              expect(pc.reload.status).to eq orig
+              skip 'is there a scenario when status should change here?  See #431'
+            end
+          end
         end
-        it 'updates PreservedCopy last_checked_on_storage' do
-          orig_timestamp = pc.last_checked_on_storage
-          po_handler.update_version_after_validation
-          expect(pc.reload.last_checked_on_storage).to be > orig_timestamp
+        context 'PreservedObject' do
+          context 'changed' do
+            it 'current_version' do
+              orig = po.current_version
+              po_handler.update_version_after_validation
+              expect(po.reload.current_version).to eq po_handler.incoming_version
+              expect(po.current_version).to be > orig
+            end
+          end
         end
 
         it 'calls #update_online_version with validated = true and status = "ok"' do
@@ -324,37 +383,67 @@ RSpec.describe PreservedObjectHandler do
         let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
 
         before do
-          # add storage root with the invalid moab to the Endpoints table
           Endpoint.find_or_create_by!(endpoint_name: 'bad_fixture_dir') do |endpoint|
             endpoint.endpoint_type = Endpoint.default_storage_root_endpoint_type
             endpoint.endpoint_node = Settings.endpoints.storage_root_defaults.endpoint_node
             endpoint.storage_location = storage_dir
             endpoint.recovery_cost = Settings.endpoints.storage_root_defaults.recovery_cost
           end
-          # these need to be in before loop so it happens before each context below
-          PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
+          po = PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
+          t = Time.current
           PreservedCopy.create!(
             preserved_object: po,
             version: po.current_version,
             size: 1,
             endpoint: ep,
-            status: PreservedCopy::OK_STATUS, # NOTE: pretending we checked for moab validation errs at create time
-            last_audited: Time.current.to_i,
-            last_checked_on_storage: Time.current
+            status: PreservedCopy::OK_STATUS, # pretending we checked for moab validation errs at create time
+            last_version_audit: t,
+            last_moab_validation: t
           )
         end
 
-        it 'updates PreservedCopy last_audited' do
-          orig_timestamp = pc.last_audited
-          sleep 1 # last_audited is bigint, and granularity is second, not fraction thereof
-          po_handler.update_version_after_validation
-          expect(pc.reload.last_audited).to be > orig_timestamp
+        context 'PreservedCopy' do
+          context 'changed' do
+            it 'last_moab_validation' do
+              orig = pc.last_moab_validation
+              po_handler.update_version_after_validation
+              expect(pc.reload.last_moab_validation).to be > orig
+            end
+            it 'status' do
+              orig = pc.status
+              po_handler.update_version_after_validation
+              expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
+              expect(pc.status).not_to eq orig
+            end
+          end
+          context 'unchanged' do
+            it 'version' do
+              orig = pc.version
+              po_handler.update_version_after_validation
+              expect(pc.reload.version).to eq orig
+            end
+            it 'size' do
+              orig = pc.size
+              po_handler.update_version_after_validation
+              expect(pc.reload.size).to eq orig
+            end
+            it 'last_version_audit' do
+              orig = pc.last_version_audit
+              po_handler.update_version_after_validation
+              expect(pc.reload.last_version_audit).to eq orig
+            end
+          end
         end
-        it 'updates PreservedCopy last_checked_on_storage' do
-          orig_timestamp = pc.last_checked_on_storage
-          po_handler.update_version_after_validation
-          expect(pc.reload.last_checked_on_storage).to be > orig_timestamp
+        context 'PreservedObject' do
+          context 'unchanged' do
+            it 'current_version' do
+              orig = po.current_version
+              po_handler.update_version_after_validation
+              expect(po.current_version).to eq orig
+            end
+          end
         end
+
         it 'ensures PreservedCopy status is invalid' do
           pc.status = PreservedCopy::OK_STATUS
           pc.save!
@@ -369,13 +458,10 @@ RSpec.describe PreservedObjectHandler do
           expect(Rails.logger).to have_received(:debug).with(msg)
         end
 
-        it 'calls PreservedObject.save! and PreservedCopy.save! if the existing record is altered' do
+        it 'does not call PreservedObject.touch when PreservedCopy only has timestamp updates' do
           po = instance_double(PreservedObject)
           allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-          allow(po).to receive(:current_version).and_return(1)
-          allow(po).to receive(:current_version=).with(incoming_version)
-          allow(po).to receive(:changed?).and_return(true)
-          allow(po).to receive(:save!)
+          allow(po).to receive(:touch)
           pc = instance_double(PreservedCopy)
           allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
           allow(pc).to receive(:version).and_return(1)
@@ -384,36 +470,14 @@ RSpec.describe PreservedObjectHandler do
           allow(pc).to receive(:endpoint).with(ep)
           allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
           allow(pc).to receive(:status=)
-          allow(pc).to receive(:last_audited=)
-          allow(pc).to receive(:last_checked_on_storage=)
+          allow(pc).to receive(:last_version_audit=)
+          allow(pc).to receive(:last_moab_validation=)
           allow(pc).to receive(:changed?).and_return(true)
           allow(pc).to receive(:save!)
           allow(po_handler).to receive(:moab_validation_errors).and_return(['foo'])
           po_handler.update_version_after_validation
-          expect(po).to have_received(:save!)
-          expect(pc).to have_received(:save!)
-        end
-
-        it 'does not call PreservedObject.touch and PreservedCopy.touch if the existing record is NOT altered' do
-          po_handler = described_class.new(druid, 1, 1, ep)
-          po = instance_double(PreservedObject)
-          allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-          allow(po).to receive(:current_version).and_return(1)
-          allow(po).to receive(:changed?).and_return(false)
-          allow(po).to receive(:touch)
-          pc = instance_double(PreservedCopy)
-          allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
-          allow(pc).to receive(:version).and_return(1)
-          allow(pc).to receive(:endpoint).with(ep)
-          allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
-          allow(pc).to receive(:status=)
-          allow(pc).to receive(:last_audited=)
-          allow(pc).to receive(:last_checked_on_storage=)
-          allow(pc).to receive(:changed?).and_return(false)
-          allow(pc).to receive(:touch)
-          po_handler.update_version_after_validation
           expect(po).not_to have_received(:touch)
-          expect(pc).not_to have_received(:touch)
+          expect(pc).to have_received(:save!)
         end
 
         context 'incoming version newer than catalog versions (both) (happy path)' do
@@ -460,51 +524,11 @@ RSpec.describe PreservedObjectHandler do
                 allow(pc).to receive(:version=)
                 allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
                 allow(pc).to receive(:status=)
-                allow(pc).to receive(:last_audited=)
-                allow(pc).to receive(:last_checked_on_storage=)
+                allow(pc).to receive(:last_version_audit=)
+                allow(pc).to receive(:last_moab_validation=)
                 allow(pc).to receive(:changed?).and_return(true)
                 allow(pc).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
                 allow(pc).to receive(:size=)
-                po_handler.update_version_after_validation
-              end
-
-              context 'DB_UPDATE_FAILED error' do
-                it 'prefix' do
-                  expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix_regex_escaped)))
-                end
-                it 'specific exception raised' do
-                  expect(results).to include(a_hash_including(result_code => a_string_matching('ActiveRecord::ActiveRecordError')))
-                end
-                it "exception's message" do
-                  expect(results).to include(a_hash_including(result_code => a_string_matching('foo')))
-                end
-              end
-            end
-          end
-          context 'PreservedObject' do
-            context 'ActiveRecordError' do
-              let(:results) do
-                allow(Rails.logger).to receive(:log)
-                # FIXME: couldn't figure out how to put next line into its own test
-                expect(Rails.logger).to receive(:log).with(Logger::ERROR, /#{db_update_failed_prefix_regex_escaped}/)
-
-                po = instance_double('PreservedObject')
-                allow(po).to receive(:current_version).and_return(5)
-                allow(po).to receive(:current_version=).with(incoming_version)
-                allow(po).to receive(:changed?).and_return(true)
-                allow(po).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
-                allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-                pc = instance_double('PreservedCopy')
-                allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
-                allow(pc).to receive(:version).and_return(5)
-                allow(pc).to receive(:version=).with(incoming_version)
-                allow(pc).to receive(:size=).with(incoming_size)
-                allow(pc).to receive(:last_audited=)
-                allow(pc).to receive(:last_checked_on_storage=)
-                allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
-                allow(pc).to receive(:status=)
-                allow(pc).to receive(:changed?).and_return(true)
-                allow(pc).to receive(:save!)
                 po_handler.update_version_after_validation
               end
 

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe PreservedObjectHandler do
           @pc.save!
         end
 
-        it_behaves_like 'unexpected version', :update_version, 8
+        it_behaves_like 'PreservedObject current_version does not match online PC version', :update_version, 3, 3, 2
       end
 
       context 'incoming version same as catalog versions (both)' do
@@ -430,7 +430,7 @@ RSpec.describe PreservedObjectHandler do
             pc.save!
           end
 
-          it_behaves_like 'unexpected version with validation', :update_version_after_validation, 8, PreservedCopy::INVALID_MOAB_STATUS
+          it_behaves_like 'update for invalid moab', :update_version_after_validation
         end
 
         context 'incoming version same as catalog versions (both)' do

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -545,6 +545,7 @@ RSpec.describe PreservedObjectHandler do
               end
             end
           end
+          # PreservedObject won't get updated if moab is invalid
         end
       end
     end

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -180,13 +180,6 @@ RSpec.shared_examples 'unexpected version' do |method_sym, incoming_version|
 
   context 'returns' do
     let!(:results) { po_handler.send(method_sym) }
-    let(:num_results) do
-      if method_sym == :update_version
-        5
-      else
-        4
-      end
-    end
 
     # results = [result1, result2]
     # result1 = {response_code: msg}


### PR DESCRIPTION
~~WIP until #437 is merged;  then this will be rebased on master.~~

PreservedCopy datestamps:
- last_moab_validation
- last_version_audit

replace:
- last_audited
- last_check_on_storage

To allow us to distinguish between these two types of audit checks.  This was discussed here:  https://github.com/sul-dlss/preservation_catalog/pull/432#discussion_r157886007

I tried to break up the commits so it would be somewhat manageable for review.  The truth is after the db migration, the specs won't pass without all these commits.  :-P

Resolves #434