### PR TITLE
catalog_to_moab: use an instance for #check_catalog_version

### DIFF
--- a/spec/lib/audit/catalog_to_moab_class_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_class_spec.rb
@@ -1,0 +1,73 @@
+require_relative '../../../lib/audit/catalog_to_moab.rb'
+require_relative '../../load_fixtures_helper.rb'
+
+RSpec.describe CatalogToMoab do
+  let(:last_checked_version_b4_date) { (Time.now.utc - 1.day).iso8601 }
+  let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
+
+  context '.check_version_on_dir' do
+    include_context 'fixture moabs in db'
+    let(:subject) { described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir) }
+
+    it 'creates an instance and calls #check_catalog_version' do
+      c2m_mock = instance_double(described_class)
+      allow(described_class).to receive(:new).and_return(c2m_mock)
+      expect(c2m_mock).to receive(:check_catalog_version).exactly(6).times # FIXME: will reduce to 3 for PR #497
+      described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir)
+    end
+    it 'will not check a PreservedCopy with a future last_version_audit date' do
+      c2m_mock = instance_double(described_class)
+      allow(described_class).to receive(:new).and_return(c2m_mock)
+      expect(c2m_mock).to receive(:check_catalog_version).exactly(6).times # FIXME: will reduce to 3 for PR #497
+      described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir)
+      pc = PreservedCopy.first
+      pc.last_version_audit = (Time.now.utc + 1.day).iso8601
+      pc.save
+      expect(c2m_mock).to receive(:check_catalog_version).exactly(5).times # FIXME: will reduce to 3 for PR #497
+      described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir)
+    end
+  end
+
+  context ".check_version_on_dir_profiled" do
+    let(:subject) { described_class.check_version_on_dir_profiled(last_checked_version_b4_date, storage_dir) }
+
+    it "spins up a profiler, calling profiling and printing methods on it" do
+      mock_profiler = instance_double(Profiler)
+      expect(Profiler).to receive(:new).and_return(mock_profiler)
+      expect(mock_profiler).to receive(:prof)
+      expect(mock_profiler).to receive(:print_results_flat).with('C2M_check_version_on_dir')
+      subject
+    end
+  end
+
+  context '.check_version_all_dirs' do
+    let(:subject) { described_class.check_version_all_dirs(last_checked_version_b4_date) }
+
+    it 'calls .check_version_for_dir once per storage root' do
+      expect(described_class).to receive(:check_version_on_dir).exactly(Settings.moab.storage_roots.count).times
+      subject
+    end
+
+    it 'calls check_version_for_dir with the right arguments' do
+      Settings.moab.storage_roots.each do |storage_root|
+        expect(described_class).to receive(:check_version_on_dir).with(
+          last_checked_version_b4_date,
+          "#{storage_root[1]}/#{Settings.moab.storage_trunk}"
+        )
+      end
+      subject
+    end
+  end
+
+  context ".check_version_all_dirs_profiled" do
+    let(:subject) { described_class.check_version_all_dirs_profiled(last_checked_version_b4_date) }
+
+    it "spins up a profiler, calling profiling and printing methods on it" do
+      mock_profiler = instance_double(Profiler)
+      expect(Profiler).to receive(:new).and_return(mock_profiler)
+      expect(mock_profiler).to receive(:prof)
+      expect(mock_profiler).to receive(:print_results_flat).with('C2M_check_version_all_dirs')
+      subject
+    end
+  end
+end

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -5,92 +5,43 @@ RSpec.describe CatalogToMoab do
   let(:last_checked_version_b4_date) { (Time.now.utc - 1.day).iso8601 }
   let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
 
-  context '.check_version_on_dir' do
-    include_context 'fixture moabs in db'
-    let(:subject) { described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir) }
-
-    # NOTE: this test will be removed once we test other things
-    it 'test_of_load_fixtures_helper (eventually will be testing code for .check_version_on_dir)' do
-      subject
-    end
-    it 'calls .check_catalog_version' do
-      expect(described_class).to receive(:check_catalog_version).at_least(3).times
-      described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir)
-    end
-    it 'will not check a PreservedCopy with a future last_version_audit date' do
-      expect(described_class).to receive(:check_catalog_version).exactly(6).times
-      described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir)
-      pc = PreservedCopy.first
-      pc.last_version_audit = (Time.now.utc + 1.day).iso8601
-      pc.save
-      expect(described_class).to receive(:check_catalog_version).exactly(5).times
-      described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir)
-    end
-  end
-
-  context ".check_version_on_dir_profiled" do
-    let(:subject) { described_class.check_version_on_dir_profiled(last_checked_version_b4_date, storage_dir) }
-
-    it "spins up a profiler, calling profiling and printing methods on it" do
-      mock_profiler = instance_double(Profiler)
-      expect(Profiler).to receive(:new).and_return(mock_profiler)
-      expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat).with('C2M_check_version_on_dir')
-      subject
-    end
-  end
-
-  context '.check_version_all_dirs' do
-    let(:subject) { described_class.check_version_all_dirs(last_checked_version_b4_date) }
-
-    it 'calls .check_version_for_dir once per storage root' do
-      expect(described_class).to receive(:check_version_on_dir).exactly(Settings.moab.storage_roots.count).times
-      subject
-    end
-
-    it 'calls check_version_for_dir with the right arguments' do
-      Settings.moab.storage_roots.each do |storage_root|
-        expect(described_class).to receive(:check_version_on_dir).with(
-          last_checked_version_b4_date,
-          "#{storage_root[1]}/#{Settings.moab.storage_trunk}"
-        )
-      end
-      subject
-    end
-  end
-
-  context ".check_version_all_dirs_profiled" do
-    let(:subject) { described_class.check_version_all_dirs_profiled(last_checked_version_b4_date) }
-
-    it "spins up a profiler, calling profiling and printing methods on it" do
-      mock_profiler = instance_double(Profiler)
-      expect(Profiler).to receive(:new).and_return(mock_profiler)
-      expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat).with('C2M_check_version_all_dirs')
-      subject
-    end
-  end
-
-  context '.check_catalog_version' do
+  context '#initialize' do
     include_context 'fixture moabs in db'
     let(:druid) { 'bj102hs9687' }
