### PR TITLE
AuditResults is the new name for PreservedObjectHandlerResults

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,7 +60,7 @@ Lint/RescueWithoutErrorClass:
 Metrics/AbcSize:
   Exclude:
     - 'app/services/preserved_object_handler.rb' # methods still readable; shameless green
-    - 'app/services/preserved_object_handler_results.rb' # method still readable
+    - 'app/services/audit_results.rb' # method still readable
     - 'lib/audit/catalog_to_moab.rb' # .check_version_all_dirs is decidedly readable
     - 'lib/audit/moab_to_catalog.rb' # .xxx_for_all_storage_roots is decidedly readable
 
@@ -76,13 +76,13 @@ Metrics/BlockNesting:
 Metrics/ClassLength:
   Exclude:
     - 'app/services/preserved_object_handler.rb'
-    - 'app/services/preserved_object_handler_results.rb'
+    - 'app/services/audit_results.rb'
     - 'lib/audit/catalog_to_moab.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/services/preserved_object_handler.rb' # update_online_version (shameless green)
-    - 'app/services/preserved_object_handler_results.rb' # logger_severity_level is simply a case statement
+    - 'app/services/audit_results.rb' # logger_severity_level is simply a case statement
 
 # because this isn't 1994
 Metrics/LineLength:
@@ -90,7 +90,7 @@ Metrics/LineLength:
   Exclude:
     - 'Rakefile' # Line length 133 for better readability
     - 'app/services/preserved_object_handler.rb' # line 269 is 121
-    - 'app/services/preserved_object_handler_results.rb' # line 35 is 121
+    - 'app/services/audit_results.rb' # line 35 is 121
     - 'app/services/workflow_errors_reporter.rb' # line 7 is 143
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # 1 line 126
     - 'spec/models/status_spec.rb' # Line length of 132 for better readability
@@ -188,7 +188,7 @@ Style/Documentation:
     - 'config/application.rb' # that's how Rails generates it
 
 Style/FormatStringToken:
-  EnforcedStyle: template # using interpolated strings in PreservedObjectHandlerResults
+  EnforcedStyle: template # using interpolated strings in AuditResults
 
 Style/GuardClause:
   Exclude:

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CatalogToMoab do
       expect(c2m.preserved_copy).to eq pres_copy
       expect(c2m.storage_dir).to eq storage_dir
       expect(c2m.druid).to eq druid
-      expect(c2m.results).to be_an_instance_of PreservedObjectHandlerResults
+      expect(c2m.results).to be_an_instance_of AuditResults
     end
   end
 
@@ -57,8 +57,8 @@ RSpec.describe CatalogToMoab do
     end
 
     it 'calls POHandlerResults.report_results' do
-      pohandler_results = instance_double(PreservedObjectHandlerResults, add_result: nil)
-      allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+      pohandler_results = instance_double(AuditResults, add_result: nil)
+      allow(AuditResults).to receive(:new).and_return(pohandler_results)
       expect(pohandler_results).to receive(:report_results)
       c2m.check_catalog_version
     end
@@ -71,10 +71,10 @@ RSpec.describe CatalogToMoab do
     context 'moab is nil (exists in catalog but not online)' do
       it 'adds an ONLINE_MOAB_DOES_NOT_EXIST result' do
         allow(Moab::StorageObject).to receive(:new).with(druid, instance_of(String)).and_return(nil)
-        pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)
-        allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+        pohandler_results = instance_double(AuditResults, report_results: nil)
+        allow(AuditResults).to receive(:new).and_return(pohandler_results)
         expect(pohandler_results).to receive(:add_result).with(
-          PreservedObjectHandlerResults::ONLINE_MOAB_DOES_NOT_EXIST
+          AuditResults::ONLINE_MOAB_DOES_NOT_EXIST
         )
         c2m.check_catalog_version
       end
@@ -89,10 +89,10 @@ RSpec.describe CatalogToMoab do
     context 'preserved_copy version != current_version of preserved_object' do
       it 'adds a PC_PO_VERSION_MISMATCH result and returns' do
         pres_copy.version = 666
