### PR TITLE
Remove duplicate checksum validation failure statuses

### DIFF
--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -5,7 +5,7 @@ class PreservedCopy < ApplicationRecord
   INVALID_MOAB_STATUS = 'invalid_moab'.freeze
   INVALID_CHECKSUM_STATUS = 'invalid_checksum'.freeze
   ONLINE_MOAB_NOT_FOUND_STATUS = 'online_moab_not_found'.freeze
-  EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS = 'unexpected_version_on_storage'.freeze
+  UNEXPECTED_VERSION_ON_STORAGE_STATUS = 'unexpected_version_on_storage'.freeze
   VALIDITY_UNKNOWN_STATUS = 'validity_unknown'.freeze
 
   # NOTE:  DO NOT change the underlying constants for enum values that have been merged to
@@ -15,7 +15,7 @@ class PreservedCopy < ApplicationRecord
     INVALID_MOAB_STATUS => 1,
     INVALID_CHECKSUM_STATUS => 2,
     ONLINE_MOAB_NOT_FOUND_STATUS => 3,
-    EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS => 4,
+    UNEXPECTED_VERSION_ON_STORAGE_STATUS => 4,
     VALIDITY_UNKNOWN_STATUS => 6
   }
 

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -10,6 +10,9 @@ class PreservedCopy < ApplicationRecord
 
   # NOTE:  DO NOT change the underlying constants for enum values that have been merged to
   # master/used in prod db (or at least, consider the necessary migration)
+  # If an enum value is removed, it's probably easiest to just not re-use the underlying int code it used before.
+  # Just add new statuses using the next highest unused int value, and treat the numbering as an increasing
+  # sequence that will likely have holes.
   enum status: {
     OK_STATUS => 0,
     INVALID_MOAB_STATUS => 1,

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -5,7 +5,7 @@ class PreservedCopy < ApplicationRecord
   INVALID_MOAB_STATUS = 'invalid_moab'.freeze
   INVALID_CHECKSUM_STATUS = 'invalid_checksum'.freeze
   ONLINE_MOAB_NOT_FOUND_STATUS = 'online_moab_not_found'.freeze
-  EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS = 'expected_vers_not_found_on_storage'.freeze
+  EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS = 'unexpected_version_on_storage'.freeze
   VALIDITY_UNKNOWN_STATUS = 'validity_unknown'.freeze
 
   # NOTE:  DO NOT change the underlying constants for enum values that have been merged to

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -6,7 +6,6 @@ class PreservedCopy < ApplicationRecord
   INVALID_CHECKSUM_STATUS = 'invalid_checksum'.freeze
   ONLINE_MOAB_NOT_FOUND_STATUS = 'online_moab_not_found'.freeze
   EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS = 'expected_vers_not_found_on_storage'.freeze
-  FIXITY_CHECK_FAILED_STATUS = 'fixity_check_failed'.freeze
   VALIDITY_UNKNOWN_STATUS = 'validity_unknown'.freeze
 
   # NOTE:  DO NOT change the underlying constants for enum values that have been merged to
@@ -17,7 +16,6 @@ class PreservedCopy < ApplicationRecord
     INVALID_CHECKSUM_STATUS => 2,
     ONLINE_MOAB_NOT_FOUND_STATUS => 3,
     EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS => 4,
-    FIXITY_CHECK_FAILED_STATUS => 5,
     VALIDITY_UNKNOWN_STATUS => 6
   }
 

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -283,8 +283,6 @@ class PreservedObjectHandler
 
     # TODO: do the check that'd set INVALID_CHECKSUM_STATUS
 
-    # TODO: do the check that'd set FIXITY_CHECK_FAILED_STATUS
-
     update_status(pres_copy, PreservedCopy::OK_STATUS)
   end
 

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -236,7 +236,7 @@ class PreservedObjectHandler
         pres_object.save!
       else
         if set_status_to_unexp_version
-          status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
         end
         update_pc_unexpected_version(pres_copy, pres_object, status)
       end
@@ -277,7 +277,7 @@ class PreservedObjectHandler
     end
 
     unless found_expected_version
-      update_status(pres_copy, PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS)
+      update_status(pres_copy, PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS)
       return
     end
 

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -148,7 +148,7 @@ class CatalogToMoab
     end
 
     unless found_expected_version
