### PR TITLE
C2M#check_catalog_version: handle pres copy status status already bad

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,6 +83,7 @@ Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/services/preserved_object_handler.rb' # update_online_version (shameless green)
     - 'app/services/audit_results.rb' # logger_severity_level is simply a case statement
+    - 'lib/audit/catalog_to_moab.rb' # check_catalog_version (shameless green)
 
 # because this isn't 1994
 Metrics/LineLength:
@@ -115,6 +116,10 @@ Metrics/PerceivedComplexity:
 
 # --- Naming ---
 
+Naming/AccessorMethodName:
+  Exclude:
+    # rubocop doesn't like single param 'set_' methods, but this isn't an instace var setter, and nice to have method name be parallel to POH method
+    - 'lib/audit/catalog_to_moab.rb'
 Naming/FileName:
   Exclude:
     - 'Capfile'

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -271,7 +271,7 @@ class PreservedObjectHandler
   # other validations of what's on disk, and will update the status accordingly
   # TODO: near duplicate of method in CatalogToMoab - extract superclass or moab wrapper class??
   def set_status_as_seen_on_disk(pres_copy, found_expected_version)
-    unless moab_validation_errors.empty?
+    if moab_validation_errors.any?
       update_status(pres_copy, PreservedCopy::INVALID_MOAB_STATUS)
       return
     end

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -269,6 +269,7 @@ class PreservedObjectHandler
 
   # given a PreservedCopy instance and whether the caller found the expected version of it on disk, this will perform
   # other validations of what's on disk, and will update the status accordingly
+  # TODO: near duplicate of method in CatalogToMoab - extract superclass or moab wrapper class??
   def set_status_as_seen_on_disk(pres_copy, found_expected_version)
     unless moab_validation_errors.empty?
       update_status(pres_copy, PreservedCopy::INVALID_MOAB_STATUS)

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -142,7 +142,7 @@ class CatalogToMoab
   # other validations of what's on disk, and will update the status accordingly.
   # TODO: near duplicate of method in POHandler - extract superclass or moab wrapper class??
   def set_status_as_seen_on_disk(found_expected_version)
-    unless moab_validation_errors.empty?
+    if moab_validation_errors.any?
       update_status(PreservedCopy::INVALID_MOAB_STATUS)
       return
     end

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -78,7 +78,30 @@ RSpec.describe CatalogToMoab do
         expect(pohandler_results).to receive(:add_result).with(
           AuditResults::ONLINE_MOAB_DOES_NOT_EXIST
         )
+        expect(pohandler_results).to receive(:add_result).with(
+          AuditResults::PC_STATUS_CHANGED, old_status: "ok", new_status: "online_moab_not_found"
+        )
         c2m.check_catalog_version
+      end
+      context 'updates status correctly' do
+        before do
+          allow(Moab::StorageObject).to receive(:new).with(druid, instance_of(String)).and_return(nil)
+        end
+
+        [
+          PreservedCopy::VALIDITY_UNKNOWN_STATUS,
+          PreservedCopy::OK_STATUS,
+          PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
+          PreservedCopy::INVALID_MOAB_STATUS,
+          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+        ].each do |orig_status|
+          it "had #{orig_status}, should now have ONLINE_MOAB_NOT_FOUND_STATUS" do
+            pres_copy.status = orig_status
+            pres_copy.save!
+            c2m.check_catalog_version
+            expect(pres_copy.reload.status).to eq PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS
+          end
+        end
       end
       it 'stops processing .check_catalog_version' do
         moab = instance_double(Moab::StorageObject)
@@ -112,6 +135,43 @@ RSpec.describe CatalogToMoab do
         )
         c2m.check_catalog_version
       end
