### PR TITLE
Test results not behavior

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,12 +87,13 @@ Metrics/LineLength:
     - 'app/services/preserved_object_handler.rb' # line 269 is 121
     - 'app/services/preserved_object_handler_results.rb' # line 35 is 121
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # 1 line 126
+    - 'spec/models/status_spec.rb' # Line length of 132 for better readability
+    - spec/services/preserved_object_handler_spec.rb
+    - 'spec/services/preserved_object_handler_check_exist_spec.rb' # 17 lines, but who's counting, officer?
     - 'spec/services/preserved_object_handler_confirm_version_spec.rb'
     - 'spec/services/preserved_object_handler_create_spec.rb'
     - 'spec/services/preserved_object_handler_update_version_spec.rb'
     - 'spec/services/shared_examples_preserved_object_handler.rb'
-    - 'spec/models/status_spec.rb' # Line length of 132 for better readability
-    - 'spec/services/preserved_object_handler_check_exist_spec.rb' # 17 lines, but who's counting, officer?
 
 Metrics/MethodLength:
   Max: 25

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -179,6 +179,12 @@ RSpec.describe PreservedObjectHandler do
         po_handler.create_after_validation
       end
 
+      it 'includes invalid moab result' do
+        results = po_handler.create_after_validation
+        code = PreservedObjectHandlerResults::INVALID_MOAB
+        expect(results).to include(a_hash_including(code => a_string_matching('Invalid moab, validation errors:')))
+      end
+
       context 'db update error' do
         context 'ActiveRecordError' do
           let(:results) do
@@ -203,12 +209,6 @@ RSpec.describe PreservedObjectHandler do
           expect(PreservedObject.where(druid: druid)).not_to exist
         end
       end
-    end
-
-    it 'includes invalid moab result' do
-      results = po_handler.create_after_validation
-      code = PreservedObjectHandlerResults::INVALID_MOAB
-      expect(results).to include(a_hash_including(code => a_string_matching('Invalid moab, validation errors:')))
     end
 
     context 'returns' do

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -81,6 +81,22 @@ RSpec.describe PreservedObjectHandler do
       bad_po_handler.confirm_version
       expect(PreservedObject.find_by(druid: druid).current_version).to eq 2
     end
+
+    context 'ActiveRecordError gives DB_UPDATE_FAILED error with rich details' do
+      let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
+      let(:results) do
+        allow(PreservedObject).to receive(:create!).with(hash_including(druid: druid))
+                                                   .and_raise(ActiveRecord::ActiveRecordError, 'specific_err_msg')
+        po_handler.create
+      end
+
+      it 'specific exception raised' do
+        expect(results).to include(a_hash_including(result_code => a_string_matching('ActiveRecord::ActiveRecordError')))
+      end
+      it "exception's message" do
+        expect(results).to include(a_hash_including(result_code => a_string_matching('specific_err_msg')))
+      end
+    end
   end
 
   describe '#moab_validation_errors' do

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -69,6 +69,18 @@ RSpec.shared_examples "attributes validated" do |method_sym|
   end
 end
 
+# TODO: change log_results to report_results after upcoming PR
+RSpec.shared_examples 'calls PreservedObjectHandlerResults.log_results' do |method_sym|
+  it '' do
+    mock_results = instance_double(PreservedObjectHandlerResults)
+    allow(mock_results).to receive(:add_result)
+    allow(mock_results).to receive(:result_array) # TODO: remove this when switch to report_results call
+    expect(mock_results).to receive(:log_results) # TODO: change this when switch to report_results call
+    expect(PreservedObjectHandlerResults).to receive(:new).and_return(mock_results)
+    po_handler.send(method_sym)
+  end
+end
+
 RSpec.shared_examples 'druid not in catalog' do |method_sym|
   let(:druid) { 'rr111rr1111' }
   let(:escaped_exp_msg) { Regexp.escape(exp_msg_prefix) + ".* PreservedObject.* db object does not exist" }


### PR DESCRIPTION
Initial approach for #455;  

Better testing for PreservedObjectHandlerResults allows us to reduce test code for PreservedObjectHandler

(this grew out of Naomi writing a few tests to ensure that seeding the catalog would report errors to dor workflows)

Connected to #455