### PR TITLE
Implemented the workflow services rest call to send error messages to preservationWF.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,7 @@ Metrics/LineLength:
   Exclude:
     - 'app/services/preserved_object_handler.rb' # line 269 is 121
     - 'app/services/preserved_object_handler_results.rb' # line 35 is 121
+    - 'app/services/workflow_errors_reporter.rb' # line 7 is 143
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # 1 line 126
     - 'spec/models/status_spec.rb' # Line length of 132 for better readability
     - spec/services/preserved_object_handler_spec.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,7 @@ Lint/RescueWithoutErrorClass:
 Metrics/AbcSize:
   Exclude:
     - 'app/services/preserved_object_handler.rb' # methods still readable; shameless green
+    - 'app/services/preserved_object_handler_results.rb' # method still readable
     - 'lib/audit/moab_to_catalog.rb' # .xxx_for_all_storage_roots is decidedly readable
 
 Metrics/BlockLength:
@@ -74,6 +75,7 @@ Metrics/BlockNesting:
 Metrics/ClassLength:
   Exclude:
     - 'app/services/preserved_object_handler.rb'
+    - 'app/services/preserved_object_handler_results.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:
@@ -89,15 +91,13 @@ Metrics/LineLength:
     - 'app/services/workflow_errors_reporter.rb' # line 7 is 143
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # 1 line 126
     - 'spec/models/status_spec.rb' # Line length of 132 for better readability
-    - spec/services/preserved_object_handler_spec.rb
     - 'spec/services/preserved_object_handler_check_exist_spec.rb' # 17 lines, but who's counting, officer?
     - 'spec/services/preserved_object_handler_confirm_version_spec.rb'
     - 'spec/services/preserved_object_handler_create_spec.rb'
+    - 'spec/services/preserved_object_handler_spec.rb' # line 94 is 121
     - 'spec/services/preserved_object_handler_update_version_spec.rb'
     - 'spec/services/shared_examples_preserved_object_handler.rb'
-    - 'spec/models/status_spec.rb' # Line length of 132 for better readability
-    - 'spec/services/preserved_object_handler_check_exist_spec.rb' # 17 lines, but who's counting, officer?
-    - 'spec/services/workflow_errors_reporter_spec.rb' # lines for body and error_msg kept long for readability
+    - 'spec/services/workflow_errors_reporter_spec.rb'
 
 Metrics/MethodLength:
   Max: 25

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,6 +95,9 @@ Metrics/LineLength:
     - 'spec/services/preserved_object_handler_create_spec.rb'
     - 'spec/services/preserved_object_handler_update_version_spec.rb'
     - 'spec/services/shared_examples_preserved_object_handler.rb'
+    - 'spec/models/status_spec.rb' # Line length of 132 for better readability
+    - 'spec/services/preserved_object_handler_check_exist_spec.rb' # 17 lines, but who's counting, officer?
+    - 'spec/services/workflow_errors_reporter_spec.rb' # lines for body and error_msg kept long for readability
 
 Metrics/MethodLength:
   Max: 25

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   # Ruby static code analyzer http://rubocop.readthedocs.io/en/latest/
   gem 'rubocop', '~> 0.50.0', require: false # avoid code churn due to rubocop changes
   gem 'rubocop-rspec'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'rails', '~> 5.1.3'
 gem 'newrelic_rpm'
 # Use honeybadger for error reporting
 gem 'honeybadger'
+# Use faraday for ReST calls
+gem 'faraday'
 
 # Stanford gems
 gem 'moab-versioning' # work with Moab Objects

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'newrelic_rpm'
 gem 'honeybadger'
 # Use faraday for ReST calls
 gem 'faraday'
-# Use retries for handling exceptions and retries
+# For more robust handling of network glitches
 gem 'retries'
 
 # Stanford gems

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'newrelic_rpm'
 gem 'honeybadger'
 # Use faraday for ReST calls
 gem 'faraday'
+# Use retries for handling exceptions and retries
+gem 'retries'
 
 # Stanford gems
 gem 'moab-versioning' # work with Moab Objects

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
     docile (1.1.5)
     druid-tools (1.0.0)
     erubi (1.6.1)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -130,6 +132,7 @@ GEM
       nokogiri-happymapper
       systemu
     multi_json (1.12.2)
+    multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
@@ -262,6 +265,7 @@ DEPENDENCIES
   coveralls
   dlss-capistrano
   druid-tools