-        pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)
-        allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+        pohandler_results = instance_double(AuditResults, report_results: nil)
+        allow(AuditResults).to receive(:new).and_return(pohandler_results)
         expect(pohandler_results).to receive(:add_result).with(
-          PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH,
+          AuditResults::PC_PO_VERSION_MISMATCH,
           pc_version: pres_copy.version,
           po_version: pres_copy.preserved_object.current_version
         )
@@ -103,10 +103,10 @@ RSpec.describe CatalogToMoab do
 
     context 'catalog version == moab version (happy path)' do
       it 'adds a VERSION_MATCHES result' do
-        pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)
-        allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+        pohandler_results = instance_double(AuditResults, report_results: nil)
+        allow(AuditResults).to receive(:new).and_return(pohandler_results)
         expect(pohandler_results).to receive(:add_result).with(
-          PreservedObjectHandlerResults::VERSION_MATCHES, 'PreservedCopy'
+          AuditResults::VERSION_MATCHES, 'PreservedCopy'
         )
         c2m.check_catalog_version
       end
@@ -120,12 +120,12 @@ RSpec.describe CatalogToMoab do
       end
 
       it 'adds an UNEXPECTED_VERSION result' do
-        pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)
+        pohandler_results = instance_double(AuditResults, report_results: nil)
         expect(pohandler_results).to receive(:add_result).with(
-          PreservedObjectHandlerResults::UNEXPECTED_VERSION, 'PreservedCopy'
+          AuditResults::UNEXPECTED_VERSION, 'PreservedCopy'
         )
         allow(pohandler_results).to receive(:add_result).with(any_args)
-        allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+        allow(AuditResults).to receive(:new).and_return(pohandler_results)
         c2m.check_catalog_version
       end
       it 'calls PreservedObjectHandler.update_version_after_validation' do
@@ -144,12 +144,12 @@ RSpec.describe CatalogToMoab do
       end
 
       it 'adds an UNEXPECTED_VERSION result' do
-        pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)
+        pohandler_results = instance_double(AuditResults, report_results: nil)
         expect(pohandler_results).to receive(:add_result).with(
-          PreservedObjectHandlerResults::UNEXPECTED_VERSION, 'PreservedCopy'
+          AuditResults::UNEXPECTED_VERSION, 'PreservedCopy'
         )
         allow(pohandler_results).to receive(:add_result).with(any_args)
-        allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+        allow(AuditResults).to receive(:new).and_return(pohandler_results)
         c2m.check_catalog_version
       end
 
@@ -180,22 +180,22 @@ RSpec.describe CatalogToMoab do
           expect(new_status).to eq PreservedCopy::INVALID_MOAB_STATUS
         end
         it 'adds an INVALID_MOAB result' do
-          pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)
+          pohandler_results = instance_double(AuditResults, report_results: nil)
           expect(pohandler_results).to receive(:add_result).with(
-            PreservedObjectHandlerResults::INVALID_MOAB, anything
+            AuditResults::INVALID_MOAB, anything
           )
           allow(pohandler_results).to receive(:add_result).with(any_args)
-          allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+          allow(AuditResults).to receive(:new).and_return(pohandler_results)
           c2m.check_catalog_version
         end
       end
       it 'adds a PC_STATUS_CHANGED result' do
-        pohandler_results = instance_double(PreservedObjectHandlerResults, report_results: nil)
+        pohandler_results = instance_double(AuditResults, report_results: nil)
         expect(pohandler_results).to receive(:add_result).with(
-          PreservedObjectHandlerResults::PC_STATUS_CHANGED, a_hash_including(:old_status, :new_status)
+          AuditResults::PC_STATUS_CHANGED, a_hash_including(:old_status, :new_status)
         )
         allow(pohandler_results).to receive(:add_result).with(any_args)