-      update_status(PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS)
+      update_status(PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS)
       return
     end
 

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -154,8 +154,6 @@ class CatalogToMoab
 
     # TODO: do the check that'd set INVALID_CHECKSUM_STATUS
 
-    # TODO: do the check that'd set FIXITY_CHECK_FAILED_STATUS
-
     update_status(PreservedCopy::OK_STATUS)
   end
 end

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe CatalogToMoab do
           PreservedCopy::OK_STATUS,
           PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
           PreservedCopy::INVALID_MOAB_STATUS,
-          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
         ].each do |orig_status|
           it "had #{orig_status}, should now have ONLINE_MOAB_NOT_FOUND_STATUS" do
             pres_copy.status = orig_status
@@ -142,7 +142,7 @@ RSpec.describe CatalogToMoab do
           PreservedCopy::OK_STATUS,
           PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
           PreservedCopy::INVALID_MOAB_STATUS,
-          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
         ].each do |orig_status|
           it "had #{orig_status}, should now have OK_STATUS" do
             pres_copy.status = orig_status
@@ -159,7 +159,7 @@ RSpec.describe CatalogToMoab do
           PreservedCopy::VALIDITY_UNKNOWN_STATUS,
           PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
           PreservedCopy::INVALID_MOAB_STATUS,
-          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
         ].each do |orig_status|
           it "had #{orig_status}, should now have INVALID_MOAB_STATUS" do
             pres_copy.status = orig_status
@@ -203,7 +203,7 @@ RSpec.describe CatalogToMoab do
           PreservedCopy::OK_STATUS,
           PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
           PreservedCopy::INVALID_MOAB_STATUS,
-          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
         ].each do |orig_status|
           it "had #{orig_status}, should now have OK_STATUS" do
             pres_copy.status = orig_status
@@ -221,7 +221,7 @@ RSpec.describe CatalogToMoab do
           PreservedCopy::OK_STATUS,
           PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
           PreservedCopy::INVALID_MOAB_STATUS,
-          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
         ].each do |orig_status|
           it "had #{orig_status}, should now have INVALID_MOAB_STATUS" do
             pres_copy.status = orig_status
@@ -261,12 +261,12 @@ RSpec.describe CatalogToMoab do
         allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
         c2m.check_catalog_version
       end
-      it 'valid moab sets status to EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS' do
+      it 'valid moab sets status to UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
         orig = pres_copy.status
         c2m.check_catalog_version
         new_status = pres_copy.reload.status
         expect(new_status).not_to eq orig