+  faraday
   hirb
   honeybadger
   jbuilder (~> 2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    retries (0.0.5)
     rspec-core (3.6.0)
       rspec-support (~> 3.6.0)
     rspec-expectations (3.6.0)
@@ -289,6 +290,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.3)
   rails-controller-testing
+  retries
   rspec-rails (~> 3.6)
   rubocop (~> 0.50.0)
   rubocop-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (8.0.0)
@@ -87,6 +89,8 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.4)
       tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     deep_merge (1.1.1)
     diff-lcs (1.3)
     dlss-capistrano (3.4.1)
@@ -102,6 +106,7 @@ GEM
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    hashdiff (0.3.4)
     hashie (3.5.6)
     hirb (0.7.3)
     honeybadger (3.2.0)
@@ -155,6 +160,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
+    public_suffix (3.0.1)
     puma (3.10.0)
     rack (2.0.3)
     rack-test (0.7.0)
@@ -221,6 +227,7 @@ GEM
     ruby-prof (0.16.2)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
     simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -250,6 +257,10 @@ GEM
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
+    webmock (3.0.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -285,6 +296,7 @@ DEPENDENCIES
   shoulda-matchers!
   spring
   spring-watcher-listen (~> 2.0.0)
+  webmock
 
 BUNDLED WITH
    1.16.0

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -43,7 +43,6 @@ class PreservedObjectHandler
     end
 
     handler_results.report_results
-    handler_results.result_array
   end
 
   def create
@@ -56,7 +55,6 @@ class PreservedObjectHandler
     end
 
     handler_results.report_results
-    handler_results.result_array
   end
 
   # this is a long, complex method (shameless green); if it is refactored, revisit the exceptions in rubocop.yml
@@ -115,7 +113,6 @@ class PreservedObjectHandler
       end
     end
     handler_results.report_results
-    handler_results.result_array
   end
 
   def confirm_version
@@ -132,7 +129,6 @@ class PreservedObjectHandler
     end
 
     handler_results.report_results
-    handler_results.result_array
   end
 
   def update_version_after_validation
@@ -154,7 +150,6 @@ class PreservedObjectHandler
     end
 
     handler_results.report_results
-    handler_results.result_array
   end
 
   def update_version
@@ -171,7 +166,6 @@ class PreservedObjectHandler
     end
 
     handler_results.report_results
-    handler_results.result_array
   end
 
   private

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -42,7 +42,7 @@ class PreservedObjectHandler
       create_db_objects(PreservedCopy::INVALID_MOAB_STATUS, true)
     end
 
-    handler_results.log_results
+    handler_results.report_results
     handler_results.result_array
   end
 
@@ -55,7 +55,7 @@ class PreservedObjectHandler
       create_db_objects(PreservedCopy::VALIDITY_UNKNOWN_STATUS)
     end
 
-    handler_results.log_results
+    handler_results.report_results
     handler_results.result_array
   end
 
@@ -114,7 +114,7 @@ class PreservedObjectHandler
         create_db_objects(PreservedCopy::INVALID_MOAB_STATUS, true)
       end
     end
-    handler_results.log_results
+    handler_results.report_results
     handler_results.result_array
   end
 
@@ -131,7 +131,7 @@ class PreservedObjectHandler
       end
     end
 
-    handler_results.log_results
+    handler_results.report_results
     handler_results.result_array
   end
 
@@ -153,7 +153,7 @@ class PreservedObjectHandler
       end
     end
 
-    handler_results.log_results
+    handler_results.report_results
     handler_results.result_array
   end
 
@@ -170,7 +170,7 @@ class PreservedObjectHandler
       end
     end
 
-    handler_results.log_results
+    handler_results.report_results
     handler_results.result_array
   end
 

--- a/app/services/preserved_object_handler_results.rb
+++ b/app/services/preserved_object_handler_results.rb
@@ -64,9 +64,10 @@ class PreservedObjectHandlerResults
     end
   end
 
-  attr_reader :result_array, :incoming_version, :msg_prefix
+  attr_reader :result_array, :incoming_version, :msg_prefix, :druid
 
   def initialize(druid, incoming_version, incoming_size, endpoint)
+    @druid = druid
     @incoming_version = incoming_version
     @msg_prefix = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{endpoint.endpoint_name if endpoint})"
     @result_array = []
@@ -88,7 +89,8 @@ class PreservedObjectHandlerResults
   # result_array = [result1, result2]
   # result1 = {response_code => msg}
   # result2 = {response_code => msg}