-        allow(PreservedObjectHandlerResults).to receive(:new).and_return(pohandler_results)
+        allow(AuditResults).to receive(:new).and_return(pohandler_results)
         c2m.check_catalog_version
       end
     end

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe PreservedObjectHandler do
             expect(results.size).to eq 2
           end
           it 'VERSION_MATCHES results' do
-            code = PreservedObjectHandlerResults::VERSION_MATCHES
+            code = AuditResults::VERSION_MATCHES
             expect(results).to include(a_hash_including(code => version_matches_pc_msg))
             expect(results).to include(a_hash_including(code => version_matches_po_msg))
           end
@@ -222,7 +222,7 @@ RSpec.describe PreservedObjectHandler do
               expect(results.size).to eq 2
             end
             it 'ARG_VERSION_GREATER_THAN_DB_OBJECT results' do
-              code = PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT
+              code = AuditResults::ARG_VERSION_GREATER_THAN_DB_OBJECT
               expect(results).to include(a_hash_including(code => version_gt_pc_msg))
               expect(results).to include(a_hash_including(code => version_gt_po_msg))
             end
@@ -336,12 +336,12 @@ RSpec.describe PreservedObjectHandler do
               expect(results.size).to eq 4
             end
             it 'ARG_VERSION_GREATER_THAN_DB_OBJECT results' do
-              code = PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT
+              code = AuditResults::ARG_VERSION_GREATER_THAN_DB_OBJECT
               expect(results).to include(a_hash_including(code => version_gt_pc_msg))
               expect(results).to include(a_hash_including(code => version_gt_po_msg))
             end
             it 'INVALID_MOAB result' do
-              expect(results).to include(a_hash_including(PreservedObjectHandlerResults::INVALID_MOAB))
+              expect(results).to include(a_hash_including(AuditResults::INVALID_MOAB))
             end
             it 'what results/logging desired for incoming version > catalog and invalid moab' do
               skip 'we need clarification of requirements on results/logging in this case'
@@ -400,7 +400,7 @@ RSpec.describe PreservedObjectHandler do
 
       context 'db update error' do
         context 'ActiveRecordError' do
-          let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
+          let(:result_code) { AuditResults::DB_UPDATE_FAILED }
           let(:incoming_version) { 2 }
 
           let(:results) do
@@ -553,18 +553,18 @@ RSpec.describe PreservedObjectHandler do
               skip 'need to get requirements on what exactly we want in results'
             end
             it 'OBJECT_DOES_NOT_EXIST results' do
-              code = PreservedObjectHandlerResults::OBJECT_DOES_NOT_EXIST
+              code = AuditResults::OBJECT_DOES_NOT_EXIST
               expect(results).to include(a_hash_including(code => exp_po_not_exist_msg))
             end
             it 'CREATED_NEW_OBJECT result' do
-              code = PreservedObjectHandlerResults::CREATED_NEW_OBJECT
+              code = AuditResults::CREATED_NEW_OBJECT
               expect(results).to include(a_hash_including(code => exp_obj_created_msg))
             end
           end
 
           context 'db update error' do
             context 'ActiveRecordError' do
-              let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
+              let(:result_code) { AuditResults::DB_UPDATE_FAILED }
               let(:results) do
                 allow(Rails.logger).to receive(:log)
                 # FIXME: couldn't figure out how to put next line into its own test
@@ -675,22 +675,22 @@ RSpec.describe PreservedObjectHandler do
               skip 'need to get requirements on what exactly we want in results'
             end
             it 'INVALID_MOAB result' do
-              code = PreservedObjectHandlerResults::INVALID_MOAB
+              code = AuditResults::INVALID_MOAB
               expect(results).to include(a_hash_including(code => exp_moab_errs_msg))
             end
             it 'OBJECT_DOES_NOT_EXIST results' do
-              code = PreservedObjectHandlerResults::OBJECT_DOES_NOT_EXIST
+              code = AuditResults::OBJECT_DOES_NOT_EXIST
               expect(results).to include(a_hash_including(code => exp_po_not_exist_msg))
             end
             it 'CREATED_NEW_OBJECT result' do
