### PR TITLE
Turn Rails.logger.warn to Rails.logger.error in workflow_errors_reporter

### DIFF
--- a/app/services/workflow_errors_reporter.rb
+++ b/app/services/workflow_errors_reporter.rb
@@ -10,11 +10,11 @@ class WorkflowErrorsReporter
         Rails.logger.debug("#{druid} - sent error to workflow service for preservationAuditWF #{process_name}")
       else
         # Note: status == 400 will be handled by the rescue clause
-        Rails.logger.warn("#{druid} - unable to update workflow for preservationAuditWF #{process_name}: #{response.body}. Error message: #{error_message}")
+        Rails.logger.error("#{druid} - unable to update workflow for preservationAuditWF #{process_name}: #{response.body}. Error message: #{error_message}")
       end
     end
   rescue StandardError => e
-    Rails.logger.warn("#{druid} - unable to update workflow for preservationAuditWF #{process_name} #{e.inspect}. Error message: #{error_message}")
+    Rails.logger.error("#{druid} - unable to update workflow for preservationAuditWF #{process_name} #{e.inspect}. Error message: #{error_message}")
   end
 
   private_class_method def self.http_workflow_request(druid, process_name, error_message)

--- a/spec/services/workflow_errors_reporter_spec.rb
+++ b/spec/services/workflow_errors_reporter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe WorkflowErrorsReporter do
         .with(body: body,
               headers: headers)
         .to_return(status: 400, body: "", headers: {})
-      expect(Rails.logger).to receive(:warn).with("#{druid} - unable to update workflow for preservationAuditWF moab-valid #<Faraday::ClientError response={:status=>400, :headers=>{}, :body=>\"\"}>. Error message: Invalid moab, validation error...ential version directories.")
+      expect(Rails.logger).to receive(:error).with("#{druid} - unable to update workflow for preservationAuditWF moab-valid #<Faraday::ClientError response={:status=>400, :headers=>{}, :body=>\"\"}>. Error message: Invalid moab, validation error...ential version directories.")
       described_class.update_workflow(druid, 'moab-valid', result)
     end
 


### PR DESCRIPTION
Only needs 1 set of eyes. 

Rails.logger.warn to Rails.logger.error, so we can get notified when these requests don't go through. They shouldn't happen often.

closes #502 