-  def log_results
+  def report_results
+    WorkflowErrorsReporter.update_workflow(druid, result_array)
     result_array.each do |r|
       severity = self.class.logger_severity_level(r.keys.first)
       msg = r.values.first

--- a/app/services/preserved_object_handler_results.rb
+++ b/app/services/preserved_object_handler_results.rb
@@ -96,6 +96,7 @@ class PreservedObjectHandlerResults
       msg = r.values.first
       Rails.logger.log(severity, msg)
     end
+    result_array
   end
 
   private

--- a/app/services/workflow_errors_reporter.rb
+++ b/app/services/workflow_errors_reporter.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'retries'
 # This class will send a put ReST call to the preservationWF via faraday. This also parses
 # out a shorter error message, that only includes the moab validation error.
 class WorkflowErrorsReporter
@@ -7,21 +8,34 @@ class WorkflowErrorsReporter
     error_message.select { |error| request(druid, 'moab-valid', moab_error(error)) if error.key?(PreservedObjectHandlerResults::INVALID_MOAB) }
   end
 
+  def self.request(druid, process_name, error_message)
+    return unless conn
+    handler = proc do |exception, attempt_number, total_delay|
+      Rails.logger.warn("Handler saw a #{exception.class}; retry attempt #{attempt_number}; #{total_delay} seconds have passed.")
+    end
+    with_retries(max_tries: 3, handler: handler, rescue: workflow_service_exceptions_to_catch) do
+      @connection.put do |request|
+        request.headers['content-type'] = "application/xml"
+        request.url  "/workflow/dor/objects/druid:#{druid}/workflows/preservationWF/#{process_name}"
+        request.body = "<process name='#{process_name}' status='error' errorMessage='#{error_message}'/>"
+      end
+    end
+  rescue *workflow_service_exceptions_to_catch => e
+    raise Faraday::Error, e
+  end
   private_class_method def self.conn
     if Settings.workflow_services.url.present?
-      @connection ||= Faraday.new(url: Settings.workflow_services.url)
-      Rails.logger.log(warn, 'no workflow hookup - assume you are in test or dev environment')
+      @connection ||= Faraday.new(url: Settings.workflow_services.url) do |c|
+        c.use Faraday::Response::RaiseError
+        c.use Faraday::Adapter::NetHttp
+      end
+    else
+      Rails.logger.warn('no workflow hookup - assume you are in test or dev environment')
     end
     @connection
   end
-
-  private_class_method def self.request(druid, process_name, error_message)
-    return unless conn
-    @connection.put do |request|
-      request.headers['content-type'] = "application/xml"
-      request.url  "/workflow/dor/objects/druid:#{druid}/workflows/preservationWF/#{process_name}"
-      request.body = "<process name='#{process_name}' status='error' errorMessage='#{error_message}'/>"
-    end
+  private_class_method def self.workflow_service_exceptions_to_catch
+    [Faraday::Error]
   end
 
   private_class_method def self.moab_error(error)

--- a/app/services/workflow_errors_reporter.rb
+++ b/app/services/workflow_errors_reporter.rb
@@ -4,7 +4,7 @@ require 'faraday'
 class WorkflowErrorsReporter
 
   def self.update_workflow(druid, error_message)
-    error_message.select { |error| request(druid, 'moab-valid', moab_error(error)) if error.key?(13) }
+    error_message.select { |error| request(druid, 'moab-valid', moab_error(error)) if error.key?(PreservedObjectHandlerResults::INVALID_MOAB) }
   end
 
   private_class_method def self.conn
@@ -20,7 +20,7 @@ class WorkflowErrorsReporter
   end
 
   private_class_method def self.moab_error(error)
-    /^.*\)(.*)$/.match(error[13]).captures.first
+    /^.*\)(.*)$/.match(error[PreservedObjectHandlerResults::INVALID_MOAB]).captures.first
   end
 
 end

--- a/app/services/workflow_errors_reporter.rb
+++ b/app/services/workflow_errors_reporter.rb
@@ -10,11 +10,11 @@ class WorkflowErrorsReporter
         Rails.logger.debug("#{druid} - sent error to workflow service for preservationWF #{process_name}")
       else
         # Note: status == 400 will be handled by the rescue clause
-        Rails.logger.warn("#{druid} - unable to update workflow: #{response.body}")
+        Rails.logger.warn("#{druid} - unable to update workflow for preservationWF #{process_name}: #{response.body}. Error message: #{error_message}")
       end
     end
   rescue StandardError => e