-              code = PreservedObjectHandlerResults::CREATED_NEW_OBJECT
+              code = AuditResults::CREATED_NEW_OBJECT
               expect(results).to include(a_hash_including(code => exp_obj_created_msg))
             end
           end
 
           context 'db update error' do
             context 'ActiveRecordError' do
-              let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
+              let(:result_code) { AuditResults::DB_UPDATE_FAILED }
               let(:results) do
                 allow(Rails.logger).to receive(:log)
                 # FIXME: couldn't figure out how to put next line into its own test

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe PreservedObjectHandler do
         PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
         po_handler = described_class.new(druid, 3, incoming_size, diff_ep)
         results = po_handler.confirm_version
-        code = PreservedObjectHandlerResults::OBJECT_DOES_NOT_EXIST
+        code = AuditResults::OBJECT_DOES_NOT_EXIST
         exp_str = "ActiveRecord::RecordNotFound: Couldn't find PreservedCopy> db object does not exist"
         expect(results).to include(a_hash_including(code => a_string_matching(exp_str)))
         expect(PreservedObject.find_by(druid: druid).current_version).to eq 2
@@ -111,7 +111,7 @@ RSpec.describe PreservedObjectHandler do
             expect(results.size).to eq 2
           end
           it 'VERSION_MATCHES results' do
-            code = PreservedObjectHandlerResults::VERSION_MATCHES
+            code = AuditResults::VERSION_MATCHES
             expect(results).to include(a_hash_including(code => version_matches_pc_msg))
             expect(results).to include(a_hash_including(code => version_matches_po_msg))
           end
@@ -217,11 +217,11 @@ RSpec.describe PreservedObjectHandler do
             expect(results.size).to eq 2
           end
           it 'UNEXPECTED_VERSION PreservedCopy result' do
-            code = PreservedObjectHandlerResults::UNEXPECTED_VERSION
+            code = AuditResults::UNEXPECTED_VERSION
             expect(results).to include(a_hash_including(code => unexpected_version_pc_msg))
           end
           it "PC_STATUS_CHANGED PreservedCopy result" do
-            code = PreservedObjectHandlerResults::PC_STATUS_CHANGED
+            code = AuditResults::PC_STATUS_CHANGED
             expect(results).to include(a_hash_including(code => updated_pc_db_status_msg))
           end
         end
@@ -238,7 +238,7 @@ RSpec.describe PreservedObjectHandler do
 
       context 'db update error' do
         context 'ActiveRecordError' do
-          let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
+          let(:result_code) { AuditResults::DB_UPDATE_FAILED }
           let(:incoming_version) { 2 }
           let(:results) do
 
@@ -259,7 +259,7 @@ RSpec.describe PreservedObjectHandler do
           end
 
           it 'DB_UPDATE_FAILED error' do
-            expect(results).to include(a_hash_including(PreservedObjectHandlerResults::DB_UPDATE_FAILED))
+            expect(results).to include(a_hash_including(AuditResults::DB_UPDATE_FAILED))
           end
         end
       end

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe PreservedObjectHandler do
       po_handler.create
       new_po_handler = described_class.new(druid, incoming_version, incoming_size, ep)
       results = new_po_handler.create
-      code = PreservedObjectHandlerResults::OBJECT_ALREADY_EXISTS
+      code = AuditResults::OBJECT_ALREADY_EXISTS
       expect(results).to include(a_hash_including(code => a_string_matching('PreservedObject db object already exists')))
     end
 
-    it_behaves_like 'calls PreservedObjectHandlerResults.report_results', :create
+    it_behaves_like 'calls AuditResults.report_results', :create
 
     context 'db update error' do
       context 'ActiveRecordError' do
@@ -53,10 +53,10 @@ RSpec.describe PreservedObjectHandler do
         end
 
         it 'DB_UPDATE_FAILED result' do
