### PR TITLE
Check existence revalidates on bad status

### DIFF
--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -72,11 +72,11 @@ class PreservedObjectHandler
           raise_rollback_if_pc_po_version_mismatch(pres_copy.version, pres_object.current_version)
 
           if incoming_version == pres_copy.version
-            check_status_if_not_ok_or_unexpected_version(pres_copy, true)
+            set_status_as_seen_on_disk(pres_copy, true) unless pres_copy.status == PreservedCopy::OK_STATUS
             handler_results.add_result(PreservedObjectHandlerResults::VERSION_MATCHES, pres_copy.class.name)
             handler_results.add_result(PreservedObjectHandlerResults::VERSION_MATCHES, pres_object.class.name)
           elsif incoming_version > pres_copy.version
-            check_status_if_not_ok_or_unexpected_version(pres_copy, true)
+            set_status_as_seen_on_disk(pres_copy, true) unless pres_copy.status == PreservedCopy::OK_STATUS
             handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT, pres_copy.class.name)
             handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT, pres_object.class.name)
             if moab_validation_errors.empty?
@@ -87,7 +87,7 @@ class PreservedObjectHandler
               update_status(pres_copy, PreservedCopy::INVALID_MOAB_STATUS)
             end
           else # incoming_version < pres_copy.version
-            check_status_if_not_ok_or_unexpected_version(pres_copy, false)
+            set_status_as_seen_on_disk(pres_copy, false)
             handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT, pres_copy.class.name)
             handler_results.add_result(PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT, pres_object.class.name)
           end
@@ -263,12 +263,6 @@ class PreservedObjectHandler
     handler_results.remove_db_updated_results unless transaction_ok
   end
 
-  def check_status_if_not_ok_or_unexpected_version(pres_copy, found_expected_version)
-    unless pres_copy.status == PreservedCopy::OK_STATUS && found_expected_version
-      set_status_as_seen_on_disk(pres_copy, found_expected_version)
-    end
-  end
-
   # given a PreservedCopy instance and whether the caller found the expected version of it on disk, this will perform
   # other validations of what's on disk, and will update the status accordingly
   def set_status_as_seen_on_disk(pres_copy, found_expected_version)
@@ -312,11 +306,11 @@ class PreservedObjectHandler
       raise_rollback_if_pc_po_version_mismatch(pres_copy.version, pres_object.current_version)
 
       if incoming_version == pres_copy.version
-        check_status_if_not_ok_or_unexpected_version(pres_copy, true)
+        set_status_as_seen_on_disk(pres_copy, true) unless pres_copy.status == PreservedCopy::OK_STATUS
         handler_results.add_result(PreservedObjectHandlerResults::VERSION_MATCHES, pres_copy.class.name)
         handler_results.add_result(PreservedObjectHandlerResults::VERSION_MATCHES, pres_object.class.name)
       else
-        check_status_if_not_ok_or_unexpected_version(pres_copy, false)
+        set_status_as_seen_on_disk(pres_copy, false)
         handler_results.add_result(PreservedObjectHandlerResults::UNEXPECTED_VERSION, pres_copy.class.name)
       end
       update_pc_audit_timestamps(pres_copy, true)

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe PreservedObjectHandler do
             context 'changed' do
               before do
                 allow(po_handler).to receive(:moab_validation_errors).and_return([])
+                allow(po_handler).to receive(:ran_moab_validation?).and_return(true)
               end
               it 'version to incoming_version' do
                 orig = pc.version

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -187,6 +187,7 @@ RSpec.describe PreservedObjectHandler do
                 expect(pc.reload.size).to eq orig
               end
             end
+            # TODO: other statuses should get corrected
             it 'what about other statuses????' do
               skip 'need to know what to do when status does NOT start as ok or invalid moab'
               pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
@@ -441,6 +442,7 @@ RSpec.describe PreservedObjectHandler do
         allow(po).to receive(:current_version).and_return(1)
         allow(po).to receive(:touch)
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
+        allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
         allow(pc).to receive(:version).and_return(1)
         allow(pc).to receive(:last_version_audit=)
         allow(pc).to receive(:changed?).and_return(false)

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -230,10 +230,13 @@ RSpec.describe PreservedObjectHandler do
             pc = instance_double("PreservedCopy")
             allow(PreservedCopy).to receive(:find_by).and_return(pc)
             allow(pc).to receive(:version).and_return(2)
+            allow(pc).to receive(:status)
+            allow(pc).to receive(:status=)
             allow(pc).to receive(:last_version_audit=)
             allow(pc).to receive(:changed?).and_return(true)
             allow(pc).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
             allow(po).to receive(:current_version).and_return(2)
+            allow(po_handler).to receive(:moab_validation_errors).and_return([])
             po_handler.confirm_version
           end
 
@@ -256,6 +259,7 @@ RSpec.describe PreservedObjectHandler do
         allow(pc).to receive(:last_version_audit=)
         allow(pc).to receive(:changed?).and_return(true)
         allow(pc).to receive(:save!)
+        allow(po_handler).to receive(:moab_validation_errors).and_return([])
         po_handler.confirm_version
         expect(po).not_to have_received(:save!)
         expect(pc).to have_received(:save!)
