### PR TITLE
pohandler_results_spec revisions

### DIFF
--- a/spec/services/preserved_object_handler_results_spec.rb
+++ b/spec/services/preserved_object_handler_results_spec.rb
@@ -19,18 +19,24 @@ RSpec.describe PreservedObjectHandlerResults do
       exp = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{endpoint.endpoint_name})"
       expect(pohr.msg_prefix).to eq exp
     end
-    it 'sets result_array to []' do
+    it 'sets result_array attr to []' do
       expect(pohr.result_array).to eq []
+    end
+    it 'sets druid attr to arg' do
+      expect(pohr.druid).to eq druid
+    end
+    it 'sets incoming_version attr to arg' do
+      expect(pohr.incoming_version).to eq incoming_version
     end
   end
 
   context '#report_results' do
-    before do
-      code = PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH
-      addl_hash = { pc_version: 1, po_version: 2 }
-      pohr.add_result(code, addl_hash)
-    end
     context 'writes to Rails log' do
+      before do
+        code = PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH
+        addl_hash = { pc_version: 1, po_version: 2 }
+        pohr.add_result(code, addl_hash)
+      end
       it 'with msg_prefix' do
         expect(Rails.logger).to receive(:log).with(Logger::ERROR, a_string_matching(Regexp.escape(pohr.msg_prefix)))
         pohr.report_results
@@ -42,6 +48,61 @@ RSpec.describe PreservedObjectHandlerResults do
         not_matched_str = 'does not match PreservedObject current_version'
         expect(Rails.logger).to receive(:log).with(Logger::ERROR, a_string_matching(not_matched_str))
         expect(Rails.logger).to receive(:log).with(Logger::INFO, a_string_matching(PreservedCopy::INVALID_MOAB_STATUS))
+        pohr.report_results
+      end
+    end
+    context 'sends errors to workflows' do
+      it 'INVALID_MOAB reported with details about the failures' do
+        result_code = PreservedObjectHandlerResults::INVALID_MOAB
+        moab_valid_errs = [
+          "Version directory name not in 'v00xx' format: original-v1",
+          "Version v0005: No files present in manifest dir"
+        ]
+        pohr.add_result(result_code, moab_valid_errs)
+        wf_err_msg = pohr.send(:result_code_msg, result_code, moab_valid_errs)
+        expect(WorkflowErrorsReporter).to receive(:update_workflow).with(druid, 'moab-valid', wf_err_msg)
+        pohr.report_results
+      end
+      it "does not send results that aren't in WORKFLOW_REPORT_CODES" do
+        code = PreservedObjectHandlerResults::CREATED_NEW_OBJECT
+        pohr.add_result(code)
+        expect(WorkflowErrorsReporter).not_to receive(:update_workflow)
+        pohr.report_results
+      end
+      it 'sends results in WORKFLOW_REPORT_CODES errors' do
+        code = PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH
+        addl_hash = { pc_version: 1, po_version: 2 }
+        pohr.add_result(code, addl_hash)
+        wf_err_msg = pohr.send(:result_code_msg, code, addl_hash)
+        expect(WorkflowErrorsReporter).to receive(:update_workflow).with(
+          druid, 'preservation-audit', a_string_starting_with(wf_err_msg)
+        )
+        pohr.report_results
+      end
+      it 'multiple errors are concatenated together with || separator' do
+        code1 = PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH
+        result_msg_args1 = { pc_version: 1, po_version: 2 }
+        pohr.add_result(code1, result_msg_args1)
+        wf_err_msg1 = pohr.send(:result_code_msg, code1, result_msg_args1)
+        code2 = PreservedObjectHandlerResults::OBJECT_ALREADY_EXISTS
+        result_msg_args2 = 'foo'
+        pohr.add_result(code2, result_msg_args2)
+        wf_err_msg2 = pohr.send(:result_code_msg, code2, result_msg_args2)
+        expect(WorkflowErrorsReporter).to receive(:update_workflow).with(
+          druid, 'preservation-audit', a_string_starting_with("#{wf_err_msg1} || #{wf_err_msg2}")
+        )
+        pohr.report_results
+      end
+      it 'includes a truncated stack trace at the end' do
+        code = PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH
+        addl_hash = { pc_version: 1, po_version: 2 }
+        pohr.add_result(code, addl_hash)
+        exp_regex = Regexp.new(" || \
+          .*preservation_catalog/app/services/preserved_object_handler_results.rb \
+          .*preservation_catalog/spec/services/preserved_object_handler_results_spec.rb .*in <top (required)>")
+        expect(WorkflowErrorsReporter).to receive(:update_workflow).with(
+          druid, 'preservation-audit', a_string_ending_with(exp_regex)
+        )
         pohr.report_results
       end
     end