-          expect(results).to include(a_hash_including(PreservedObjectHandlerResults::DB_UPDATE_FAILED))
+          expect(results).to include(a_hash_including(AuditResults::DB_UPDATE_FAILED))
         end
         it 'does NOT get CREATED_NEW_OBJECT result' do
-          expect(results).not_to include(hash_including(PreservedObjectHandlerResults::CREATED_NEW_OBJECT))
+          expect(results).not_to include(hash_including(AuditResults::CREATED_NEW_OBJECT))
         end
       end
 
@@ -75,7 +75,7 @@ RSpec.describe PreservedObjectHandler do
         expect(result.size).to eq 1
       end
       it 'CREATED_NEW_OBJECT result' do
-        code = PreservedObjectHandlerResults::CREATED_NEW_OBJECT
+        code = AuditResults::CREATED_NEW_OBJECT
         expect(result).to include(a_hash_including(code => exp_msg))
       end
     end
@@ -88,7 +88,7 @@ RSpec.describe PreservedObjectHandler do
 
     it_behaves_like 'attributes validated', :create_after_validation
 
-    it_behaves_like 'calls PreservedObjectHandlerResults.report_results', :create_after_validation
+    it_behaves_like 'calls AuditResults.report_results', :create_after_validation
 
     context 'sets validation timestamps' do
       let(:t) { Time.current }
@@ -180,7 +180,7 @@ RSpec.describe PreservedObjectHandler do
 
       it 'includes invalid moab result' do
         results = po_handler.create_after_validation
-        code = PreservedObjectHandlerResults::INVALID_MOAB
+        code = AuditResults::INVALID_MOAB
         expect(results).to include(a_hash_including(code => a_string_matching('Invalid moab, validation errors:')))
       end
 
@@ -194,10 +194,10 @@ RSpec.describe PreservedObjectHandler do
           end
 
           it 'DB_UPDATE_FAILED result' do
-            expect(results).to include(a_hash_including(PreservedObjectHandlerResults::DB_UPDATE_FAILED))
+            expect(results).to include(a_hash_including(AuditResults::DB_UPDATE_FAILED))
           end
           it 'does NOT get CREATED_NEW_OBJECT result' do
-            expect(results).not_to include(hash_including(PreservedObjectHandlerResults::CREATED_NEW_OBJECT))
+            expect(results).not_to include(hash_including(AuditResults::CREATED_NEW_OBJECT))
           end
         end
 
@@ -219,7 +219,7 @@ RSpec.describe PreservedObjectHandler do
         expect(result.size).to eq 1
       end
       it 'CREATED_NEW_OBJECT result' do
-        code = PreservedObjectHandlerResults::CREATED_NEW_OBJECT
+        code = AuditResults::CREATED_NEW_OBJECT
         expect(result).to include(a_hash_including(code => exp_msg))
       end
     end

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe PreservedObjectHandler do
     end
 
     context 'ActiveRecordError gives DB_UPDATE_FAILED error with rich details' do
-      let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
+      let(:result_code) { AuditResults::DB_UPDATE_FAILED }
       let(:results) do
         allow(PreservedObject).to receive(:create!).with(hash_including(druid: druid))
                                                    .and_raise(ActiveRecord::ActiveRecordError, 'specific_err_msg')

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe PreservedObjectHandler do
             expect(results.size).to eq 2
           end
           it 'ARG_VERSION_GREATER_THAN_DB_OBJECT results' do
-            code = PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT
+            code = AuditResults::ARG_VERSION_GREATER_THAN_DB_OBJECT
             expect(results).to include(a_hash_including(code => version_gt_pc_msg))
             expect(results).to include(a_hash_including(code => version_gt_po_msg))
           end
@@ -128,7 +128,7 @@ RSpec.describe PreservedObjectHandler do
       end
 
       context 'db update error' do
-        let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
+        let(:result_code) { AuditResults::DB_UPDATE_FAILED }
 
         context 'PreservedCopy' do
           context 'ActiveRecordError' do
@@ -487,7 +487,7 @@ RSpec.describe PreservedObjectHandler do
         end
 
         context 'db update error' do
