### PR TITLE
HTML Escape text in error message sent to workflow

### DIFF
--- a/app/services/workflow_errors_reporter.rb
+++ b/app/services/workflow_errors_reporter.rb
@@ -32,7 +32,7 @@ class WorkflowErrorsReporter
   private_class_method def self.request_params(request, druid, process_name, error_message)
     request.headers['content-type'] = "application/xml"
     request.url  "/workflow/dor/objects/druid:#{druid}/workflows/preservationAuditWF/#{process_name}"
-    request.body = "<process name='#{process_name}' status='error' errorMessage='#{error_message}'/>"
+    request.body = "<process name='#{process_name}' status='error' errorMessage='#{CGI.escapeHTML(error_message)}'/>"
   end
 
   private_class_method def self.conn

--- a/spec/services/workflow_errors_reporter_spec.rb
+++ b/spec/services/workflow_errors_reporter_spec.rb
@@ -5,10 +5,8 @@ RSpec.describe WorkflowErrorsReporter do
     'https://sul-lyberservices-test.stanford.edu/workflow/dor/objects/druid:jj925bx9565/workflows/preservationAuditWF/moab-valid'
   end
   let(:headers) { { 'Content-Type' => 'application/xml' } }
-  let(:result) do
-    { 13 => "Invalid moab, validation error...ential version directories." }
-  end
-  let(:body) { "<process name='moab-valid' status='error' errorMessage='{13=>\"Invalid moab, validation error...ential version directories.\"}'/>" }
+  let(:result) { "Invalid moab, validation error...ential version directories." }
+  let(:body) { "<process name='moab-valid' status='error' errorMessage='#{result}'/>" }
   let(:druid) { 'jj925bx9565' }
 
   context '.update_workflow' do
@@ -28,7 +26,7 @@ RSpec.describe WorkflowErrorsReporter do
         .with(body: body,
               headers: headers)
         .to_return(status: 400, body: "", headers: {})
-      expect(Rails.logger).to receive(:warn).with("#{druid} - unable to update workflow for preservationAuditWF moab-valid #<Faraday::ClientError response={:status=>400, :headers=>{}, :body=>\"\"}>. Error message: #{result}")
+      expect(Rails.logger).to receive(:warn).with("#{druid} - unable to update workflow for preservationAuditWF moab-valid #<Faraday::ClientError response={:status=>400, :headers=>{}, :body=>\"\"}>. Error message: Invalid moab, validation error...ential version directories.")
       described_class.update_workflow(druid, 'moab-valid', result)
     end
 
@@ -53,4 +51,19 @@ RSpec.describe WorkflowErrorsReporter do
       expect(headers_hash).to eq("content-type" => "application/xml")
     end
   end
+
+  context '.request_params' do
+    it 'escapes special characters in error message' do
+      process_name = 'moab-valid'
+      error_msg = "Invalid moab, validation errors: [\"Version directory name not in 'v00xx' format: original-v1\"]"
+      mock_request = instance_double(Faraday::Request)
+      headers_hash = {}
+      expected_error_msg = CGI.escapeHTML(error_msg)
+      allow(mock_request).to receive(:headers).and_return(headers_hash)
+      allow(mock_request).to receive(:url)
+      expect(mock_request).to receive(:body=).with("<process name='#{process_name}' status='error' errorMessage='#{expected_error_msg}'/>")
+      described_class.send(:request_params, mock_request, druid, process_name, error_msg)
+    end
+  end
+
 end


### PR DESCRIPTION
When we sent this errorMessage:
`"PreservedObjectHandler(bp534qj1626, 7, 12877062629, services-disk02) Invalid moab, validation errors: [\"Version directory name not in 'v00xx' format: original-v1\"]"` 

- Ruby didn't escape the quotes, the errorMessage didn't have parsable structure when a PUT request was sent.
- WorkflowService responded with a 400 bad request.
- Wrote RSpec test to test this. 
- We discovered this in prod, but was reproducible in stage.

paired w/ @tallenaz @jmartin-sul  