### PR TITLE
(CV) PreservedCopy scopes: fixity_check_expired, and related minor refactoring

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -170,6 +170,7 @@ RSpec/NestedGroups:
   Exclude:
     - 'spec/lib/audit/catalog_to_moab_instance_spec.rb'
     - 'spec/lib/audit/moab_to_catalog_spec.rb'
+    - 'spec/models/preserved_copy_spec.rb'
     - 'spec/services/audit_results_spec.rb'
     - 'spec/services/preserved_object_handler_check_exist_spec.rb'
     - 'spec/services/preserved_object_handler_confirm_version_spec.rb'

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -38,6 +38,21 @@ class PreservedCopy < ApplicationRecord
       .where(endpoints: { storage_location: storage_dir })
       .where('last_version_audit IS NULL or last_version_audit < ?', last_checked_b4_date)
       .order('last_version_audit IS NOT NULL, last_version_audit ASC')
+    # possibly counter-intuitive: the .order sorts so that null values come first (because IS NOT NULL evaluates
+    # to 0 for nulls, which sorts before 1 for non-nulls, which are then sorted by last_version_audit)
+  }
+
+  scope :fixity_check_expired, lambda {
+    joins(:preserved_object)
+      .joins(
+        'INNER JOIN preservation_policies'\
+        ' ON preservation_policies.id = preserved_objects.preservation_policy_id'\
+        ' AND (last_checksum_validation + (fixity_ttl * INTERVAL \'1 SECOND\')) < CURRENT_TIMESTAMP'\
+        ' OR last_checksum_validation IS NULL'
+      )
+      .order('last_checksum_validation IS NOT NULL, last_checksum_validation ASC')
+    # possibly counter-intuitive: the .order sorts so that null values come first (because IS NOT NULL evaluates
+    # to 0 for nulls, which sorts before 1 for non-nulls, which are then sorted by last_version_audit)
   }
 
   def update_audit_timestamps(moab_validated, version_audited)

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -32,6 +32,10 @@ class PreservedCopy < ApplicationRecord
   validates :status, inclusion: { in: statuses.keys }
   validates :version, presence: true
 
+  scope :by_storage_location, lambda { |storage_dir|
+    joins(:endpoint).where(endpoints: { storage_location: storage_dir })
+  }
+
   scope :least_recent_version_audit, lambda { |last_checked_b4_date, storage_dir|
     last_checked_b4_date = normalize_date(last_checked_b4_date)
     joins(:endpoint)

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -36,11 +36,9 @@ class PreservedCopy < ApplicationRecord
     joins(:endpoint).where(endpoints: { storage_location: storage_dir })
   }
 
