### PR TITLE
AuditResults: renamed "incoming_version" to "actual_version"

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -28,15 +28,15 @@ class AuditResults
 
   RESPONSE_CODE_TO_MESSAGES = {
     INVALID_ARGUMENTS => "encountered validation error(s): %{addl}",
-    VERSION_MATCHES => "incoming version (%{incoming_version}) matches %{addl} db version",
-    ARG_VERSION_GREATER_THAN_DB_OBJECT => "incoming version (%{incoming_version}) greater than %{addl} db version",
-    ARG_VERSION_LESS_THAN_DB_OBJECT => "incoming version (%{incoming_version}) less than %{addl} db version; ERROR!",
+    VERSION_MATCHES => "actual version (%{actual_version}) matches %{addl} db version",
+    ARG_VERSION_GREATER_THAN_DB_OBJECT => "actual version (%{actual_version}) greater than %{addl} db version",
+    ARG_VERSION_LESS_THAN_DB_OBJECT => "actual version (%{actual_version}) less than %{addl} db version; ERROR!",
     CREATED_NEW_OBJECT => "added object to db as it did not exist",
     DB_UPDATE_FAILED => "db update failed: %{addl}",
     OBJECT_ALREADY_EXISTS => "%{addl} db object already exists",
     OBJECT_DOES_NOT_EXIST => "%{addl} db object does not exist",
     PC_STATUS_CHANGED => "PreservedCopy status changed from %{old_status} to %{new_status}",
-    UNEXPECTED_VERSION => "incoming version (%{incoming_version}) has unexpected relationship to %{addl} db version; ERROR!",
+    UNEXPECTED_VERSION => "actual version (%{actual_version}) has unexpected relationship to %{addl} db version; ERROR!",
     INVALID_MOAB => "Invalid moab, validation errors: %{addl}",
     PC_PO_VERSION_MISMATCH => "PreservedCopy online moab version %{pc_version} does not match PreservedObject current_version %{po_version}",
     ONLINE_MOAB_DOES_NOT_EXIST => "db has moab that is not found online"
@@ -75,12 +75,13 @@ class AuditResults
     end
   end
 
-  attr_reader :result_array, :incoming_version, :msg_prefix, :druid
+  attr_reader :result_array, :msg_prefix, :druid
+  attr_accessor :actual_version
 
-  def initialize(druid, incoming_version, endpoint)
+  def initialize(druid, actual_version, endpoint)
     @druid = druid
-    @incoming_version = incoming_version
-    @msg_prefix = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{endpoint.endpoint_name if endpoint})"
+    @actual_version = actual_version
+    @msg_prefix = "PreservedObjectHandler(#{druid}, #{actual_version}, #{endpoint.endpoint_name if endpoint})"
     @result_array = []
   end
 
@@ -138,7 +139,7 @@ class AuditResults
   end
 
   def result_code_msg(code, addl=nil)
-    arg_hash = { incoming_version: incoming_version }
+    arg_hash = { actual_version: actual_version }
     if addl.is_a?(Hash)
       arg_hash.merge!(addl)
     else

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -77,10 +77,10 @@ class AuditResults
 
   attr_reader :result_array, :incoming_version, :msg_prefix, :druid
 
-  def initialize(druid, incoming_version, incoming_size, endpoint)
+  def initialize(druid, incoming_version, endpoint)
     @druid = druid
     @incoming_version = incoming_version
-    @msg_prefix = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{endpoint.endpoint_name if endpoint})"
+    @msg_prefix = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{endpoint.endpoint_name if endpoint})"
     @result_array = []
   end
 

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -270,9 +270,6 @@ class PreservedObjectHandler
   # given a PreservedCopy instance and whether the caller found the expected version of it on disk, this will perform
   # other validations of what's on disk, and will update the status accordingly
   def set_status_as_seen_on_disk(pres_copy, found_expected_version)
