### PR TITLE
add specs for existing C2M.check_catalog_version method

### DIFF
--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -46,13 +46,13 @@ class CatalogToMoab
   private_class_method def self.check_catalog_version(preserved_copy, storage_dir)
     # TODO: Pohandler.ensure_po_version_matches_this_pc_version (for non-archived, online moab) - see #483
 
-    id = preserved_copy.preserved_object.druid
+    druid = preserved_copy.preserved_object.druid
     catalog_version = preserved_copy.version
     storage_location = preserved_copy.endpoint.storage_location # FIXME: or just, storage_dir?
-    results = PreservedObjectHandlerResults.new(id, nil, nil, preserved_copy.endpoint)
-    object_dir = "#{storage_location}/#{DruidTools::Druid.new(id).tree.join('/')}"
+    results = PreservedObjectHandlerResults.new(druid, nil, nil, preserved_copy.endpoint)
+    object_dir = "#{storage_location}/#{DruidTools::Druid.new(druid).tree.join('/')}"
 
-    moab = Moab::StorageObject.new(id, object_dir)
+    moab = Moab::StorageObject.new(druid, object_dir)
     # TODO: report error if moab doesn't exist - see #482
 
     moab_version = moab.current_version_id
@@ -60,19 +60,19 @@ class CatalogToMoab
     # TODO: anything special if preserved_copy.status is not OK_STATUS? - see #480
 
     if catalog_version == moab_version
-      p "hooray - #{id} versions match: #{catalog_version}"
+      p "hooray - #{druid} versions match: #{catalog_version}"
       results.add_result(PreservedObjectHandlerResults::VERSION_MATCHES, preserved_copy.class.name)
       # TODO:  original spec asks for verifying files????  read audit requirements - see #481
       results.report_results
     elsif catalog_version < moab_version
       results.add_result(PreservedObjectHandlerResults::UNEXPECTED_VERSION, preserved_copy.class.name)
-      p "boo - #{id} catalog has #{catalog_version} but moab has #{moab_version}"
+      p "boo - #{druid} catalog has #{catalog_version} but moab has #{moab_version}"
       # update the catalog
       # TODO: avoid repetitious results ... (leave out line above??) - see #484
-      pohandler = PreservedObjectHandler.new(id, moab_version, moab.size, preserved_copy.endpoint)
+      pohandler = PreservedObjectHandler.new(druid, moab_version, moab.size, preserved_copy.endpoint)
       pohandler.update_version_after_validation # results reported by this call
     else # catalog_version > moab_version
-      p "boo - #{id} catalog has #{catalog_version} but moab has #{moab_version}"
+      p "boo - #{druid} catalog has #{catalog_version} but moab has #{moab_version}"
       results.add_result(PreservedObjectHandlerResults::UNEXPECTED_VERSION, preserved_copy.class.name)
       if moab_validation_errors.empty?
         update_status(preserved_copy, PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS)

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -40,9 +40,7 @@ class CatalogToMoab
     profiler.print_results_flat('C2M_check_version_all_dirs')
   end
 
-  # FIXME:  temporarily turning off rubocop until we migrate the code to its final home
-  # rubocop:disable all
-  private_class_method def self.check_catalog_version(preserved_copy, storage_dir)
+  private_class_method def self.check_catalog_version(preserved_copy, _storage_dir)
     # TODO: Pohandler.ensure_po_version_matches_this_pc_version (for non-archived, online moab) - see #483
 
     druid = preserved_copy.preserved_object.druid
@@ -82,6 +80,5 @@ class CatalogToMoab
     # update_pc_audit_timestamps(preserved_copy, ran_moab_validation, true) - see #477
     # update_db_object(preserved_copy) - see #478
   end
-  # rubocop:enable all
 
 end

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -59,19 +59,15 @@ class CatalogToMoab
     # TODO: anything special if preserved_copy.status is not OK_STATUS? - see #480
 
     if catalog_version == moab_version
-      p "hooray - #{druid} versions match: #{catalog_version}"
       results.add_result(PreservedObjectHandlerResults::VERSION_MATCHES, preserved_copy.class.name)
       # TODO:  original spec asks for verifying files????  read audit requirements - see #481
       results.report_results
     elsif catalog_version < moab_version
       results.add_result(PreservedObjectHandlerResults::UNEXPECTED_VERSION, preserved_copy.class.name)
-      p "boo - #{druid} catalog has #{catalog_version} but moab has #{moab_version}"
-      # update the catalog
       # TODO: avoid repetitious results ... (leave out line above??) - see #484
       pohandler = PreservedObjectHandler.new(druid, moab_version, moab.size, preserved_copy.endpoint)
       pohandler.update_version_after_validation # results reported by this call
     else # catalog_version > moab_version
-      p "boo - #{druid} catalog has #{catalog_version} but moab has #{moab_version}"
       results.add_result(PreservedObjectHandlerResults::UNEXPECTED_VERSION, preserved_copy.class.name)
       # TODO: can moab_validation_errors be a class method or otherwise callable from here and POHandler? - see #491
       # if moab_validation_errors.empty?

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -40,7 +40,6 @@ class CatalogToMoab
     profiler.print_results_flat('C2M_check_version_all_dirs')
   end
 
-  # TODO:  you need to write tests for this!!!
   # FIXME:  temporarily turning off rubocop until we migrate the code to its final home
   # rubocop:disable all
   private_class_method def self.check_catalog_version(preserved_copy, storage_dir)
