### PR TITLE
catalog_to_moab.check_catalog_version: implement case of catalog_version > moab_version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,6 +105,7 @@ Metrics/MethodLength:
   Max: 25
   Exclude:
     - 'app/services/preserved_object_handler.rb' # check_existence shameless green
+    - 'lib/audit/catalog_to_moab.rb' # check_catalog_version shameless green
 
 Metrics/PerceivedComplexity:
   Exclude:
@@ -160,6 +161,7 @@ RSpec/NamedSubject:
 
 RSpec/NestedGroups:
   Exclude:
+    - 'spec/lib/audit/catalog_to_moab_instance_spec.rb'
     - 'spec/lib/audit/moab_to_catalog_spec.rb'
     - 'spec/services/preserved_object_handler_confirm_version_spec.rb'
     - 'spec/services/preserved_object_handler_create_spec.rb'
@@ -178,7 +180,8 @@ Style/BlockDelimiters:
 
 Style/BracesAroundHashParameters:
   Exclude:
-    - app/services/preserved_object_handler.rb # code is clearer with the braces
+    - app/services/preserved_object_handler.rb # #update_status is clearer with the braces
+    - lib/audit/catalog_to_moab.rb # #update_status is clearer with the braces
 
 Style/Documentation:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,13 +61,13 @@ Metrics/AbcSize:
   Exclude:
     - 'app/services/preserved_object_handler.rb' # methods still readable; shameless green
     - 'app/services/preserved_object_handler_results.rb' # method still readable
-    - 'lib/audit/moab_to_catalog.rb' # .xxx_for_all_storage_roots is decidedly readable
     - 'lib/audit/catalog_to_moab.rb' # .check_version_all_dirs is decidedly readable
+    - 'lib/audit/moab_to_catalog.rb' # .xxx_for_all_storage_roots is decidedly readable
 
 Metrics/BlockLength:
   Exclude:
-    - 'spec/**/*'
     - 'app/services/preserved_object_handler.rb' # check_existence shameless green
+    - 'spec/**/*'
 
 Metrics/BlockNesting:
   Exclude:
@@ -87,10 +87,10 @@ Metrics/CyclomaticComplexity:
 Metrics/LineLength:
   Max: 120
   Exclude:
+    - 'Rakefile' # Line length 133 for better readability
     - 'app/services/preserved_object_handler.rb' # line 269 is 121
     - 'app/services/preserved_object_handler_results.rb' # line 35 is 121
     - 'app/services/workflow_errors_reporter.rb' # line 7 is 143
-    - 'Rakefile' # Line length 133 for better readability
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # 1 line 126
     - 'spec/models/status_spec.rb' # Line length of 132 for better readability
     - 'spec/services/preserved_object_handler_check_exist_spec.rb' # 17 lines, but who's counting, officer?
@@ -127,8 +127,8 @@ Rails/HasAndBelongsToMany:
 
 Rails/Output:
   Exclude:
-    - 'lib/audit/moab_to_catalog.rb' # use puts statements for following progress of long job
     - 'lib/audit/catalog_to_moab.rb' # use puts statements for following progress of long job
+    - 'lib/audit/moab_to_catalog.rb' # use puts statements for following progress of long job
 
 Rails/SkipsModelValidations:
   Exclude:
@@ -139,7 +139,6 @@ Rails/SkipsModelValidations:
 RSpec/BeforeAfterAll:
   Exclude:
     # we use after(:all) specifically to prevent state leakage
-    - 'spec/load_fixtures_helper.rb'
     - 'spec/models/preservation_policy_spec.rb'
 
 RSpec/ExampleLength:
@@ -163,10 +162,10 @@ RSpec/NestedGroups:
   Exclude:
     - 'spec/lib/audit/catalog_to_moab_instance_spec.rb'
     - 'spec/lib/audit/moab_to_catalog_spec.rb'
+    - 'spec/services/preserved_object_handler_check_exist_spec.rb'
     - 'spec/services/preserved_object_handler_confirm_version_spec.rb'
     - 'spec/services/preserved_object_handler_create_spec.rb'
     - 'spec/services/preserved_object_handler_update_version_spec.rb'