-    Rails.logger.warn("#{druid} - unable to update workflow #{e.inspect}")
+    Rails.logger.warn("#{druid} - unable to update workflow for preservationWF #{process_name} #{e.inspect}. Error message: #{error_message}")
   end
 
   private_class_method def self.http_workflow_request(druid, process_name, error_message)

--- a/app/services/workflow_errors_reporter.rb
+++ b/app/services/workflow_errors_reporter.rb
@@ -1,0 +1,26 @@
+require 'faraday'
+# This class will send a put ReST call to the preservationWF via faraday. This also parses
+# out a shorter error message, that only includes the moab validation error.
+class WorkflowErrorsReporter
+
+  def self.update_workflow(druid, error_message)
+    error_message.select { |error| request(druid, 'moab-valid', moab_error(error)) if error.key?(13) }
+  end
+
+  private_class_method def self.conn
+    @conn ||= Faraday.new(url: Settings.workflow_services.url)
+  end
+
+  private_class_method def self.request(druid, process_name, error_message)
+    conn.put do |request|
+      request.headers['content-type'] = "application/xml"
+      request.url  "/workflow/dor/objects/druid:#{druid}/workflows/preservationWF/#{process_name}"
+      request.body = "<process name='#{process_name}' status='error' errorMessage='#{error_message}'/>"
+    end
+  end
+
+  private_class_method def self.moab_error(error)
+    /^.*\)(.*)$/.match(error[13]).captures.first
+  end
+
+end

--- a/app/services/workflow_errors_reporter.rb
+++ b/app/services/workflow_errors_reporter.rb
@@ -1,45 +1,44 @@
 require 'faraday'
 require 'retries'
-# This class will send a put ReST call to the preservationWF via faraday. This also parses
-# out a shorter error message, that only includes the moab validation error.
+# send errors to preservationWF workflow for an object via ReST calls.
 class WorkflowErrorsReporter
 
-  def self.update_workflow(druid, error_message)
-    error_message.select { |error| request(druid, 'moab-valid', moab_error(error)) if error.key?(PreservedObjectHandlerResults::INVALID_MOAB) }
-  end
-
-  def self.request(druid, process_name, error_message)
-    return unless conn
-    handler = proc do |exception, attempt_number, total_delay|
-      Rails.logger.warn("Handler saw a #{exception.class}; retry attempt #{attempt_number}; #{total_delay} seconds have passed.")
-    end
-    with_retries(max_tries: 3, handler: handler, rescue: workflow_service_exceptions_to_catch) do
-      @connection.put do |request|
-        request.headers['content-type'] = "application/xml"
-        request.url  "/workflow/dor/objects/druid:#{druid}/workflows/preservationWF/#{process_name}"
-        request.body = "<process name='#{process_name}' status='error' errorMessage='#{error_message}'/>"
+  def self.update_workflow(druid, process_name, error_message)
+    response = http_workflow_request(druid, process_name, error_message)
+    if response
+      if response.status == 204
+        Rails.logger.debug("#{druid} - sent error to workflow service for preservationWF #{process_name}")
+      else
+        # Note: status == 400 will be handled by the rescue clause
+        Rails.logger.warn("#{druid} - unable to update workflow: #{response.body}")
       end
     end
-  rescue *workflow_service_exceptions_to_catch => e
-    raise Faraday::Error, e
+  rescue StandardError => e
+    Rails.logger.warn("#{druid} - unable to update workflow #{e.inspect}")
   end
+
+  private_class_method def self.http_workflow_request(druid, process_name, error_message)
+    return unless conn
+    handler = proc do |exception, attempt_number, total_delay|
+      Rails.logger.debug("Handler saw a #{exception.class}; retry attempt #{attempt_number}; #{total_delay} seconds have passed.")
+    end
+    with_retries(max_tries: 3, handler: handler, rescue: Faraday::Error) do
+      conn.put do |request|
+        request.headers['content-type'] = "application/xml"
+        request.url  "/workflow/dor/objects/druid:#{druid}/workflows/preservationWF/#{process_name}"
+        request.body = "<process name='#{process_name} status='error' errorMessage='#{error_message}'/>"
+      end
+    end
+  end
+
   private_class_method def self.conn
-    if Settings.workflow_services.url.present?
-      @connection ||= Faraday.new(url: Settings.workflow_services.url) do |c|
+    if Settings.workflow_services_url.present?
+      @connection ||= Faraday.new(url: Settings.workflow_services_url) do |c|
         c.use Faraday::Response::RaiseError
         c.use Faraday::Adapter::NetHttp
       end
     else
       Rails.logger.warn('no workflow hookup - assume you are in test or dev environment')
     end