@@ -268,6 +272,7 @@ RSpec.describe PreservedObjectHandler do
         allow(po).to receive(:current_version).and_return(1)
         allow(po).to receive(:touch)
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
+        allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
         allow(pc).to receive(:version).and_return(1)
         allow(pc).to receive(:last_version_audit=)
         allow(pc).to receive(:changed?).and_return(false)

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -160,6 +160,10 @@ RSpec.describe PreservedObjectHandler do
         }
         let(:updated_pc_db_obj_msg) { "#{exp_msg_prefix} PreservedCopy db object updated" }
 
+        before do
+          allow(po_handler).to receive(:moab_validation_errors).and_return([])
+        end
+
         context 'PreservedCopy' do
           context 'changed' do
             it 'status to expected_vers_not_found_on_storage' do
@@ -309,6 +313,7 @@ RSpec.describe PreservedObjectHandler do
       it 'logs a debug message' do
         msg = "confirm_version #{druid} called"
         allow(Rails.logger).to receive(:debug)
+        allow(po_handler).to receive(:moab_validation_errors).and_return([])
         po_handler.confirm_version
         expect(Rails.logger).to have_received(:debug).with(msg)
       end

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe PreservedObjectHandler do
       )
       bad_po_handler = described_class.new(druid, 6, incoming_size, ep)
       allow(pc).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError)
+      allow(bad_po_handler).to receive(:moab_validation_errors).and_return([])
       bad_po_handler.confirm_version
       expect(PreservedObject.find_by(druid: druid).current_version).to eq 2
     end

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe PreservedObjectHandler do
         end
 
         it 'calls #update_online_version with validated = true and status = "ok"' do
-          expect(po_handler).to receive(:update_online_version).with(true, PreservedCopy::OK_STATUS).and_call_original
+          expect(po_handler).to receive(:update_online_version).with(PreservedCopy::OK_STATUS).and_call_original
           po_handler.update_version_after_validation
           skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
         end

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -539,7 +539,6 @@ RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, 
     expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
   end
   it 'had OK_STATUS, but is now INVALID_MOAB_STATUS' do
-    skip 'currently fails because confirm_version does not validate when an unexpected version is encountered'
     pc.status = PreservedCopy::OK_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }])
@@ -561,7 +560,6 @@ RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, 
     expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
   end
   it 'had VALIDITY_UNKNOWN_STATUS, but is now INVALID_MOAB_STATUS' do
-    skip 'currently fails because confirm_version overrides what check_status_if_not_ok had set earlier in the method'
     pc.status = PreservedCopy::VALIDITY_UNKNOWN_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }])

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -473,3 +473,106 @@ RSpec.shared_examples 'PreservedObject current_version does not match online PC 
     end
   end
 end
+
+RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, and incoming_version == pc.version' do |method_sym|
+  let(:incoming_version) { pc.version }
+
+  it 'had OK_STATUS, and is still OK' do
+    pc.status = PreservedCopy::OK_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+  end
+  it 'had EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS, but is now OK' do
+    pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+  end
+  it 'had EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS, but is now INVALID_MOAB_STATUS' do
+    pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
+  end
+  it 'had INVALID_MOAB_STATUS, but is now OK' do
+    pc.status = PreservedCopy::INVALID_MOAB_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+  end
+  it 'had VALIDITY_UNKNOWN_STATUS, but is now OK' do
+    pc.status = PreservedCopy::VALIDITY_UNKNOWN_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+  end
+  it 'had VALIDITY_UNKNOWN_STATUS, but is now INVALID_MOAB_STATUS' do
+    pc.status = PreservedCopy::VALIDITY_UNKNOWN_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
+  end
+  it 'had EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS, seems to have an acceptable version now' do
+    pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+  end
+end
+
+RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, and incoming_version < pc.version' do |method_sym|
+  let(:incoming_version) { pc.version - 1 }
+
+  it 'had OK_STATUS, but is now EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS' do
+    pc.status = PreservedCopy::OK_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+  end
+  it 'had OK_STATUS, but is now INVALID_MOAB_STATUS' do
+    skip 'currently fails because confirm_version does not validate when an unexpected version is encountered'
+    pc.status = PreservedCopy::OK_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
+  end
+  it 'had INVALID_MOAB_STATUS, was made to a valid moab, but is now EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS' do
+    pc.status = PreservedCopy::INVALID_MOAB_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+  end
+  it 'had EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS, still seeing an unexpected version' do
+    pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+  end
+  it 'had VALIDITY_UNKNOWN_STATUS, but is now INVALID_MOAB_STATUS' do
+    skip 'currently fails because confirm_version overrides what check_status_if_not_ok had set earlier in the method'
+    pc.status = PreservedCopy::VALIDITY_UNKNOWN_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
+  end
+  it 'had VALIDITY_UNKNOWN_STATUS, but is now EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS' do
+    pc.status = PreservedCopy::VALIDITY_UNKNOWN_STATUS
+    pc.save!
+    allow(po_handler).to receive(:moab_validation_errors).and_return([])
+    po_handler.send(method_sym)
+    expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+  end
+end


### PR DESCRIPTION
~~pretty close, added new tests, still need to:~~
- [x] move most of the new tests to a shared example, except for the ones that deal with status becoming `EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS`, since the conditions for that differ between `check_existence` and `confirm_version`.
- [x] re-implement the `EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS` tests appropriately for `confirm_version` (e.g. add a test where the version increases, which is fine by `check_existence`, but not `confirm_version`).
- [x] call the shared example on `check_existence` and `confirm_version` in the appropriate place in the respective spec files.

paired with @tingulfsen for most of this.

supersedes #438 

closes #431

closes #433