@@ -74,11 +73,12 @@ class CatalogToMoab
     else # catalog_version > moab_version
       p "boo - #{druid} catalog has #{catalog_version} but moab has #{moab_version}"
       results.add_result(PreservedObjectHandlerResults::UNEXPECTED_VERSION, preserved_copy.class.name)
-      if moab_validation_errors.empty?
-        update_status(preserved_copy, PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS)
-      else
-        update_status(preserved_copy, PreservedCopy::INVALID_MOAB_STATUS)
-      end
+      # TODO: can moab_validation_errors be a class method or otherwise callable from here and POHandler? - see #491
+      # if moab_validation_errors.empty?
+      #   update_status(preserved_copy, PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS)
+      # else
+      #   update_status(preserved_copy, PreservedCopy::INVALID_MOAB_STATUS)
+      # end
       results.report_results
     end
 

--- a/spec/lib/audit/catalog_to_moab_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_spec.rb
@@ -70,4 +70,101 @@ RSpec.describe CatalogToMoab do
       subject
     end
   end
+
+  context '.check_catalog_version' do
+    include_context 'fixture moabs in db'
+    let(:druid) { 'bj102hs9687' }
+    let(:po) { PreservedObject.find_by(druid: druid) }
+    let(:pres_copy) do
+      ep = Endpoint.find_by(storage_location: storage_dir).id
+      PreservedCopy.find_by(preserved_object: po, endpoint: ep)
+    end
+    let(:object_dir) { "#{storage_dir}/#{DruidTools::Druid.new(druid).tree.join('/')}" }
+
+    it 'instantiates Moab::StorageObject from druid and storage_dir' do
+      expect(Moab::StorageObject).to receive(:new).with(druid, a_string_matching(object_dir)).and_call_original
+      described_class.send(:check_catalog_version, pres_copy, nil)
+    end
+
+    it 'gets the current version on disk from the Moab::StorageObject' do
+      moab = instance_double(Moab::StorageObject)
+      allow(Moab::StorageObject).to receive(:new).with(druid, instance_of(String)).and_return(moab)
+      expect(moab).to receive(:current_version_id).and_return(3)
+      described_class.send(:check_catalog_version, pres_copy, nil)
+    end
+
+    it 'calls PreservedCopy.update_audit_timestamps' do
+      skip 'add this test after #477 is merged'
+    end
+
+    it 'calls PreservedCopy.save!' do
+      skip 'add this test after #478; update_at is changed ... what else?  and it calls save! ?'
+    end
+
+    it 'calls POHandlerResults.report_results' do
+      pohandler_results = instance_double(PreservedObjectHandlerResults, add_result: nil)
+      allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+      expect(pohandler_results).to receive(:report_results)
+      described_class.send(:check_catalog_version, pres_copy, nil)
+    end
+
+    context 'catalog version == moab version (happy path)' do
+      it 'adds a VERSION_MATCHES result' do
+        pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)
+        allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+        expect(pohandler_results).to receive(:add_result).with(
+          PreservedObjectHandlerResults::VERSION_MATCHES, 'PreservedCopy'
+        )
+        described_class.send(:check_catalog_version, pres_copy, nil)
+      end
+    end
+
+    context 'catalog version < moab version' do
+      before do
+        moab = instance_double(Moab::StorageObject, size: 666, object_pathname: object_dir)
+        allow(Moab::StorageObject).to receive(:new).with(druid, instance_of(String)).and_return(moab)
+        allow(moab).to receive(:current_version_id).and_return(4)
+      end
+
+      it 'adds an UNEXPECTED_VERSION result' do
+        pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)
+        expect(pohandler_results).to receive(:add_result).with(
+          PreservedObjectHandlerResults::UNEXPECTED_VERSION, 'PreservedCopy'
+        )
+        allow(pohandler_results).to receive(:add_result).with(any_args)
+        allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+        described_class.send(:check_catalog_version, pres_copy, nil)
+      end
+      it 'calls PreservedObjectHandler.update_version_after_validation' do
+        pohandler = instance_double(PreservedObjectHandler)
+        expect(PreservedObjectHandler).to receive(:new).and_return(pohandler)
+        expect(pohandler).to receive(:update_version_after_validation)
+        described_class.send(:check_catalog_version, pres_copy, nil)
+      end
+    end
+
+    context 'catalog version > moab version' do
+      before do
+        moab = instance_double(Moab::StorageObject, size: 666, object_pathname: object_dir)
+        allow(Moab::StorageObject).to receive(:new).with(druid, instance_of(String)).and_return(moab)
+        allow(moab).to receive(:current_version_id).and_return(2)
+      end
+
+      it 'adds an UNEXPECTED_VERSION result' do
+        pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)
+        expect(pohandler_results).to receive(:add_result).with(
+          PreservedObjectHandlerResults::UNEXPECTED_VERSION, 'PreservedCopy'
+        )
+        allow(pohandler_results).to receive(:add_result).with(any_args)
+        allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+        described_class.send(:check_catalog_version, pres_copy, nil)
+      end
+      it 'does moab validation' do
+        skip 'add tests after #491'
+      end
+      it 'updates status' do
+        skip 'add tests after #491, #477'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Catches up on the missing specs for `lib/audit/catalog_to_moab.check_catalog_version`

One question:  should `check_catalog_version` take a storage_dir argument and avoid the endpoint lookup for each preserved_copy object?   Or should the argument go away and code stay as is?

Resolves #479

🎉 upped our coverage to 97% with this!  w00t!