@@ -69,14 +130,29 @@ RSpec.describe PreservedObjectHandlerResults do
   end
 
   context '#remove_db_updated_results' do
-    it 'needs tests' do
-      skip
+    before do
+      code = PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH
+      result_msg_args = { pc_version: 1, po_version: 2 }
+      pohr.add_result(code, result_msg_args)
+      code = PreservedObjectHandlerResults::PC_STATUS_CHANGED
+      result_msg_args = { old_status: PreservedCopy::OK_STATUS, new_status: PreservedCopy::INVALID_MOAB_STATUS }
+      pohr.add_result(code, result_msg_args)
+      code = PreservedObjectHandlerResults::CREATED_NEW_OBJECT
+      pohr.add_result(code)
+      code = PreservedObjectHandlerResults::INVALID_MOAB
+      pohr.add_result(code, 'foo')
     end
-  end
-
-  context '#result_hash' do
-    it 'needs tests' do
-      skip
+    it 'removes results matching DB_UPDATED_CODES' do
+      expect(pohr.result_array.size).to eq 4
+      pohr.remove_db_updated_results
+      expect(pohr.result_array.size).to eq 2
+      expect(pohr.result_array).not_to include(a_hash_including(PreservedObjectHandlerResults::CREATED_NEW_OBJECT))
+      expect(pohr.result_array).not_to include(a_hash_including(PreservedObjectHandlerResults::PC_STATUS_CHANGED))
+    end
+    it 'keeps results not matching DB_UPDATED_CODES' do
+      pohr.remove_db_updated_results
+      expect(pohr.result_array).to include(a_hash_including(PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH))
+      expect(pohr.result_array).to include(a_hash_including(PreservedObjectHandlerResults::INVALID_MOAB))
     end
   end
 end

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -73,8 +73,7 @@ RSpec.shared_examples 'calls PreservedObjectHandlerResults.report_results' do |m
   it '' do
     mock_results = instance_double(PreservedObjectHandlerResults)
     allow(mock_results).to receive(:add_result)
-    allow(mock_results).to receive(:result_array) # TODO: remove this when switch to report_results call
-    expect(mock_results).to receive(:report_results) # TODO: change this when switch to report_results call
+    expect(mock_results).to receive(:report_results)
     expect(PreservedObjectHandlerResults).to receive(:new).and_return(mock_results)
     po_handler.send(method_sym)
   end

--- a/spec/services/workflow_errors_reporter_spec.rb
+++ b/spec/services/workflow_errors_reporter_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe WorkflowErrorsReporter do
       described_class.update_workflow(druid, 'moab-valid', result)
     end
 
-    it 'make sure request get correct params' do
+    it 'make sure request gets correct params' do
       process_name = 'moab-valid'
       error_msg = "Invalid moab, validation error...ential version directories."
       mock_request = instance_double(Faraday::Request)


### PR DESCRIPTION
2 reviewers?  Beats me.

- specs that ensure we call `WorkflowErrorsReporter.update_workflow` as appropriate
- implemented rest of public method specs for `POHandlerResults` class (preparatory for #528, #509 and #455)
- fixed a typo in a spec description
- removed vestigial comments in a shared_examples spec

Closes #385
Connects to #455 
Connects to #528