### PR TITLE
[WIP] Moab exists on Catalog but does not exist online

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,6 +105,7 @@ Metrics/MethodLength:
   Max: 25
   Exclude:
     - 'app/services/preserved_object_handler.rb' # check_existence shameless green
+    - 'lib/audit/catalog_to_moab.rb' # check_catalog_version (assuming in the future) shameless green
 
 Metrics/PerceivedComplexity:
   Exclude:

--- a/app/services/preserved_object_handler_results.rb
+++ b/app/services/preserved_object_handler_results.rb
@@ -20,6 +20,7 @@ class PreservedObjectHandlerResults
   UNEXPECTED_VERSION = 12
   INVALID_MOAB = 13
   PC_PO_VERSION_MISMATCH = 14
+  ONLINE_MOAB_DOES_NOT_EXIST = 15
 
   RESPONSE_CODE_TO_MESSAGES = {
     INVALID_ARGUMENTS => "encountered validation error(s): %{addl}",
@@ -35,7 +36,8 @@ class PreservedObjectHandlerResults
     PC_STATUS_CHANGED => "PreservedCopy status changed from %{old_status} to %{new_status}",
     UNEXPECTED_VERSION => "incoming version (%{incoming_version}) has unexpected relationship to %{addl} db version; ERROR!",
     INVALID_MOAB => "Invalid moab, validation errors: %{addl}",
-    PC_PO_VERSION_MISMATCH => "PreservedCopy online moab version %{pc_version} does not match PreservedObject current_version %{po_version}"
+    PC_PO_VERSION_MISMATCH => "PreservedCopy online moab version %{pc_version} does not match PreservedObject current_version %{po_version}",
+    ONLINE_MOAB_DOES_NOT_EXIST => "db has a moab that is not found online"
   }.freeze
 
   WORKFLOW_REPORT_CODES = [
@@ -44,7 +46,8 @@ class PreservedObjectHandlerResults
     OBJECT_ALREADY_EXISTS,
     OBJECT_DOES_NOT_EXIST,
     UNEXPECTED_VERSION,
-    PC_PO_VERSION_MISMATCH
+    PC_PO_VERSION_MISMATCH,
+    ONLINE_MOAB_DOES_NOT_EXIST
   ].freeze
 
   DB_UPDATED_CODES = [
@@ -70,6 +73,7 @@ class PreservedObjectHandlerResults
     when UNEXPECTED_VERSION then Logger::ERROR
     when INVALID_MOAB then Logger::ERROR
     when PC_PO_VERSION_MISMATCH then Logger::ERROR
+    when ONLINE_MOAB_DOES_NOT_EXIST then Logger::ERROR
     end
   end
 

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -67,7 +67,8 @@ class CatalogToMoab
     object_dir = "#{storage_dir}/#{DruidTools::Druid.new(druid).tree.join('/')}"
     moab = Moab::StorageObject.new(druid, object_dir)
 
-    # TODO: report error if moab doesn't exist - see #482
+
+    return unless moab_found_on_disk?(moab, results)
 
     moab_version = moab.current_version_id
     catalog_version = preserved_copy.version
@@ -95,4 +96,14 @@ class CatalogToMoab
     # update_pc_audit_timestamps(preserved_copy, ran_moab_validation, true) - see #477
     # update_db_object(preserved_copy) - see #478
   end
+  
+  def moab_found_on_disk?(moab, results)
+    unless moab
+      results.add_result(PreservedObjectHandlerResults::ONLINE_MOAB_DOES_NOT_EXIST)
+      results.report_results
+      return false
+    end
+    true
+  end
+
 end

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe CatalogToMoab do
       c2m.check_catalog_version
     end
 
+    it 'calls online_moab_found?(druid, storage_dir)' do
+      c2m.check_catalog_version
+    end
+
+    context 'moab is nil (exists in catalog but not online' do
+      it 'adds an ONLINE_MOAB_DOES_NOT_EXIST result' do
+      end
+      it 'stops processing .check_catalog_version' do
+      end
+    end
+
     context 'preserved_copy version != current_version of preserved_object' do
       it 'adds a PC_PO_VERSION_MISMATCH result and returns' do
         pres_copy.version = 666


### PR DESCRIPTION
### NOTE: IGNORE THIS PR, will close this PR once #508 is merged :)

- I would like 2 reviewers to approve this before it gets merged.


- Couple of thoughts on this PR:
1. In `catalog_to_moab_spec.rb:130`, I wanted to test:  `if 'moab is nil'`, we stop processing the rest of the code in `check_catalog_version`. I couldn't think of a straightforward way to do this and thought once we add more code in `check_catalog_version` we would have an easier way to test this.
2. Do we like `.moab_found_on_disk?` or `.moab_found_online`? 
3. Should I add a test that says something like: `if 'moab exists; code runs normally'`?



closes #482 