-    @connection
   end
-  private_class_method def self.workflow_service_exceptions_to_catch
-    [Faraday::Error]
-  end
-
-  private_class_method def self.moab_error(error)
-    /^.*\)(.*)$/.match(error[PreservedObjectHandlerResults::INVALID_MOAB]).captures.first
-  end
-
 end

--- a/app/services/workflow_errors_reporter.rb
+++ b/app/services/workflow_errors_reporter.rb
@@ -1,20 +1,20 @@
 require 'faraday'
 require 'retries'
-# send errors to preservationWF workflow for an object via ReST calls.
+# send errors to preservationAuditWF workflow for an object via ReST calls.
 class WorkflowErrorsReporter
 
   def self.update_workflow(druid, process_name, error_message)
     response = http_workflow_request(druid, process_name, error_message)
     if response
       if response.status == 204
-        Rails.logger.debug("#{druid} - sent error to workflow service for preservationWF #{process_name}")
+        Rails.logger.debug("#{druid} - sent error to workflow service for preservationAuditWF #{process_name}")
       else
         # Note: status == 400 will be handled by the rescue clause
-        Rails.logger.warn("#{druid} - unable to update workflow for preservationWF #{process_name}: #{response.body}. Error message: #{error_message}")
+        Rails.logger.warn("#{druid} - unable to update workflow for preservationAuditWF #{process_name}: #{response.body}. Error message: #{error_message}")
       end
     end
   rescue StandardError => e
-    Rails.logger.warn("#{druid} - unable to update workflow for preservationWF #{process_name} #{e.inspect}. Error message: #{error_message}")
+    Rails.logger.warn("#{druid} - unable to update workflow for preservationAuditWF #{process_name} #{e.inspect}. Error message: #{error_message}")
   end
 
   private_class_method def self.http_workflow_request(druid, process_name, error_message)
@@ -25,7 +25,7 @@ class WorkflowErrorsReporter
     with_retries(max_tries: 3, handler: handler, rescue: Faraday::Error) do
       conn.put do |request|
         request.headers['content-type'] = "application/xml"
-        request.url  "/workflow/dor/objects/druid:#{druid}/workflows/preservationWF/#{process_name}"
+        request.url  "/workflow/dor/objects/druid:#{druid}/workflows/preservationAuditWF/#{process_name}"
         request.body = "<process name='#{process_name} status='error' errorMessage='#{error_message}'/>"
       end
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,3 +37,6 @@ preservation_policies:
 
 provlog:
   enable: false
+
+workflow_services:
+  url: 'https://sul-lyberservices-test.stanford.edu/workflow/'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,4 +39,4 @@ provlog:
   enable: false
 
 workflow_services:
-  url: 'https://sul-lyberservices-test.stanford.edu/workflow/'
+  url: ''

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,5 +38,4 @@ preservation_policies:
 provlog:
   enable: false
 
-workflow_services:
-  url: ''
+workflow_services_url: ''

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -4,4 +4,4 @@ moab:
     # name: '/location/on/disk'  # e.g.
     fixture_sr1: 'spec/fixtures/storage_root01'
     fixture_sr2: 'spec/fixtures/storage_root02'
-  
+workflow_services_url: 'https://sul-lyberservices-test.stanford.edu/workflow/'

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PreservedObjectHandler do
       expect(results).to include(a_hash_including(code => a_string_matching('PreservedObject db object already exists')))
     end
 
-    it_behaves_like 'calls PreservedObjectHandlerResults.log_results', :create
+    it_behaves_like 'calls PreservedObjectHandlerResults.report_results', :create
 
     context 'db update error' do
       context 'ActiveRecordError' do
@@ -89,7 +89,7 @@ RSpec.describe PreservedObjectHandler do
 
     it_behaves_like 'attributes validated', :create_after_validation
 
-    it_behaves_like 'calls PreservedObjectHandlerResults.log_results', :create_after_validation
+    it_behaves_like 'calls PreservedObjectHandlerResults.report_results', :create_after_validation
 
     context 'sets validation timestamps' do
       let(:t) { Time.current }

--- a/spec/services/preserved_object_handler_results_spec.rb
+++ b/spec/services/preserved_object_handler_results_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PreservedObjectHandlerResults do
     end
   end
 
-  context '#log_results' do
+  context '#report_results' do
     before do
       code = PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH
       addl_hash = { pc_version: 1, po_version: 2 }