-    - 'spec/services/preserved_object_handler_check_exist_spec.rb'
 
 # --- Style ---
 

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -164,6 +164,7 @@ class PreservedObjectHandler
 
   private
 
+  # TODO: near duplicate of method in catalog_to_moab - extract superclass or moab wrapper class??
   def moab_validation_errors
     @moab_errors ||=
       begin
@@ -183,6 +184,7 @@ class PreservedObjectHandler
       end
   end
 
+  # TODO: duplicate of method in catalog_to_moab - extract superclass or moab wrapper class??
   def ran_moab_validation?
     @ran_moab_validation ||= false
   end
@@ -346,6 +348,7 @@ class PreservedObjectHandler
     end
   end
 
+  # TODO: near duplicate of method in catalog_to_moab - extract superclass or moab wrapper class??
   def update_status(preserved_copy, new_status)
     preserved_copy.update_status(new_status) do
       handler_results.add_result(

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -91,8 +91,8 @@ class CatalogToMoab
       results.report_results
     end
 
-    # TODO: call these methods on PreservedCopy object
-    # update_pc_audit_timestamps(preserved_copy, ran_moab_validation, true) - see #477
+    preserved_copy.update_audit_timestamps(ran_moab_validation?, true)
+
     # update_db_object(preserved_copy) - see #478
   end
 

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -93,6 +93,8 @@ class CatalogToMoab
 
     preserved_copy.update_audit_timestamps(ran_moab_validation?, true)
 
+    # TODO: We need to save preserved copy.  Do we want to use something like
+    #  PreservedObjectHandler.update_db_object? - see #478
     # update_db_object(preserved_copy) - see #478
   end
 

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -45,18 +45,17 @@ class CatalogToMoab
 
   # ----  INSTANCE code below this line ---------------------------
 
-  attr_reader :preserved_copy, :storage_dir, :results, :moab
+  attr_reader :preserved_copy, :storage_dir, :druid, :results, :moab
 
   def initialize(preserved_copy, storage_dir)
     @preserved_copy = preserved_copy
     @storage_dir = storage_dir
+    @druid = preserved_copy.preserved_object.druid
+    @results = PreservedObjectHandlerResults.new(druid, nil, nil, preserved_copy.endpoint)
   end
 
   # shameless green implementation
   def check_catalog_version
-    druid = preserved_copy.preserved_object.druid
-    @results = PreservedObjectHandlerResults.new(druid, nil, nil, preserved_copy.endpoint)
-
     unless preserved_copy.matches_po_current_version?
       results.add_result(PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH,
                          pc_version: preserved_copy.version,

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe CatalogToMoab do
       c2m = described_class.new(pres_copy, storage_dir)
       expect(c2m.preserved_copy).to eq pres_copy
       expect(c2m.storage_dir).to eq storage_dir
+      expect(c2m.druid).to eq druid
+      expect(c2m.results).to be_an_instance_of PreservedObjectHandlerResults
     end
   end
 

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe CatalogToMoab do
     end
 
     it 'calls PreservedCopy.update_audit_timestamps' do
-      skip 'add this test after #477 is merged'
+      expect(pres_copy).to receive(:update_audit_timestamps).with(anything, true)
+      c2m.check_catalog_version
     end
 
     it 'calls PreservedCopy.save!' do


### PR DESCRIPTION
2 reviewers, please.

- I duplicated 3 methods, more or less, from `POHandler` in `CatalogToMoab`.  In our streamlined, shameless green, critical path work only, this felt expeditious and didn't even conflict with Sandi Metz ("hold your nose, duplicate code ... for the 2nd and 3rd times ... then refactor")
    - I did a wonderful job of calling it out with comments
- I finished implementing the work from PR #477 (PR #489), actually calling the pres_copy methods now that they exist.
- I got all OCD and alphabetized the rubocop exceptions ...

Fixes #491
Fixes #489