+
+      context 'check whether PreservedCopy already has a status other than OK_STATUS, re-check status if so' do
+        [
+          PreservedCopy::VALIDITY_UNKNOWN_STATUS,
+          PreservedCopy::OK_STATUS,
+          PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
+          PreservedCopy::INVALID_MOAB_STATUS,
+          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+        ].each do |orig_status|
+          it "had #{orig_status}, should now have OK_STATUS" do
+            pres_copy.status = orig_status
+            pres_copy.save!
+            allow(c2m).to receive(:moab_validation_errors).and_return([])
+            c2m.check_catalog_version
+            expect(pres_copy.reload.status).to eq PreservedCopy::OK_STATUS
+          end
+        end
+
+        # PreservedCopy::OK_STATUS intentionally omitted, since we don't check status on disk
+        # if versions match
+        [
+          PreservedCopy::VALIDITY_UNKNOWN_STATUS,
+          PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
+          PreservedCopy::INVALID_MOAB_STATUS,
+          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+        ].each do |orig_status|
+          it "had #{orig_status}, should now have INVALID_MOAB_STATUS" do
+            pres_copy.status = orig_status
+            pres_copy.save!
+            allow(c2m).to receive(:moab_validation_errors).and_return(
+              [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
+            )
+            c2m.check_catalog_version
+            expect(pres_copy.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
+          end
+        end
+      end
     end
 
     context 'catalog version < moab version' do
@@ -135,6 +195,46 @@ RSpec.describe CatalogToMoab do
         expect(PreservedObjectHandler).to receive(:new).and_return(pohandler)
         expect(pohandler).to receive(:update_version_after_validation)
         c2m.check_catalog_version
+      end
+
+      context 'check whether PreservedCopy already has a status other than OK_STATUS, re-check status if so' do
+        [
+          PreservedCopy::VALIDITY_UNKNOWN_STATUS,
+          PreservedCopy::OK_STATUS,
+          PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
+          PreservedCopy::INVALID_MOAB_STATUS,
+          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+        ].each do |orig_status|
+          it "had #{orig_status}, should now have OK_STATUS" do
+            pres_copy.status = orig_status
+            pres_copy.save!
+            mock_sov = instance_double(Stanford::StorageObjectValidator)
+            allow(mock_sov).to receive(:validation_errors).and_return([])
+            allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
+            c2m.check_catalog_version
+            expect(pres_copy.reload.status).to eq PreservedCopy::OK_STATUS
+          end
+        end
+
+        [
+          PreservedCopy::VALIDITY_UNKNOWN_STATUS,
+          PreservedCopy::OK_STATUS,
+          PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
+          PreservedCopy::INVALID_MOAB_STATUS,
+          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+        ].each do |orig_status|
+          it "had #{orig_status}, should now have INVALID_MOAB_STATUS" do
+            pres_copy.status = orig_status
+            pres_copy.save!
+            mock_sov = instance_double(Stanford::StorageObjectValidator)
+            allow(mock_sov).to receive(:validation_errors).and_return(
+              [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
+            )
+            allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
+            c2m.check_catalog_version
+            expect(pres_copy.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
+          end
+        end
       end
     end
 
@@ -199,6 +299,42 @@ RSpec.describe CatalogToMoab do
         allow(pohandler_results).to receive(:add_result).with(any_args)
         allow(AuditResults).to receive(:new).and_return(pohandler_results)
         c2m.check_catalog_version
+      end
+
+      context 'check whether PreservedCopy already has a status other than OK_STATUS, re-check status if so' do
+        [
+          PreservedCopy::VALIDITY_UNKNOWN_STATUS,
+          PreservedCopy::OK_STATUS,
+          PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
+          PreservedCopy::INVALID_MOAB_STATUS,
+          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+        ].each do |orig_status|
+          it "had #{orig_status}, should now have EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS" do
+            pres_copy.status = orig_status
+            pres_copy.save!
+            allow(c2m).to receive(:moab_validation_errors).and_return([])
+            c2m.check_catalog_version
+            expect(pres_copy.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          end
+        end
+
+        [
+          PreservedCopy::VALIDITY_UNKNOWN_STATUS,
+          PreservedCopy::OK_STATUS,
+          PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
+          PreservedCopy::INVALID_MOAB_STATUS,
+          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+        ].each do |orig_status|
+          it "had #{orig_status}, should now have INVALID_MOAB_STATUS" do
+            pres_copy.status = orig_status
+            pres_copy.save!
+            allow(c2m).to receive(:moab_validation_errors).and_return(
+              [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
+            )
+            c2m.check_catalog_version
+            expect(pres_copy.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
+          end
+        end
       end
     end
   end

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe CatalogToMoab do
     let(:pres_copy) do
       po = PreservedObject.find_by(druid: druid)
       ep = Endpoint.find_by(storage_location: storage_dir).id
-      PreservedCopy.find_by(preserved_object: po, endpoint: ep)
+      pc = PreservedCopy.find_by(preserved_object: po, endpoint: ep)
+      pc.update(status: PreservedCopy::OK_STATUS)
+      pc
     end
     let(:object_dir) { "#{storage_dir}/#{DruidTools::Druid.new(druid).tree.join('/')}" }
     let(:c2m) { described_class.new(pres_copy, storage_dir) }
@@ -40,7 +42,7 @@ RSpec.describe CatalogToMoab do
     end
 
     it 'gets the current version on disk from the Moab::StorageObject' do
-      moab = instance_double(Moab::StorageObject)
+      moab = instance_double(Moab::StorageObject, object_pathname: object_dir)
       allow(Moab::StorageObject).to receive(:new).with(druid, instance_of(String)).and_return(moab)
       expect(moab).to receive(:current_version_id).and_return(3)
       c2m.check_catalog_version


### PR DESCRIPTION
since this adds its own `preserved_copy#save!` call, which also happens in #519 and #525, so those should probably get merged first, and then this should get rebased.

assumed similar behavior to `PreservedObjectHandler#check_existence`.

paired w/ @SaravShah

closes #480