@@ -33,7 +33,7 @@ RSpec.describe PreservedObjectHandlerResults do
     context 'writes to Rails log' do
       it 'with msg_prefix' do
         expect(Rails.logger).to receive(:log).with(Logger::ERROR, a_string_matching(Regexp.escape(pohr.msg_prefix)))
-        pohr.log_results
+        pohr.report_results
       end
       it 'for each result' do
         code = PreservedObjectHandlerResults::PC_STATUS_CHANGED
@@ -46,7 +46,7 @@ RSpec.describe PreservedObjectHandlerResults do
         expect(Rails.logger).to receive(:log).with(Logger::ERROR, a_string_matching(not_matched_str))
         expect(Rails.logger).to receive(:log).with(Logger::INFO, a_string_matching(PreservedCopy::INVALID_MOAB_STATUS))
         expect(Rails.logger).to receive(:log).with(Logger::INFO, a_string_matching(db_obj_details))
-        pohr.log_results
+        pohr.report_results
       end
     end
   end

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -70,12 +70,12 @@ RSpec.shared_examples "attributes validated" do |method_sym|
 end
 
 # TODO: change log_results to report_results after upcoming PR
-RSpec.shared_examples 'calls PreservedObjectHandlerResults.log_results' do |method_sym|
+RSpec.shared_examples 'calls PreservedObjectHandlerResults.report_results' do |method_sym|
   it '' do
     mock_results = instance_double(PreservedObjectHandlerResults)
     allow(mock_results).to receive(:add_result)
     allow(mock_results).to receive(:result_array) # TODO: remove this when switch to report_results call
-    expect(mock_results).to receive(:log_results) # TODO: change this when switch to report_results call
+    expect(mock_results).to receive(:report_results) # TODO: change this when switch to report_results call
     expect(PreservedObjectHandlerResults).to receive(:new).and_return(mock_results)
     po_handler.send(method_sym)
   end

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -69,7 +69,6 @@ RSpec.shared_examples "attributes validated" do |method_sym|
   end
 end
 
-# TODO: change log_results to report_results after upcoming PR
 RSpec.shared_examples 'calls PreservedObjectHandlerResults.report_results' do |method_sym|
   it '' do
     mock_results = instance_double(PreservedObjectHandlerResults)

--- a/spec/services/workflow_errors_reporter_spec.rb
+++ b/spec/services/workflow_errors_reporter_spec.rb
@@ -1,42 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe WorkflowErrorsReporter do
-  describe '.update_workflow(druid, error_message)' do
-    let(:body) { "<process name='moab-valid' status='error' errorMessage=' Invalid moab, validation errors: [\"Should contain only sequential version directories. Current directories: [\\\"v0001\\\", \\\"v0002\\\", \\\"v0009\\\"]\"]'/>" }
-    let(:error_msg) do
-      [{ 10 => "PreservedObjectHandler(jj925bx9565, 9, 6570668, <Endpoint:...>) PreservedObject db object does not exist" },
-       { 13 => "PreservedObjectHandler(jj925bx9565, 9, 6570668, <Endpoint:...>) Invalid moab, validation errors: [\"Should contain only sequential version directories. Current directories: [\\\"v0001\\\", \\\"v0002\\\", \\\"v0009\\\"]\"]" }]
+  let(:full_url) do
+    'https://sul-lyberservices-test.stanford.edu/workflow/dor/objects/druid:jj925bx9565/workflows/preservationWF/moab-valid'
+  end
+  let(:headers) { { 'Content-Type' => 'application/xml' } }
+  let(:result) do
+    { 13 => "Invalid moab, validation error...ential version directories." }
+  end
+  let(:body) { "<process name='moab-valid status='error' errorMessage='#{result}'/>" }
+  let(:druid) { 'jj925bx9565' }
+
+  context '.update_workflow' do
+    it '204 response' do
+      Settings.workflow_services_url = 'https://sul-lyberservices-test.stanford.edu/workflow/'
+      stub_request(:put, full_url)
+        .with(body: body, headers: headers)
+        .to_return(status: 204, body: '', headers: {})
+      expect(Rails.logger).to receive(:debug).with("#{druid} - sent error to workflow service for preservationWF moab-valid")
+      described_class.update_workflow(druid, 'moab-valid', result)
     end
 
