### PR TITLE
Add method to match pc version against its po current version

### DIFF
--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -51,4 +51,8 @@ class PreservedCopy < ApplicationRecord
     yield
     self.status = new_status
   end
+
+  def matches_po_current_version?
+    version == preserved_object.current_version
+  end
 end

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -53,8 +53,12 @@ class CatalogToMoab
   def check_catalog_version
     druid = preserved_copy.preserved_object.druid
     results = PreservedObjectHandlerResults.new(druid, nil, nil, preserved_copy.endpoint)
-
-    # TODO: Pohandler.ensure_po_version_matches_this_pc_version (for non-archived, online moab) - see #483
+    unless preserved_copy.matches_po_current_version?
+      results.add_result(PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH,
+                         pc_version: preserved_copy.version,
+                         po_version: preserved_copy.preserved_object.current_version)
+      return
+    end
 
     # TODO: anything special if preserved_copy.status is not OK_STATUS? - see #480
 

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe CatalogToMoab do
       c2m.check_catalog_version
     end
 
+    context 'preserved_copy version != current_version of preserved_object' do
+      it 'adds a PC_PO_VERSION_MISMATCH result and returns' do
+        pres_copy.version = 666
+        pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)
+        allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+        expect(pohandler_results).to receive(:add_result).with(
+          PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH,
+          pc_version: pres_copy.version,
+          po_version: pres_copy.preserved_object.current_version
+        )
+        expect(Moab::StorageObject).not_to receive(:new).with(druid, a_string_matching(object_dir)).and_call_original
+        c2m.check_catalog_version
+      end
+    end
+
     context 'catalog version == moab version (happy path)' do
       it 'adds a VERSION_MATCHES result' do
         pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -180,4 +180,18 @@ RSpec.describe PreservedCopy, type: :model do
       expect(pc.changed?).to eq true
     end
   end
+
+  context '#matches_po_current_version?' do
+    it 'returns true when its version matches its preserved objects current version' do
+      preserved_copy.version = 666
+      preserved_copy.preserved_object.current_version = 666
+      expect(preserved_copy.matches_po_current_version?).to be true
+    end
+
+    it 'returns false when its version does not match its preserved objects current version' do
+      preserved_copy.version = 666
+      preserved_copy.preserved_object.current_version = 777
+      expect(preserved_copy.matches_po_current_version?).to be false
+    end
+  end
 end


### PR DESCRIPTION
- adds a method on preserved_copy to check the version agains its preserved_object current_version. I picked that location instead of the po_handler, since preserved copy is handed into `check_catalog_version`.

- implements the new method inside of `check_catalog_version` with an `if` statement that adds results to the handler (includes a new code for when versions match)

- specs for the new method

Connects to #483
(#483 is finished when the code in this PR is called from `C2M.check_catalog_version` )