### PR TITLE
Remove unnecessary comment regarding audit requirements after checking with Julian

### DIFF
--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -75,7 +75,6 @@ class CatalogToMoab
     catalog_version = preserved_copy.version
     if catalog_version == moab_version
       results.add_result(PreservedObjectHandlerResults::VERSION_MATCHES, preserved_copy.class.name)
-      # TODO:  original spec asks for verifying files????  read audit requirements - see #481
       results.report_results
     elsif catalog_version < moab_version
       results.add_result(PreservedObjectHandlerResults::UNEXPECTED_VERSION, preserved_copy.class.name)


### PR DESCRIPTION
"[C2m] is just a check to see that the Moab directories actually exist. Nothing fancy" - Julian

- Audit requirement on C2M is correct and there is nothing beyond "does moab exist?" and "is the version what we expect" 

- PR removes TODO comment `# TODO: original spec asks for verifying files???? read audit requirements`

closes #481 