-  scope :least_recent_version_audit, lambda { |last_checked_b4_date, storage_dir|
+  scope :least_recent_version_audit, lambda { |last_checked_b4_date|
     last_checked_b4_date = normalize_date(last_checked_b4_date)
-    joins(:endpoint)
-      .where(endpoints: { storage_location: storage_dir })
-      .where('last_version_audit IS NULL or last_version_audit < ?', last_checked_b4_date)
+    where('last_version_audit IS NULL or last_version_audit < ?', last_checked_b4_date)
       .order('last_version_audit IS NOT NULL, last_version_audit ASC')
     # possibly counter-intuitive: the .order sorts so that null values come first (because IS NOT NULL evaluates
     # to 0 for nulls, which sorts before 1 for non-nulls, which are then sorted by last_version_audit)

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -32,6 +32,10 @@ class PreservedCopy < ApplicationRecord
   validates :status, inclusion: { in: statuses.keys }
   validates :version, presence: true
 
+  scope :by_endpoint_name, lambda { |endpoint_name|
+    joins(:endpoint).where(endpoints: { endpoint_name: endpoint_name })
+  }
+
   scope :by_storage_location, lambda { |storage_dir|
     joins(:endpoint).where(endpoints: { storage_location: storage_dir })
   }

--- a/spec/lib/audit/catalog_to_moab_class_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_class_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe CatalogToMoab do
         # and we are ensuring that we call #check_catalog_version on all 3 objects.
 
         # we must set up all the described_class instance objects ahead of any process calling CatalogToMoab.new
-        pcs_from_scope = PreservedCopy.least_recent_version_audit(last_checked_version_b4_date, storage_dir)
+        pcs_from_scope =
+          PreservedCopy.least_recent_version_audit(last_checked_version_b4_date).by_storage_location(storage_dir)
         c2m_list = pcs_from_scope.map do |pc|
           described_class.new(pc, storage_dir)
         end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe PreservedCopy, type: :model do
-  let!(:endpoint) { Endpoint.first }
+  let(:endpoint) { Endpoint.find_by(endpoint_name: 'fixture_sr1') }
   let!(:preserved_object) do
     policy_id = PreservationPolicy.default_policy.id
     PreservedObject.create!(druid: 'ab123cd4567', current_version: 1, preservation_policy_id: policy_id)
@@ -314,6 +314,14 @@ RSpec.describe PreservedCopy, type: :model do
     it 'returns no PreservedCopies with timestamps indicating still-valid fixity check' do
       expect(pcs_ordered_by_query).not_to include recently_checked_pc1
       expect(pcs_ordered_by_query).not_to include recently_checked_pc2
+    end
+  end
+
+  context '.by_storage_location' do
+    it 'returns the expected preserved copies' do
+      expect(PreservedCopy.by_storage_location('spec/fixtures/storage_root01/moab_storage_trunk').length).to eq 1
+      expect(PreservedCopy.by_storage_location('spec/fixtures/storage_root02/moab_storage_trunk').length).to eq 0
+      expect(PreservedCopy.by_storage_location('spec/fixtures/empty/moab_storage_trunk').length).to eq 0
     end
   end
 end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe PreservedCopy, type: :model do
     end
   end
 
-  context '.least_recent_version_audit(last_checked_b4_date, storage_dir)' do
+  context '.least_recent_version_audit(last_checked_b4_date)' do
     let!(:newer_timestamp_pc) do
       PreservedCopy.create!(
         preserved_object_id: preserved_object.id,
@@ -226,7 +226,7 @@ RSpec.describe PreservedCopy, type: :model do
       )
     end
     let!(:nil_timestamp_pc) { preserved_copy }
-    let!(:pcs_ordered_by_query) { PreservedCopy.least_recent_version_audit(Time.now.utc, endpoint.storage_location) }
+    let!(:pcs_ordered_by_query) { PreservedCopy.least_recent_version_audit(Time.now.utc) }
 
     it 'returns PreservedCopies with nils first, then old to new timestamps' do
       expect(pcs_ordered_by_query).to eq [nil_timestamp_pc, older_timestamp_pc, newer_timestamp_pc]

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -317,6 +317,14 @@ RSpec.describe PreservedCopy, type: :model do
     end
   end
 
+  context '.by_endpoint_name' do
+    it 'returns the expected preserved copies' do
+      expect(PreservedCopy.by_endpoint_name('fixture_sr1').length).to eq 1
+      expect(PreservedCopy.by_endpoint_name('fixture_sr2').length).to eq 0
+      expect(PreservedCopy.by_endpoint_name('fixture_empty').length).to eq 0
+    end
+  end
+
   context '.by_storage_location' do
     it 'returns the expected preserved copies' do
       expect(PreservedCopy.by_storage_location('spec/fixtures/storage_root01/moab_storage_trunk').length).to eq 1
@@ -369,6 +377,20 @@ RSpec.describe PreservedCopy, type: :model do
           size: 1,
           last_checksum_validation: (Time.now.utc - 1.day)
         )
+      end
+
+      context '.by_endpoint_name' do
+        let(:pcs_ordered_by_query1) { PreservedCopy.fixity_check_expired.by_endpoint_name('fixture_sr1') }
+        let(:pcs_ordered_by_query2) { PreservedCopy.fixity_check_expired.by_endpoint_name('fixture_sr2') }
+
+        it 'returns PreservedCopies with nils first, then old to new timestamps, only for the chosen storage root' do
+          expect(pcs_ordered_by_query1).to eq [never_checked_pc, checked_before_threshold_pc1]
+          expect(pcs_ordered_by_query2).to eq [checked_before_threshold_pc2]
+        end
+        it 'returns no PreservedCopies with timestamps indicating fixity check in the last week' do
+          expect(pcs_ordered_by_query1).not_to include recently_checked_pc1
+          expect(pcs_ordered_by_query2).not_to include recently_checked_pc2
+        end
       end
 
       context '.by_storage_location' do


### PR DESCRIPTION
~~on hold for a bit since we aren't working on checksum validation quite yet (i just happened to be playing with scopes and this query at the end of the day last friday).  just making a PR so we can easily link the branch to the issue it addresses.~~

adds `fixity_check_expired`, and a couple utility scopes for filtering pres copies by endpoint.  also refactors an existing scope to use the new endpoint filter scope (`by_storage_location`) instead of taking a storage location param itself.

closes #515