-    # TODO: when we implement C2M, we should add a check here to look for the object on disk, and set PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS
-    # if needed.  or maybe the caller will have done that already, since it needs to try reading the moab to obtain incoming_version?
-
     unless moab_validation_errors.empty?
       update_status(pres_copy, PreservedCopy::INVALID_MOAB_STATUS)
       return

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -28,7 +28,7 @@ class PreservedObjectHandler
     @incoming_version = version_string_to_int(incoming_version)
     @incoming_size = string_to_int(incoming_size)
     @endpoint = endpoint
-    @handler_results = AuditResults.new(druid, incoming_version, incoming_size, endpoint)
+    @handler_results = AuditResults.new(druid, incoming_version, endpoint)
   end
 
   def create_after_validation

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -51,7 +51,7 @@ class CatalogToMoab
     @preserved_copy = preserved_copy
     @storage_dir = storage_dir
     @druid = preserved_copy.preserved_object.druid
-    @results = AuditResults.new(druid, nil, nil, preserved_copy.endpoint)
+    @results = AuditResults.new(druid, nil, preserved_copy.endpoint)
   end
 
   # shameless green implementation

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -72,6 +72,7 @@ class CatalogToMoab
     end
 
     moab_version = moab.current_version_id
+    results.actual_version = moab_version
     catalog_version = preserved_copy.version
     if catalog_version == moab_version
       results.add_result(AuditResults::VERSION_MATCHES, preserved_copy.class.name)

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe CatalogToMoab do
     end
 
     it 'calls POHandlerResults.report_results' do
-      pohandler_results = instance_double(AuditResults, add_result: nil)
+      pohandler_results = instance_double(AuditResults, add_result: nil, :actual_version= => nil)
       allow(AuditResults).to receive(:new).and_return(pohandler_results)
       expect(pohandler_results).to receive(:report_results)
       c2m.check_catalog_version
@@ -103,7 +103,7 @@ RSpec.describe CatalogToMoab do
 
     context 'catalog version == moab version (happy path)' do
       it 'adds a VERSION_MATCHES result' do
-        pohandler_results = instance_double(AuditResults, report_results: nil)
+        pohandler_results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
         allow(AuditResults).to receive(:new).and_return(pohandler_results)
         expect(pohandler_results).to receive(:add_result).with(
           AuditResults::VERSION_MATCHES, 'PreservedCopy'
@@ -120,7 +120,7 @@ RSpec.describe CatalogToMoab do
       end
 
       it 'adds an UNEXPECTED_VERSION result' do
-        pohandler_results = instance_double(AuditResults, report_results: nil)
+        pohandler_results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
         expect(pohandler_results).to receive(:add_result).with(
           AuditResults::UNEXPECTED_VERSION, 'PreservedCopy'
         )
@@ -144,7 +144,7 @@ RSpec.describe CatalogToMoab do
       end
 
       it 'adds an UNEXPECTED_VERSION result' do
-        pohandler_results = instance_double(AuditResults, report_results: nil)
+        pohandler_results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
         expect(pohandler_results).to receive(:add_result).with(
           AuditResults::UNEXPECTED_VERSION, 'PreservedCopy'
         )
@@ -180,7 +180,7 @@ RSpec.describe CatalogToMoab do
           expect(new_status).to eq PreservedCopy::INVALID_MOAB_STATUS
         end
         it 'adds an INVALID_MOAB result' do
-          pohandler_results = instance_double(AuditResults, report_results: nil)
+          pohandler_results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
           expect(pohandler_results).to receive(:add_result).with(
             AuditResults::INVALID_MOAB, anything
           )
@@ -190,7 +190,7 @@ RSpec.describe CatalogToMoab do
         end
       end
       it 'adds a PC_STATUS_CHANGED result' do
-        pohandler_results = instance_double(AuditResults, report_results: nil)
+        pohandler_results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
         expect(pohandler_results).to receive(:add_result).with(
           AuditResults::PC_STATUS_CHANGED, a_hash_including(:old_status, :new_status)
         )

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -3,9 +3,8 @@ require 'rails_helper'
 RSpec.describe AuditResults do
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
-  let(:incoming_size) { 666 }
   let(:endpoint) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
-  let(:pohr) { described_class.new(druid, incoming_version, incoming_size, endpoint) }
+  let(:pohr) { described_class.new(druid, incoming_version, endpoint) }
 
   context '.logger_severity_level' do
     it 'PC_PO_VERSION_MISMATCH is an ERROR' do
@@ -16,7 +15,7 @@ RSpec.describe AuditResults do
 
   context '#new' do
     it 'assigns msg_prefix' do
-      exp = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{endpoint.endpoint_name})"
+      exp = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{endpoint.endpoint_name})"
       expect(pohr.msg_prefix).to eq exp
     end
     it 'sets result_array attr to []' do

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe AuditResults do
   let(:druid) { 'ab123cd4567' }