-          let(:result_code) { PreservedObjectHandlerResults::DB_UPDATE_FAILED }
+          let(:result_code) { AuditResults::DB_UPDATE_FAILED }
 
           context 'PreservedCopy' do
             context 'ActiveRecordError' do

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -19,10 +19,10 @@ RSpec.shared_examples "attributes validated" do |method_sym|
       expect(result.size).to eq 1
     end
     it 'INVALID_ARGUMENTS' do
-      expect(result).to include(a_hash_including(PreservedObjectHandlerResults::INVALID_ARGUMENTS))
+      expect(result).to include(a_hash_including(AuditResults::INVALID_ARGUMENTS))
     end
     context 'result message includes' do
-      let(:msg) { result.first[PreservedObjectHandlerResults::INVALID_ARGUMENTS] }
+      let(:msg) { result.first[AuditResults::INVALID_ARGUMENTS] }
       let(:exp_msg_prefix) { "PreservedObjectHandler(#{bad_druid}, #{bad_version}, #{bad_size}, #{bad_endpoint.endpoint_name if bad_endpoint})" }
 
       it "prefix" do
@@ -69,12 +69,12 @@ RSpec.shared_examples "attributes validated" do |method_sym|
   end
 end
 
-RSpec.shared_examples 'calls PreservedObjectHandlerResults.report_results' do |method_sym|
+RSpec.shared_examples 'calls AuditResults.report_results' do |method_sym|
   it '' do
-    mock_results = instance_double(PreservedObjectHandlerResults)
+    mock_results = instance_double(AuditResults)
     allow(mock_results).to receive(:add_result)
     expect(mock_results).to receive(:report_results)
-    expect(PreservedObjectHandlerResults).to receive(:new).and_return(mock_results)
+    expect(AuditResults).to receive(:new).and_return(mock_results)
     po_handler.send(method_sym)
   end
 end
@@ -90,7 +90,7 @@ RSpec.shared_examples 'druid not in catalog' do |method_sym|
   end
 
   it 'OBJECT_DOES_NOT_EXIST error' do
-    code = PreservedObjectHandlerResults::OBJECT_DOES_NOT_EXIST
+    code = AuditResults::OBJECT_DOES_NOT_EXIST
     expect(results).to include(a_hash_including(code => a_string_matching(escaped_exp_msg)))
   end
 end
@@ -115,7 +115,7 @@ RSpec.shared_examples 'PreservedCopy does not exist' do |method_sym|
   end
 
   it 'OBJECT_DOES_NOT_EXIST error' do
-    code = PreservedObjectHandlerResults::OBJECT_DOES_NOT_EXIST
+    code = AuditResults::OBJECT_DOES_NOT_EXIST
     expect(results).to include(a_hash_including(code => exp_msg))
   end
 end
@@ -199,15 +199,15 @@ RSpec.shared_examples 'unexpected version' do |method_sym, incoming_version|
       expect(results.size).to eq 4
     end
     it 'UNEXPECTED_VERSION result' do
-      code = PreservedObjectHandlerResults::UNEXPECTED_VERSION
+      code = AuditResults::UNEXPECTED_VERSION
       expect(results).to include(a_hash_including(code => unexpected_version_msg))
     end
     it 'specific version results' do
       # NOTE this is not checking that we have the CORRECT specific code
       codes = [
-        PreservedObjectHandlerResults::VERSION_MATCHES,
-        PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT,
-        PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT
+        AuditResults::VERSION_MATCHES,
+        AuditResults::ARG_VERSION_GREATER_THAN_DB_OBJECT,
+        AuditResults::ARG_VERSION_LESS_THAN_DB_OBJECT
       ]
       obj_version_results = results.select { |r| codes.include?(r.keys.first) }
       msgs = obj_version_results.map { |r| r.values.first }
@@ -216,11 +216,11 @@ RSpec.shared_examples 'unexpected version' do |method_sym, incoming_version|
     end
     if method_sym == :update_version
       it 'PC_STATUS_CHANGED result' do