-    before do
-      Settings.workflow_services.url = 'https://sul-lyberservices-test.stanford.edu/workflow/'
-      stub_request(:put, 'https://sul-lyberservices-test.stanford.edu/workflow/dor/objects/druid:jj925bx9565/workflows/preservationWF/moab-valid')
-        .with(body: body,
-              headers: { 'Content-Type' => 'application/xml' })
-        .to_return(status: 204, body: "", headers: {})
+    it '400 response' do
+      Settings.workflow_services_url = 'https://sul-lyberservices-test.stanford.edu/workflow/'
+      stub_request(:put, full_url)
+        .with(body: body, headers: headers)
+        .to_return(status: 400, body: "", headers: {})
+      expect(Rails.logger).to receive(:warn).with("#{druid} - unable to update workflow #<Faraday::ClientError response={:status=>400, :headers=>{}, :body=>\"\"}>")
+      described_class.update_workflow(druid, 'moab-valid', result)
     end
-    it 'updates preservationWF with invalid moab errors' do
-      expect(described_class.update_workflow('jj925bx9565', error_msg)).to eq [error_msg[1]]
-    end
-  end
-  describe '.request' do
-    it 'rescues for Faraday::Error' do
-      allow(described_class).to receive(:request).and_raise(Faraday::Error)
-      expect { described_class.request('jj925bx9565', 'moab-valid', 'Foo() error') }.to raise_error(Faraday::Error)
-    end
-  end
 
-  describe '.update_workflow with invalid workflow_services.url' do
-    before do
-      stub_request(:put, "https://sul-lyberservices-test.stanford.edu/workflow/dor/objects/druid:jj925bx9565/workflows/preservationWF/moab-valid")
-        .with(body: "<process name='moab-valid' status='error' errorMessage=' Invalid Moab'/>",
-              headers: { 'Content-Type' => 'application/xml' })
-        .to_return(status: 200, body: "", headers: {})
-    end
-    it 'returns Rails warning' do
-      Settings.workflow_services.url = ''
+    it 'has invalid workflow_services_url' do
+      stub_request(:put, full_url)
+        .with(body: body, headers: headers)
+        .to_return(status: 400, body: "", headers: {})
+      Settings.workflow_services_url = ''
       expect(Rails.logger).to receive(:warn).with('no workflow hookup - assume you are in test or dev environment')
-      described_class.update_workflow('jj925bx9565', [{ 13 => "Foo() Invalid Moab" }])
+      described_class.update_workflow(druid, 'moab-valid', result)
     end
   end
 end

--- a/spec/services/workflow_errors_reporter_spec.rb
+++ b/spec/services/workflow_errors_reporter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe WorkflowErrorsReporter do
       stub_request(:put, full_url)
         .with(body: body, headers: headers)
         .to_return(status: 400, body: "", headers: {})
-      expect(Rails.logger).to receive(:warn).with("#{druid} - unable to update workflow #<Faraday::ClientError response={:status=>400, :headers=>{}, :body=>\"\"}>")
+      expect(Rails.logger).to receive(:warn).with("#{druid} - unable to update workflow for preservationWF moab-valid #<Faraday::ClientError response={:status=>400, :headers=>{}, :body=>\"\"}>. Error message: #{result}")
       described_class.update_workflow(druid, 'moab-valid', result)
     end
 

--- a/spec/services/workflow_errors_reporter_spec.rb
+++ b/spec/services/workflow_errors_reporter_spec.rb
@@ -25,4 +25,18 @@ RSpec.describe WorkflowErrorsReporter do
       expect { described_class.request('jj925bx9565', 'moab-valid', 'Foo() error') }.to raise_error(Faraday::Error)
     end
   end
+
+  describe '.update_workflow with invalid workflow_services.url' do
+    before do
+      stub_request(:put, "https://sul-lyberservices-test.stanford.edu/workflow/dor/objects/druid:jj925bx9565/workflows/preservationWF/moab-valid")
+        .with(body: "<process name='moab-valid' status='error' errorMessage=' Invalid Moab'/>",
+              headers: { 'Content-Type' => 'application/xml' })
+        .to_return(status: 200, body: "", headers: {})
+    end
+    it 'returns Rails warning' do
+      Settings.workflow_services.url = ''
+      expect(Rails.logger).to receive(:warn).with('no workflow hookup - assume you are in test or dev environment')
+      described_class.update_workflow('jj925bx9565', [{ 13 => "Foo() Invalid Moab" }])
+    end
+  end
 end

