### PR TITLE
Refactor to spec for ordering in c2m SQL query

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -193,6 +193,7 @@ Style/FormatStringToken:
 Style/GuardClause:
   Exclude:
     - app/services/preserved_object_handler.rb # update_status method easy to read as is
+    - lib/audit/catalog_to_moab.rb # wrapping method on line 17 is more readable
 
 Style/PercentLiteralDelimiters:
   Exclude:

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -31,6 +31,13 @@ class PreservedCopy < ApplicationRecord
   validates :status, inclusion: { in: statuses.keys }
   validates :version, presence: true
 
+  scope :least_recent_version_audit, lambda { |last_checked_b4_date, storage_dir|
+    joins(:endpoint)
+      .where(endpoints: { storage_location: storage_dir })
+      .where('last_version_audit IS NULL or last_version_audit < ?', last_checked_b4_date)
+      .order('last_version_audit IS NOT NULL, last_version_audit ASC')
+  }
+
   def update_audit_timestamps(moab_validated, version_audited)
     t = Time.current
     self.last_moab_validation = t if moab_validated

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,3 +39,4 @@ provlog:
   enable: false
 
 workflow_services_url: ''
+c2m_sql_limit: 1000

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -5,16 +5,18 @@ require 'profiler.rb'
 class CatalogToMoab
 
   # allows for sharding/parallelization by storage_dir
-  def self.check_version_on_dir(last_checked_b4_date, storage_dir)
+  def self.check_version_on_dir_of_batch(last_checked_b4_date, storage_dir, limit)
     # TODO: ensure last_checked_version_b4_date is in the right format for query - see #485
-    pcs = PreservedCopy
-          .joins(:endpoint)
-          .where(endpoints: { storage_location: storage_dir })
-          .where('last_version_audit IS NULL or last_version_audit < ?', last_checked_b4_date)
-          .order('last_version_audit IS NOT NULL, last_version_audit ASC')
-    pcs.find_each do |pc|
+    pcs = PreservedCopy.least_recent_version_audit(last_checked_b4_date, storage_dir).limit(limit)
+    pcs.each do |pc|
       c2m = CatalogToMoab.new(pc, storage_dir)
       c2m.check_catalog_version
+    end
+  end
+
+  def self.check_version_on_dir(last_checked_b4_date, storage_dir)
+    unless PreservedCopy.least_recent_version_audit(last_checked_b4_date, storage_dir).count.zero?
+      check_version_on_dir_of_batch(last_checked_b4_date, storage_dir, Settings.c2m_sql_limit)
     end
   end
 


### PR DESCRIPTION
  Extracts the SQL query from check_version_on_dir into PreservedCopy
  This made writing the spec more straightforward

  Adds a spec on c2m to test that sql orders objects differently
  depending on last_version_audit timestamp

  To get the spec running we saved the preserved_copy, though
  we haven't agreed on the best way of saving the pc

  The spec seems a bit fragile in the way it uses timestamps in
  method calls

 Paired with @jmartin-sul 

Closes #476 but shouldn't be merged until we get further along with how to save the preserved_copy in `check_catalog_version`, which connects this to #478 

Closes #537 