-        expect(results).to include(a_hash_including(PreservedObjectHandlerResults::PC_STATUS_CHANGED))
+        expect(results).to include(a_hash_including(AuditResults::PC_STATUS_CHANGED))
       end
     else
       it 'no PC_STATUS_CHANGED result' do
-        expect(results).not_to include(a_hash_including(PreservedObjectHandlerResults::PC_STATUS_CHANGED))
+        expect(results).not_to include(a_hash_including(AuditResults::PC_STATUS_CHANGED))
       end
     end
   end
@@ -313,27 +313,27 @@ RSpec.shared_examples 'unexpected version with validation' do |method_sym, incom
     end
     if method_sym == :update_version_after_validation
       it 'UNEXPECTED_VERSION result unless INVALID_MOAB' do
-        unless results.find { |r| r.keys.first == PreservedObjectHandlerResults::INVALID_MOAB }
-          code = PreservedObjectHandlerResults::UNEXPECTED_VERSION
+        unless results.find { |r| r.keys.first == AuditResults::INVALID_MOAB }
+          code = AuditResults::UNEXPECTED_VERSION
           expect(results).to include(a_hash_including(code => unexpected_version_msg))
         end
       end
     end
     it 'specific version results' do
       codes = [
-        PreservedObjectHandlerResults::VERSION_MATCHES,
-        PreservedObjectHandlerResults::ARG_VERSION_GREATER_THAN_DB_OBJECT,
-        PreservedObjectHandlerResults::ARG_VERSION_LESS_THAN_DB_OBJECT
+        AuditResults::VERSION_MATCHES,
+        AuditResults::ARG_VERSION_GREATER_THAN_DB_OBJECT,
+        AuditResults::ARG_VERSION_LESS_THAN_DB_OBJECT
       ]
       obj_version_results = results.select { |r| codes.include?(r.keys.first) }
       msgs = obj_version_results.map { |r| r.values.first }
-      unless results.find { |r| r.keys.first == PreservedObjectHandlerResults::INVALID_MOAB }
+      unless results.find { |r| r.keys.first == AuditResults::INVALID_MOAB }
         expect(msgs).to include(a_string_matching("PreservedObject"))
         expect(msgs).to include(a_string_matching("PreservedCopy"))
       end
     end
     it 'PC_STATUS_CHANGED result' do
-      expect(results).to include(a_hash_including(PreservedObjectHandlerResults::PC_STATUS_CHANGED => updated_status_msg_regex))
+      expect(results).to include(a_hash_including(AuditResults::PC_STATUS_CHANGED => updated_status_msg_regex))
     end
   end
 end
@@ -397,11 +397,11 @@ RSpec.shared_examples 'update for invalid moab' do |method_sym|
       expect(results.size).to eq 2
     end
     it 'INVALID_MOAB result' do
-      code = PreservedObjectHandlerResults::INVALID_MOAB
+      code = AuditResults::INVALID_MOAB
       expect(results).to include(hash_including(code => invalid_moab_msg))
     end
     it 'PC_STATUS_CHANGED result' do
-      expect(results).to include(a_hash_including(PreservedObjectHandlerResults::PC_STATUS_CHANGED => updated_status_msg_regex))
+      expect(results).to include(a_hash_including(AuditResults::PC_STATUS_CHANGED => updated_status_msg_regex))
     end
   end
 end
@@ -438,7 +438,7 @@ RSpec.shared_examples 'PreservedObject current_version does not match online PC 
       expect(results.size).to eq 1
     end
     it 'PC_PO_VERSION_MISMATCH result' do
-      code = PreservedObjectHandlerResults::PC_PO_VERSION_MISMATCH
+      code = AuditResults::PC_PO_VERSION_MISMATCH
       expect(results).to include(hash_including(code => version_mismatch_msg))
     end
   end


### PR DESCRIPTION
~~WIP: to be reviewed after #530 is merged~~

AuditResults is the new name for PreservedObjectHandlerResults

Closes #512