--- a/spec/services/workflow_errors_reporter_spec.rb
+++ b/spec/services/workflow_errors_reporter_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe WorkflowErrorsReporter do
+  describe '.update_workflow(druid, error_message)' do
+    let(:body) { "<process name='moab-valid' status='error' errorMessage=' Invalid moab, validation errors: [\"Should contain only sequential version directories. Current directories: [\\\"v0001\\\", \\\"v0002\\\", \\\"v0009\\\"]\"]'/>" }
+    let(:error_msg) do
+      [{ 10 => "PreservedObjectHandler(jj925bx9565, 9, 6570668, <Endpoint:...>) PreservedObject db object does not exist" },
+       { 13 => "PreservedObjectHandler(jj925bx9565, 9, 6570668, <Endpoint:...>) Invalid moab, validation errors: [\"Should contain only sequential version directories. Current directories: [\\\"v0001\\\", \\\"v0002\\\", \\\"v0009\\\"]\"]" }]
+    end
+
+    before do
+      Settings.workflow_services.url = 'https://sul-lyberservices-test.stanford.edu/workflow/'
+      stub_request(:put, 'https://sul-lyberservices-test.stanford.edu/workflow/dor/objects/druid:jj925bx9565/workflows/preservationWF/moab-valid')
+        .with(body: body,
+              headers: { 'Content-Type' => 'application/xml' })
+        .to_return(status: 204, body: "", headers: {})
+    end
+    it 'updates preservationWF with invalid moab errors' do
+      expect(described_class.update_workflow('jj925bx9565', error_msg)).to eq [error_msg[1]]
+    end
+  end
+end

--- a/spec/services/workflow_errors_reporter_spec.rb
+++ b/spec/services/workflow_errors_reporter_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe WorkflowErrorsReporter do
       expect(described_class.update_workflow('jj925bx9565', error_msg)).to eq [error_msg[1]]
     end
   end
+  describe '.request' do
+    it 'rescues for Faraday::Error' do
+      allow(described_class).to receive(:request).and_raise(Faraday::Error)
+      expect { described_class.request('jj925bx9565', 'moab-valid', 'Foo() error') }.to raise_error(Faraday::Error)
+    end
+  end
 end

--- a/spec/services/workflow_errors_reporter_spec.rb
+++ b/spec/services/workflow_errors_reporter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe WorkflowErrorsReporter do
   let(:full_url) do
-    'https://sul-lyberservices-test.stanford.edu/workflow/dor/objects/druid:jj925bx9565/workflows/preservationWF/moab-valid'
+    'https://sul-lyberservices-test.stanford.edu/workflow/dor/objects/druid:jj925bx9565/workflows/preservationAuditWF/moab-valid'
   end
   let(:headers) { { 'Content-Type' => 'application/xml' } }
   let(:result) do
@@ -17,7 +17,7 @@ RSpec.describe WorkflowErrorsReporter do
       stub_request(:put, full_url)
         .with(body: body, headers: headers)
         .to_return(status: 204, body: '', headers: {})
-      expect(Rails.logger).to receive(:debug).with("#{druid} - sent error to workflow service for preservationWF moab-valid")
+      expect(Rails.logger).to receive(:debug).with("#{druid} - sent error to workflow service for preservationAuditWF moab-valid")
       described_class.update_workflow(druid, 'moab-valid', result)
     end
 
@@ -26,7 +26,7 @@ RSpec.describe WorkflowErrorsReporter do
       stub_request(:put, full_url)
         .with(body: body, headers: headers)
         .to_return(status: 400, body: "", headers: {})
-      expect(Rails.logger).to receive(:warn).with("#{druid} - unable to update workflow for preservationWF moab-valid #<Faraday::ClientError response={:status=>400, :headers=>{}, :body=>\"\"}>. Error message: #{result}")
+      expect(Rails.logger).to receive(:warn).with("#{druid} - unable to update workflow for preservationAuditWF moab-valid #<Faraday::ClientError response={:status=>400, :headers=>{}, :body=>\"\"}>. Error message: #{result}")
       described_class.update_workflow(druid, 'moab-valid', result)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'coveralls'
+require 'webmock/rspec'
 Coveralls.wear!('rails')
 
 RSpec.configure do |config|


### PR DESCRIPTION
Incorporated it into the PreservedObjectHandler.report_results method. 
Wrote RSpec tests using WebMock. 

Only have two workflow steps, `'moab-valid' and 'pc-process'` The `'pc-process'` name is just all other errors other than `PreservedObjectHandlerResults::INVALID_MOAB` so if there is another name we should use, let me know.

connects to #404 

(Travis fails will be fixed in follow on PR)