-        expect(new_status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+        expect(new_status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
       end
       context 'invalid moab' do
         before do
@@ -307,14 +307,14 @@ RSpec.describe CatalogToMoab do
           PreservedCopy::OK_STATUS,
           PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
           PreservedCopy::INVALID_MOAB_STATUS,
-          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
         ].each do |orig_status|
           it "had #{orig_status}, should now have EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS" do
             pres_copy.status = orig_status
             pres_copy.save!
             allow(c2m).to receive(:moab_validation_errors).and_return([])
             c2m.check_catalog_version
-            expect(pres_copy.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+            expect(pres_copy.reload.status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
           end
         end
 
@@ -323,7 +323,7 @@ RSpec.describe CatalogToMoab do
           PreservedCopy::OK_STATUS,
           PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS,
           PreservedCopy::INVALID_MOAB_STATUS,
-          PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
         ].each do |orig_status|
           it "had #{orig_status}, should now have INVALID_MOAB_STATUS" do
             pres_copy.status = orig_status

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe PreservedCopy, type: :model do
       PreservedCopy::INVALID_MOAB_STATUS => 1,
       PreservedCopy::INVALID_CHECKSUM_STATUS => 2,
       PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS => 3,
-      PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS => 4,
+      PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS => 4,
       PreservedCopy::VALIDITY_UNKNOWN_STATUS => 6
     )
   end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe PreservedCopy, type: :model do
       PreservedCopy::INVALID_CHECKSUM_STATUS => 2,
       PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS => 3,
       PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS => 4,
-      PreservedCopy::FIXITY_CHECK_FAILED_STATUS => 5,
       PreservedCopy::VALIDITY_UNKNOWN_STATUS => 6
     )
   end

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe PreservedObjectHandler do
                 invalid_po_handler.check_existence
                 expect(invalid_pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
               end
-              it 'ensures status becomes invalid_moab from expected_vers_not_found_on_storage' do
+              it 'ensures status becomes invalid_moab from unexpected_version_on_storage' do
                 invalid_pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
                 invalid_pc.save!
                 invalid_po_handler.check_existence

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe PreservedObjectHandler do
                 expect(invalid_pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
               end
               it 'ensures status becomes invalid_moab from unexpected_version_on_storage' do
-                invalid_pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+                invalid_pc.status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
                 invalid_pc.save!
                 invalid_po_handler.check_existence
                 expect(invalid_pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
@@ -323,7 +323,7 @@ RSpec.describe PreservedObjectHandler do
         let(:druid) { 'bp628nk4868' }
         let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root02/moab_storage_trunk') }
 
-        it_behaves_like 'unexpected version with validation', :check_existence, 1, PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+        it_behaves_like 'unexpected version with validation', :check_existence, 1, PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
       end
 
       context 'PreservedCopy already has a status other than OK_STATUS' do
@@ -348,8 +348,8 @@ RSpec.describe PreservedObjectHandler do
             po_handler.check_existence
             expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
           end
-          it 'had EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS, seems to have an acceptable version now' do
-            pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          it 'had UNEXPECTED_VERSION_ON_STORAGE_STATUS, seems to have an acceptable version now' do
+            pc.status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
             pc.save!
             allow(po_handler).to receive(:moab_validation_errors).and_return([])
             po_handler.check_existence

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -119,19 +119,19 @@ RSpec.describe PreservedObjectHandler do
         context 'incoming_version > db version' do
           let(:incoming_version) { pc.version + 1 }
 
-          it 'had OK_STATUS, but is now EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS' do
+          it 'had OK_STATUS, but is now UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
             pc.status = PreservedCopy::OK_STATUS
             pc.save!
             allow(po_handler).to receive(:moab_validation_errors).and_return([])
             po_handler.confirm_version
-            expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+            expect(pc.reload.status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
           end
-          it 'had INVALID_MOAB_STATUS, structure seems to be remediated, but is now EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS' do
+          it 'had INVALID_MOAB_STATUS, structure seems to be remediated, but is now UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
             pc.status = PreservedCopy::INVALID_MOAB_STATUS
             pc.save!
             allow(po_handler).to receive(:moab_validation_errors).and_return([])
             po_handler.confirm_version
-            expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+            expect(pc.reload.status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
           end
         end
       end
@@ -160,7 +160,7 @@ RSpec.describe PreservedObjectHandler do
               it 'status to unexpected_version_on_storage' do
                 expect(pc.status).to eq PreservedCopy::OK_STATUS
                 po_handler.confirm_version
-                expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+                expect(pc.reload.status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
               end
               it 'last_version_audit' do
                 orig = Time.current
@@ -258,7 +258,7 @@ RSpec.describe PreservedObjectHandler do
       it 'calls PreservedCopy.save! (but not PreservedObject.save!) if the existing record is altered' do
         po = instance_double(PreservedObject)
         pc = instance_double(PreservedCopy)
-        status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+        status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
         allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
         allow(po).to receive(:current_version).and_return(1)
         allow(po).to receive(:save!)

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe PreservedObjectHandler do
           "#{exp_msg_prefix} actual version (1) has unexpected relationship to PreservedCopy db version; ERROR!"
         }
         let(:updated_pc_db_status_msg) {
-          "#{exp_msg_prefix} PreservedCopy status changed from ok to expected_vers_not_found_on_storage"
+          "#{exp_msg_prefix} PreservedCopy status changed from ok to unexpected_version_on_storage"
         }
 
         it_behaves_like 'calls AuditResults.report_results', :confirm_version
@@ -157,7 +157,7 @@ RSpec.describe PreservedObjectHandler do
 
           context 'PreservedCopy' do
             context 'changed' do
-              it 'status to expected_vers_not_found_on_storage' do
+              it 'status to unexpected_version_on_storage' do
                 expect(pc.status).to eq PreservedCopy::OK_STATUS
                 po_handler.confirm_version
                 expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -105,10 +105,10 @@ RSpec.shared_examples 'unexpected version' do |method_sym, actual_version|
         expect(pc.reload.last_version_audit).to be > orig
       end
       if method_sym == :update_version
-        it 'status becomes EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS' do
+        it 'status becomes UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
           orig = pc.status
           po_handler.send(method_sym)
-          expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+          expect(pc.reload.status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
           expect(pc.status).not_to eq orig
         end
       end
@@ -130,7 +130,7 @@ RSpec.shared_examples 'unexpected version' do |method_sym, actual_version|
         expect(pc.reload.last_moab_validation).to eq orig
       end
       if method_sym != :update_version
-        it 'status becomes EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS' do
+        it 'status becomes UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
           orig = pc.status
           po_handler.send(method_sym)
           expect(pc.status).to eq orig
@@ -385,15 +385,15 @@ RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, 
     po_handler.send(method_sym)
     expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
   end
-  it 'had EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS, but is now OK' do
-    pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+  it 'had UNEXPECTED_VERSION_ON_STORAGE_STATUS, but is now OK' do
+    pc.status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
     po_handler.send(method_sym)
     expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
   end
-  it 'had EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS, but is now INVALID_MOAB_STATUS' do
-    pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+  it 'had UNEXPECTED_VERSION_ON_STORAGE_STATUS, but is now INVALID_MOAB_STATUS' do
+    pc.status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }])
     po_handler.send(method_sym)
@@ -420,8 +420,8 @@ RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, 
     po_handler.send(method_sym)
     expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
   end
-  it 'had EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS, seems to have an acceptable version now' do
-    pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+  it 'had UNEXPECTED_VERSION_ON_STORAGE_STATUS, seems to have an acceptable version now' do
+    pc.status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
     po_handler.send(method_sym)
@@ -432,12 +432,12 @@ end
 RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, and incoming_version < pc.version' do |method_sym|
   let(:incoming_version) { pc.version - 1 }
 
-  it 'had OK_STATUS, but is now EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS' do
+  it 'had OK_STATUS, but is now UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
     pc.status = PreservedCopy::OK_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
     po_handler.send(method_sym)
-    expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+    expect(pc.reload.status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
   end
   it 'had OK_STATUS, but is now INVALID_MOAB_STATUS' do
     pc.status = PreservedCopy::OK_STATUS
@@ -446,19 +446,19 @@ RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, 
     po_handler.send(method_sym)
     expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
   end
-  it 'had INVALID_MOAB_STATUS, was made to a valid moab, but is now EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS' do
+  it 'had INVALID_MOAB_STATUS, was made to a valid moab, but is now UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
     pc.status = PreservedCopy::INVALID_MOAB_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
     po_handler.send(method_sym)
-    expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+    expect(pc.reload.status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
   end
-  it 'had EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS, still seeing an unexpected version' do
-    pc.status = PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+  it 'had UNEXPECTED_VERSION_ON_STORAGE_STATUS, still seeing an unexpected version' do
+    pc.status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
     po_handler.send(method_sym)
-    expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+    expect(pc.reload.status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
   end
   it 'had VALIDITY_UNKNOWN_STATUS, but is now INVALID_MOAB_STATUS' do
     pc.status = PreservedCopy::VALIDITY_UNKNOWN_STATUS
@@ -467,11 +467,11 @@ RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, 
     po_handler.send(method_sym)
     expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
   end
-  it 'had VALIDITY_UNKNOWN_STATUS, but is now EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS' do
+  it 'had VALIDITY_UNKNOWN_STATUS, but is now UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
     pc.status = PreservedCopy::VALIDITY_UNKNOWN_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
     po_handler.send(method_sym)
-    expect(pc.reload.status).to eq PreservedCopy::EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS
+    expect(pc.reload.status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
   end
 end


### PR DESCRIPTION
this is branched off of c2m-handle-pc-status-already-bad from PR #526, because that PR includes a comment that references one of the statuses being removed here (because it ripped off a method from POH that did the same, also fixed in this PR).  so we should merge that PR and rebase this one on master before merging it (hence the WIP).

closes #372