-  let(:incoming_version) { 6 }
+  let(:actual_version) { 6 }
   let(:endpoint) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
-  let(:pohr) { described_class.new(druid, incoming_version, endpoint) }
+  let(:pohr) { described_class.new(druid, actual_version, endpoint) }
 
   context '.logger_severity_level' do
     it 'PC_PO_VERSION_MISMATCH is an ERROR' do
@@ -15,7 +15,7 @@ RSpec.describe AuditResults do
 
   context '#new' do
     it 'assigns msg_prefix' do
-      exp = "PreservedObjectHandler(#{druid}, #{incoming_version}, #{endpoint.endpoint_name})"
+      exp = "PreservedObjectHandler(#{druid}, #{actual_version}, #{endpoint.endpoint_name})"
       expect(pohr.msg_prefix).to eq exp
     end
     it 'sets result_array attr to []' do
@@ -24,8 +24,8 @@ RSpec.describe AuditResults do
     it 'sets druid attr to arg' do
       expect(pohr.druid).to eq druid
     end
-    it 'sets incoming_version attr to arg' do
-      expect(pohr.incoming_version).to eq incoming_version
+    it 'sets actual_version attr to arg' do
+      expect(pohr.actual_version).to eq actual_version
     end
   end
 
@@ -134,7 +134,7 @@ RSpec.describe AuditResults do
       code = AuditResults::VERSION_MATCHES
       pohr.add_result(code, 'foo')
       expect(pohr.result_array.size).to eq 1
-      expect(pohr.result_array.first).to eq code => "#{pohr.msg_prefix} incoming version (6) matches foo db version"
+      expect(pohr.result_array.first).to eq code => "#{pohr.msg_prefix} actual version (6) matches foo db version"
     end
   end
 

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -211,9 +211,6 @@ RSpec.describe PreservedObjectHandler do
               expect(results).to include(a_hash_including(code => version_gt_pc_msg))
               expect(results).to include(a_hash_including(code => version_gt_po_msg))
             end
-            it 'what results/logging desired for incoming version > catalog' do
-              skip 'we need clarification of requirements on results/logging in this case'
-            end
           end
         end
 
@@ -319,9 +316,6 @@ RSpec.describe PreservedObjectHandler do
             end
             it 'INVALID_MOAB result' do
               expect(results).to include(a_hash_including(AuditResults::INVALID_MOAB))
-            end
-            it 'what results/logging desired for incoming version > catalog and invalid moab' do
-              skip 'we need clarification of requirements on results/logging in this case'
             end
           end
         end
@@ -509,9 +503,6 @@ RSpec.describe PreservedObjectHandler do
               expect(results).to be_an_instance_of Array
               expect(results.size).to eq 2
             end
-            it 'not sure what results we REALLY want' do
-              skip 'need to get requirements on what exactly we want in results'
-            end
             it 'OBJECT_DOES_NOT_EXIST results' do
               code = AuditResults::OBJECT_DOES_NOT_EXIST
               expect(results).to include(a_hash_including(code => exp_po_not_exist_msg))
@@ -605,9 +596,6 @@ RSpec.describe PreservedObjectHandler do
             it '3 results' do
               expect(results).to be_an_instance_of Array
               expect(results.size).to eq 3