-    let(:po) { PreservedObject.find_by(druid: druid) }
     let(:pres_copy) do
+      po = PreservedObject.find_by(druid: druid)
+      ep = Endpoint.find_by(storage_location: storage_dir).id
+      PreservedCopy.find_by(preserved_object: po, endpoint: ep)
+    end
+
+    it 'sets attributes' do
+      c2m = described_class.new(pres_copy, storage_dir)
+      expect(c2m.preserved_copy).to eq pres_copy
+      expect(c2m.storage_dir).to eq storage_dir
+    end
+  end
+
+  context '#check_catalog_version' do
+    include_context 'fixture moabs in db'
+    let(:druid) { 'bj102hs9687' }
+    let(:pres_copy) do
+      po = PreservedObject.find_by(druid: druid)
       ep = Endpoint.find_by(storage_location: storage_dir).id
       PreservedCopy.find_by(preserved_object: po, endpoint: ep)
     end
     let(:object_dir) { "#{storage_dir}/#{DruidTools::Druid.new(druid).tree.join('/')}" }
+    let(:c2m) { described_class.new(pres_copy, storage_dir) }
 
     it 'instantiates Moab::StorageObject from druid and storage_dir' do
       expect(Moab::StorageObject).to receive(:new).with(druid, a_string_matching(object_dir)).and_call_original
-      described_class.send(:check_catalog_version, pres_copy, nil)
+      c2m.check_catalog_version
     end
 
     it 'gets the current version on disk from the Moab::StorageObject' do
       moab = instance_double(Moab::StorageObject)
       allow(Moab::StorageObject).to receive(:new).with(druid, instance_of(String)).and_return(moab)
       expect(moab).to receive(:current_version_id).and_return(3)
-      described_class.send(:check_catalog_version, pres_copy, nil)
+      c2m.check_catalog_version
     end
 
     it 'calls PreservedCopy.update_audit_timestamps' do
@@ -105,7 +56,7 @@ RSpec.describe CatalogToMoab do
       pohandler_results = instance_double(PreservedObjectHandlerResults, add_result: nil)
       allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
       expect(pohandler_results).to receive(:report_results)
-      described_class.send(:check_catalog_version, pres_copy, nil)
+      c2m.check_catalog_version
     end
 
     context 'catalog version == moab version (happy path)' do
@@ -115,7 +66,7 @@ RSpec.describe CatalogToMoab do
         expect(pohandler_results).to receive(:add_result).with(
           PreservedObjectHandlerResults::VERSION_MATCHES, 'PreservedCopy'
         )
-        described_class.send(:check_catalog_version, pres_copy, nil)
+        c2m.check_catalog_version
       end
     end
 
@@ -133,13 +84,13 @@ RSpec.describe CatalogToMoab do
         )
         allow(pohandler_results).to receive(:add_result).with(any_args)
         allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
-        described_class.send(:check_catalog_version, pres_copy, nil)
+        c2m.check_catalog_version
       end
       it 'calls PreservedObjectHandler.update_version_after_validation' do
         pohandler = instance_double(PreservedObjectHandler)
         expect(PreservedObjectHandler).to receive(:new).and_return(pohandler)
         expect(pohandler).to receive(:update_version_after_validation)
-        described_class.send(:check_catalog_version, pres_copy, nil)
+        c2m.check_catalog_version
       end
     end
 
@@ -157,7 +108,7 @@ RSpec.describe CatalogToMoab do
         )
         allow(pohandler_results).to receive(:add_result).with(any_args)
         allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
-        described_class.send(:check_catalog_version, pres_copy, nil)
+        c2m.check_catalog_version
       end
       it 'does moab validation' do
         skip 'add tests after #491'


### PR DESCRIPTION
shall we have 2 reviewers on this before merge??

This avoids all sorts of annoyances later.

Note that I envision that all methods besides `check_catalog_version` will be private ... but we can cross that bridge in other PRs.

Note further that I envisioned a large file for specs, so I split it ...