-            end
-            it 'not sure what results we REALLY want' do
-              skip 'need to get requirements on what exactly we want in results'
             end
             it 'INVALID_MOAB result' do
               code = AuditResults::INVALID_MOAB

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PreservedObjectHandler do
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
   let(:pc) { PreservedCopy.find_by(preserved_object: po, endpoint: ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{ep.endpoint_name})" }
+  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name})" }
   let(:db_update_failed_prefix_regex_escaped) { Regexp.escape("#{exp_msg_prefix} db update failed") }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
 
@@ -32,7 +32,7 @@ RSpec.describe PreservedObjectHandler do
 
       context "incoming and db versions match" do
         let(:po_handler) { described_class.new(druid, 2, 1, ep) }
-        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, 1, #{ep.endpoint_name})" }
+        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, #{ep.endpoint_name})" }
         let(:version_matches_po_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservedObject db version" }
         let(:version_matches_pc_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservedCopy db version" }
 
@@ -100,8 +100,7 @@ RSpec.describe PreservedObjectHandler do
       end
 
       context "incoming version > db version" do
-        let(:incoming_version) { 6 }
-        let(:incoming_size) { 9876 }
+        # let(:incoming_version) { 6 }
         let(:version_gt_pc_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than PreservedCopy db version" }
         let(:version_gt_po_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than PreservedObject db version" }
 
@@ -222,7 +221,7 @@ RSpec.describe PreservedObjectHandler do
           let(:invalid_po) { PreservedObject.find_by(druid: invalid_druid) }
           let(:invalid_pc) { PreservedCopy.find_by(preserved_object: invalid_po) }
           let(:exp_msg_prefix) do
-            "PreservedObjectHandler(#{invalid_druid}, #{incoming_version}, #{incoming_size}, #{invalid_ep.endpoint_name})"
+            "PreservedObjectHandler(#{invalid_druid}, #{incoming_version}, #{invalid_ep.endpoint_name})"
           end
 
           before do
@@ -469,7 +468,7 @@ RSpec.describe PreservedObjectHandler do
         end
 
         context 'moab is valid' do
-          let(:exp_msg_prefix) { "PreservedObjectHandler(#{valid_druid}, #{incoming_version}, #{incoming_size}, #{ep.endpoint_name})" }
+          let(:exp_msg_prefix) { "PreservedObjectHandler(#{valid_druid}, #{incoming_version}, #{ep.endpoint_name})" }
 
           it 'PreservedObject created' do
             po_args = {
@@ -552,7 +551,7 @@ RSpec.describe PreservedObjectHandler do
           let(:storage_dir) { 'spec/fixtures/bad_root01/bad_moab_storage_trunk' }
           let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
           let(:invalid_druid) { 'xx000xx0000' }
-          let(:exp_msg_prefix) { "PreservedObjectHandler(#{invalid_druid}, #{incoming_version}, #{incoming_size}, #{ep.endpoint_name})" }
+          let(:exp_msg_prefix) { "PreservedObjectHandler(#{invalid_druid}, #{incoming_version}, #{ep.endpoint_name})" }
           let(:exp_moab_errs_msg) { "#{exp_msg_prefix} Invalid moab, validation errors: [\"Missing directory: [\\\"data\\\", \\\"manifests\\\"] Version: v0001\"]" }
           let(:po_handler) { described_class.new(invalid_druid, incoming_version, incoming_size, ep) }
 

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe PreservedObjectHandler do
       context "incoming and db versions match" do
         let(:po_handler) { described_class.new(druid, 2, 1, ep) }
         let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, #{ep.endpoint_name})" }
-        let(:version_matches_po_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservedObject db version" }
-        let(:version_matches_pc_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservedCopy db version" }
+        let(:version_matches_po_msg) { "#{exp_msg_prefix} actual version (2) matches PreservedObject db version" }
+        let(:version_matches_pc_msg) { "#{exp_msg_prefix} actual version (2) matches PreservedCopy db version" }
 
         context 'PreservedCopy' do
           context 'changed' do
@@ -100,9 +100,8 @@ RSpec.describe PreservedObjectHandler do
       end
 
       context "incoming version > db version" do
-        # let(:incoming_version) { 6 }
-        let(:version_gt_pc_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than PreservedCopy db version" }
-        let(:version_gt_po_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than PreservedObject db version" }
+        let(:version_gt_pc_msg) { "#{exp_msg_prefix} actual version (#{incoming_version}) greater than PreservedCopy db version" }
+        let(:version_gt_po_msg) { "#{exp_msg_prefix} actual version (#{incoming_version}) greater than PreservedObject db version" }
 
         it 'calls Stanford::StorageObjectValidator.validation_errors for moab' do
           mock_sov = instance_double(Stanford::StorageObjectValidator)

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PreservedObjectHandler do
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
   let(:pc) { PreservedCopy.find_by(preserved_object: po, endpoint: ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{ep.endpoint_name})" }
+  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name})" }
   let(:db_update_failed_prefix_regex_escaped) { Regexp.escape("#{exp_msg_prefix} db update failed") }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
 
@@ -48,7 +48,7 @@ RSpec.describe PreservedObjectHandler do
 
       context "incoming and db versions match" do
         let(:po_handler) { described_class.new(druid, 2, 1, ep) }
-        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, 1, #{ep.endpoint_name})" }
+        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, #{ep.endpoint_name})" }
         let(:version_matches_po_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservedObject db version" }
         let(:version_matches_pc_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservedCopy db version" }
 
@@ -139,7 +139,7 @@ RSpec.describe PreservedObjectHandler do
       context 'incoming version does NOT match db version' do
         let(:druid) { 'bj102hs9687' } # for shared_examples 'calls AuditResults.report_results'
         let(:po_handler) { described_class.new(druid, 1, 666, ep) }
-        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 1, 666, #{ep.endpoint_name})" }
+        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 1, #{ep.endpoint_name})" }
         let(:unexpected_version_pc_msg) {
           "#{exp_msg_prefix} incoming version (1) has unexpected relationship to PreservedCopy db version; ERROR!"
         }

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe PreservedObjectHandler do
       context "incoming and db versions match" do
         let(:po_handler) { described_class.new(druid, 2, 1, ep) }
         let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, #{ep.endpoint_name})" }
-        let(:version_matches_po_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservedObject db version" }
-        let(:version_matches_pc_msg) { "#{exp_msg_prefix} incoming version (2) matches PreservedCopy db version" }
+        let(:version_matches_po_msg) { "#{exp_msg_prefix} actual version (2) matches PreservedObject db version" }
+        let(:version_matches_pc_msg) { "#{exp_msg_prefix} actual version (2) matches PreservedCopy db version" }
 
         context 'PreservedCopy' do
           context 'changed' do
@@ -141,7 +141,7 @@ RSpec.describe PreservedObjectHandler do
         let(:po_handler) { described_class.new(druid, 1, 666, ep) }
         let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 1, #{ep.endpoint_name})" }
         let(:unexpected_version_pc_msg) {
-          "#{exp_msg_prefix} incoming version (1) has unexpected relationship to PreservedCopy db version; ERROR!"
+          "#{exp_msg_prefix} actual version (1) has unexpected relationship to PreservedCopy db version; ERROR!"
         }
         let(:updated_pc_db_status_msg) {
           "#{exp_msg_prefix} PreservedCopy status changed from ok to expected_vers_not_found_on_storage"

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PreservedObjectHandler do
   let(:incoming_size) { 9876 }
   let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
   let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{ep.endpoint_name})" }
+  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name})" }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
   let(:exp_msg) { "#{exp_msg_prefix} added object to db as it did not exist" }
 
@@ -144,7 +144,7 @@ RSpec.describe PreservedObjectHandler do
       let(:storage_dir) { 'spec/fixtures/bad_root01/bad_moab_storage_trunk' }
       let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
       let(:invalid_druid) { 'xx000xx0000' }
-      let(:exp_msg_prefix) { "PreservedObjectHandler(#{invalid_druid}, #{incoming_version}, #{incoming_size}, #{ep.endpoint_name})" }
+      let(:exp_msg_prefix) { "PreservedObjectHandler(#{invalid_druid}, #{incoming_version}, #{ep.endpoint_name})" }
       let(:po_handler) { described_class.new(invalid_druid, incoming_version, incoming_size, ep) }
 
       # add storage root with invalid moab to the Endpoints table
@@ -212,7 +212,7 @@ RSpec.describe PreservedObjectHandler do
 
     context 'returns' do
       let!(:result) { po_handler.create_after_validation }
-      let(:exp_msg_prefix) { "PreservedObjectHandler(#{valid_druid}, #{incoming_version}, #{incoming_size}, #{ep.endpoint_name})" }
+      let(:exp_msg_prefix) { "PreservedObjectHandler(#{valid_druid}, #{incoming_version}, #{ep.endpoint_name})" }
 
       it '1 result' do
         expect(result).to be_an_instance_of Array

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PreservedObjectHandler do
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
   let(:pc) { PreservedCopy.find_by(preserved_object: po, endpoint: ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{ep})" }
+  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep})" }
   let(:db_update_failed_prefix_regex_escaped) { Regexp.escape("#{exp_msg_prefix} db update failed") }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
 

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe PreservedObjectHandler do
   let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name})" }
   let(:updated_status_msg_regex) { Regexp.new(Regexp.escape("#{exp_msg_prefix} PreservedCopy status changed from")) }
   let(:db_update_failed_prefix_regex_escaped) { Regexp.escape("#{exp_msg_prefix} db update failed") }
-  let(:version_gt_pc_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than PreservedCopy db version" }
-  let(:version_gt_po_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than PreservedObject db version" }
+  let(:version_gt_pc_msg) { "#{exp_msg_prefix} actual version (#{incoming_version}) greater than PreservedCopy db version" }
+  let(:version_gt_po_msg) { "#{exp_msg_prefix} actual version (#{incoming_version}) greater than PreservedObject db version" }
 
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
 

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PreservedObjectHandler do
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
   let(:pc) { PreservedCopy.find_by(preserved_object: po, endpoint: ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{incoming_size}, #{ep.endpoint_name})" }
+  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name})" }
   let(:updated_status_msg_regex) { Regexp.new(Regexp.escape("#{exp_msg_prefix} PreservedCopy status changed from")) }
   let(:db_update_failed_prefix_regex_escaped) { Regexp.escape("#{exp_msg_prefix} db update failed") }
   let(:version_gt_pc_msg) { "#{exp_msg_prefix} incoming version (#{incoming_version}) greater than PreservedCopy db version" }

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -23,7 +23,7 @@ RSpec.shared_examples "attributes validated" do |method_sym|
     end
     context 'result message includes' do
       let(:msg) { result.first[AuditResults::INVALID_ARGUMENTS] }
-      let(:exp_msg_prefix) { "PreservedObjectHandler(#{bad_druid}, #{bad_version}, #{bad_size}, #{bad_endpoint.endpoint_name if bad_endpoint})" }
+      let(:exp_msg_prefix) { "PreservedObjectHandler(#{bad_druid}, #{bad_version}, #{bad_endpoint.endpoint_name if bad_endpoint})" }
 
       it "prefix" do
         expect(msg).to match(Regexp.escape("#{exp_msg_prefix} encountered validation error(s): "))
@@ -93,7 +93,7 @@ end
 
 RSpec.shared_examples 'unexpected version' do |method_sym, incoming_version|
   let(:po_handler) { described_class.new(druid, incoming_version, 1, ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, 1, #{ep.endpoint_name if ep})" }
+  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name if ep})" }
   let(:version_msg_prefix) { "#{exp_msg_prefix} incoming version (#{incoming_version})" }
   let(:unexpected_version_msg) { "#{version_msg_prefix} has unexpected relationship to PreservedCopy db version; ERROR!" }
 
@@ -185,7 +185,7 @@ end
 
 RSpec.shared_examples 'unexpected version with validation' do |method_sym, incoming_version, new_status|
   let(:po_handler) { described_class.new(druid, incoming_version, 1, ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, 1, #{ep.endpoint_name if ep})" }
+  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name if ep})" }
   let(:version_msg_prefix) { "#{exp_msg_prefix} incoming version (#{incoming_version})" }
   let(:unexpected_version_msg) { "#{version_msg_prefix} has unexpected relationship to PreservedCopy db version; ERROR!" }
   let(:updated_status_msg_regex) { Regexp.new(Regexp.escape("#{exp_msg_prefix} PreservedCopy status changed from")) }
@@ -347,7 +347,7 @@ end
 
 RSpec.shared_examples 'PreservedObject current_version does not match online PC version' do |method_sym, incoming_version, pc_v, po_v|
   let(:po_handler) { described_class.new(druid, incoming_version, 1, ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, 1, #{ep.endpoint_name if ep})" }
+  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name if ep})" }
   let(:version_mismatch_msg) { "#{exp_msg_prefix} PreservedCopy online moab version #{pc_v} does not match PreservedObject current_version #{po_v}" }
 
   it 'does not update PreservedCopy' do

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -91,10 +91,10 @@ RSpec.shared_examples 'PreservedCopy does not exist' do |method_sym|
   end
 end
 
-RSpec.shared_examples 'unexpected version' do |method_sym, incoming_version|
-  let(:po_handler) { described_class.new(druid, incoming_version, 1, ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name if ep})" }
-  let(:version_msg_prefix) { "#{exp_msg_prefix} incoming version (#{incoming_version})" }
+RSpec.shared_examples 'unexpected version' do |method_sym, actual_version|
+  let(:po_handler) { described_class.new(druid, actual_version, 1, ep) }
+  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{actual_version}, #{ep.endpoint_name if ep})" }
+  let(:version_msg_prefix) { "#{exp_msg_prefix} actual version (#{actual_version})" }
   let(:unexpected_version_msg) { "#{version_msg_prefix} has unexpected relationship to PreservedCopy db version; ERROR!" }
 
   context 'PreservedCopy' do
@@ -186,7 +186,7 @@ end
 RSpec.shared_examples 'unexpected version with validation' do |method_sym, incoming_version, new_status|
   let(:po_handler) { described_class.new(druid, incoming_version, 1, ep) }
   let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name if ep})" }
-  let(:version_msg_prefix) { "#{exp_msg_prefix} incoming version (#{incoming_version})" }
+  let(:version_msg_prefix) { "#{exp_msg_prefix} actual version (#{incoming_version})" }
   let(:unexpected_version_msg) { "#{version_msg_prefix} has unexpected relationship to PreservedCopy db version; ERROR!" }
   let(:updated_status_msg_regex) { Regexp.new(Regexp.escape("#{exp_msg_prefix} PreservedCopy status changed from")) }
 

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -59,8 +59,6 @@ RSpec.shared_examples 'druid not in catalog' do |method_sym|
   let(:escaped_exp_msg) { Regexp.escape(exp_msg_prefix) + ".* PreservedObject.* db object does not exist" }
   let(:results) do
     allow(Rails.logger).to receive(:log)
-    # FIXME: couldn't figure out how to put next line into its own test
-    expect(Rails.logger).to receive(:log).with(Logger::ERROR, /#{escaped_exp_msg}/)
     po_handler.send(method_sym)
   end
 
@@ -77,8 +75,6 @@ RSpec.shared_examples 'PreservedCopy does not exist' do |method_sym|
   let(:exp_msg) { "#{exp_msg_prefix} #<ActiveRecord::RecordNotFound: foo> db object does not exist" }
   let(:results) do
     allow(Rails.logger).to receive(:log)
-    # FIXME: couldn't figure out how to put next line into its own test
-    expect(Rails.logger).to receive(:log).with(Logger::ERROR, /#{Regexp.escape(exp_msg)}/)
     po = instance_double(PreservedObject)
     allow(po).to receive(:current_version).and_return(2)
     allow(po).to receive(:current_version=)


### PR DESCRIPTION
- audit_results
  - remove incoming_size as it's not doing anything for us here
  - renamed "incoming_version" to "actual_version" so it applies beyond POHandler
- removed some FIXME and TODO lines that are no longer needed -- do you agree with me?

Connects to #539