### PR TITLE
Audit results msg prefix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,11 +90,10 @@ Metrics/LineLength:
   Max: 120
   Exclude:
     - 'Rakefile' # Line length 133 for better readability
-    - 'app/services/preserved_object_handler.rb' # line 269 is 121
     - 'app/services/audit_results.rb' # line 35 is 121
+    - 'app/services/preserved_object_handler.rb' # line 269 is 121
     - 'app/services/workflow_errors_reporter.rb' # line 7 is 143
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # 1 line 126
-    - 'spec/models/status_spec.rb' # Line length of 132 for better readability
     - 'spec/services/preserved_object_handler_check_exist_spec.rb' # 17 lines, but who's counting, officer?
     - 'spec/services/preserved_object_handler_confirm_version_spec.rb'
     - 'spec/services/preserved_object_handler_create_spec.rb'

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -75,13 +75,13 @@ class AuditResults
     end
   end
 
-  attr_reader :result_array, :msg_prefix, :druid
+  attr_reader :result_array, :druid, :endpoint
   attr_accessor :actual_version
 
   def initialize(druid, actual_version, endpoint)
     @druid = druid
     @actual_version = actual_version
-    @msg_prefix = "PreservedObjectHandler(#{druid}, #{actual_version}, #{endpoint.endpoint_name if endpoint})"
+    @endpoint = endpoint
     @result_array = []
   end
 
@@ -135,7 +135,7 @@ class AuditResults
   def log_result(result)
     severity = self.class.logger_severity_level(result.keys.first)
     msg = result.values.first
-    Rails.logger.log(severity, msg)
+    Rails.logger.log(severity, "#{msg_prefix} #{msg}")
   end
 
   def result_code_msg(code, addl=nil)
@@ -146,6 +146,10 @@ class AuditResults
       arg_hash[:addl] = addl
     end
 
-    "#{msg_prefix} #{RESPONSE_CODE_TO_MESSAGES[code] % arg_hash}"
+    RESPONSE_CODE_TO_MESSAGES[code] % arg_hash
+  end
+
+  def msg_prefix
+    @msg_prefix ||= "FIXME: some-audit-check(#{druid}, #{endpoint.endpoint_name if endpoint})"
   end
 end

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -76,12 +76,13 @@ class AuditResults
   end
 
   attr_reader :result_array, :druid, :endpoint
-  attr_accessor :actual_version
+  attr_accessor :actual_version, :check_name
 
-  def initialize(druid, actual_version, endpoint)
+  def initialize(druid, actual_version, endpoint, check_name=nil)
     @druid = druid
     @actual_version = actual_version
     @endpoint = endpoint
+    @check_name = check_name
     @result_array = []
   end
 
@@ -150,6 +151,6 @@ class AuditResults
   end
 
   def msg_prefix
-    @msg_prefix ||= "FIXME: some-audit-check(#{druid}, #{endpoint.endpoint_name if endpoint})"
+    @msg_prefix ||= "#{check_name}(#{druid}, #{endpoint.endpoint_name if endpoint})"
   end
 end

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -32,6 +32,7 @@ class PreservedObjectHandler
   end
 
   def create_after_validation
+    handler_results.check_name = 'create_after_validation'
     if invalid?
       handler_results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
     elsif PreservedObject.exists?(druid: druid)
@@ -46,6 +47,7 @@ class PreservedObjectHandler
   end
 
   def create
+    handler_results.check_name = 'create'
     if invalid?
       handler_results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
     elsif PreservedObject.exists?(druid: druid)
@@ -59,6 +61,7 @@ class PreservedObjectHandler
 
   # this is a long, complex method (shameless green); if it is refactored, revisit the exceptions in rubocop.yml
   def check_existence
+    handler_results.check_name = 'check_existence'
     if invalid?
       handler_results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
     elsif PreservedObject.exists?(druid: druid)
@@ -110,6 +113,7 @@ class PreservedObjectHandler
   end
 
   def confirm_version
+    handler_results.check_name = 'confirm_version'
     if invalid?
       handler_results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
     else
@@ -126,6 +130,7 @@ class PreservedObjectHandler
   end
 
   def update_version_after_validation
+    handler_results.check_name = 'update_version_after_validation'
     if invalid?
       handler_results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
     else
@@ -147,6 +152,7 @@ class PreservedObjectHandler
   end
 
   def update_version
+    handler_results.check_name = 'update_version'
     if invalid?
       handler_results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
     else

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -56,6 +56,7 @@ class CatalogToMoab
 
   # shameless green implementation
   def check_catalog_version
+    results.check_name = 'check_catalog_version'
     unless preserved_copy.matches_po_current_version?
       results.add_result(AuditResults::PC_PO_VERSION_MISMATCH,
                          pc_version: preserved_copy.version,

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe CatalogToMoab do
     end
 
     it 'calls AuditResults.report_results' do
-      results = instance_double(AuditResults, add_result: nil, :actual_version= => nil)
+      results = instance_double(AuditResults, add_result: nil, :actual_version= => nil, :check_name= => nil)
       allow(AuditResults).to receive(:new).and_return(results)
       expect(results).to receive(:report_results)
       c2m.check_catalog_version
@@ -73,7 +73,7 @@ RSpec.describe CatalogToMoab do
     context 'moab is nil (exists in catalog but not online)' do
       it 'adds an ONLINE_MOAB_DOES_NOT_EXIST result' do
         allow(Moab::StorageObject).to receive(:new).with(druid, instance_of(String)).and_return(nil)
-        results = instance_double(AuditResults, report_results: nil)
+        results = instance_double(AuditResults, report_results: nil, :check_name= => nil)
         allow(AuditResults).to receive(:new).and_return(results)
         expect(results).to receive(:add_result).with(AuditResults::ONLINE_MOAB_DOES_NOT_EXIST)
         expect(results).to receive(:add_result).with(
@@ -112,7 +112,7 @@ RSpec.describe CatalogToMoab do
     context 'preserved_copy version != current_version of preserved_object' do
       it 'adds a PC_PO_VERSION_MISMATCH result and returns' do
         pres_copy.version = 666
-        results = instance_double(AuditResults, report_results: nil)
+        results = instance_double(AuditResults, report_results: nil, :check_name= => nil)
         allow(AuditResults).to receive(:new).and_return(results)
         expect(results).to receive(:add_result).with(
           AuditResults::PC_PO_VERSION_MISMATCH,
@@ -126,7 +126,7 @@ RSpec.describe CatalogToMoab do
 
     context 'catalog version == moab version (happy path)' do
       it 'adds a VERSION_MATCHES result' do
-        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
+        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil, :check_name= => nil)
         allow(AuditResults).to receive(:new).and_return(results)
         expect(results).to receive(:add_result).with(AuditResults::VERSION_MATCHES, 'PreservedCopy')
         c2m.check_catalog_version
@@ -178,7 +178,7 @@ RSpec.describe CatalogToMoab do
       end
 
       it 'adds an UNEXPECTED_VERSION result' do
-        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
+        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil, :check_name= => nil)
         expect(results).to receive(:add_result).with(AuditResults::UNEXPECTED_VERSION, 'PreservedCopy')
         allow(results).to receive(:add_result).with(any_args)
         allow(AuditResults).to receive(:new).and_return(results)
@@ -240,7 +240,7 @@ RSpec.describe CatalogToMoab do
       end
 
       it 'adds an UNEXPECTED_VERSION result' do
-        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
+        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil, :check_name= => nil)
         expect(results).to receive(:add_result).with(AuditResults::UNEXPECTED_VERSION, 'PreservedCopy')
         allow(results).to receive(:add_result).with(any_args)
         allow(AuditResults).to receive(:new).and_return(results)
@@ -274,7 +274,7 @@ RSpec.describe CatalogToMoab do
           expect(new_status).to eq PreservedCopy::INVALID_MOAB_STATUS
         end
         it 'adds an INVALID_MOAB result' do
-          results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
+          results = instance_double(AuditResults, report_results: nil, :actual_version= => nil, :check_name= => nil)
           expect(results).to receive(:add_result).with(AuditResults::INVALID_MOAB, anything)
           allow(results).to receive(:add_result).with(any_args)
           allow(AuditResults).to receive(:new).and_return(results)
@@ -282,7 +282,7 @@ RSpec.describe CatalogToMoab do
         end
       end
       it 'adds a PC_STATUS_CHANGED result' do
-        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
+        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil, :check_name= => nil)
         expect(results).to receive(:add_result).with(
           AuditResults::PC_STATUS_CHANGED, a_hash_including(:old_status, :new_status)
         )

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -58,10 +58,10 @@ RSpec.describe CatalogToMoab do
       c2m.check_catalog_version
     end
 
-    it 'calls POHandlerResults.report_results' do
-      pohandler_results = instance_double(AuditResults, add_result: nil, :actual_version= => nil)
-      allow(AuditResults).to receive(:new).and_return(pohandler_results)
-      expect(pohandler_results).to receive(:report_results)
+    it 'calls AuditResults.report_results' do
+      results = instance_double(AuditResults, add_result: nil, :actual_version= => nil)
+      allow(AuditResults).to receive(:new).and_return(results)
+      expect(results).to receive(:report_results)
       c2m.check_catalog_version
     end
 
@@ -73,12 +73,10 @@ RSpec.describe CatalogToMoab do
     context 'moab is nil (exists in catalog but not online)' do
       it 'adds an ONLINE_MOAB_DOES_NOT_EXIST result' do
         allow(Moab::StorageObject).to receive(:new).with(druid, instance_of(String)).and_return(nil)
-        pohandler_results = instance_double(AuditResults, report_results: nil)
-        allow(AuditResults).to receive(:new).and_return(pohandler_results)
-        expect(pohandler_results).to receive(:add_result).with(
-          AuditResults::ONLINE_MOAB_DOES_NOT_EXIST
-        )
-        expect(pohandler_results).to receive(:add_result).with(
+        results = instance_double(AuditResults, report_results: nil)
+        allow(AuditResults).to receive(:new).and_return(results)
+        expect(results).to receive(:add_result).with(AuditResults::ONLINE_MOAB_DOES_NOT_EXIST)
+        expect(results).to receive(:add_result).with(
           AuditResults::PC_STATUS_CHANGED, old_status: "ok", new_status: "online_moab_not_found"
         )
         c2m.check_catalog_version
@@ -114,9 +112,9 @@ RSpec.describe CatalogToMoab do
     context 'preserved_copy version != current_version of preserved_object' do
       it 'adds a PC_PO_VERSION_MISMATCH result and returns' do
         pres_copy.version = 666
-        pohandler_results = instance_double(AuditResults, report_results: nil)
-        allow(AuditResults).to receive(:new).and_return(pohandler_results)
-        expect(pohandler_results).to receive(:add_result).with(
+        results = instance_double(AuditResults, report_results: nil)
+        allow(AuditResults).to receive(:new).and_return(results)
+        expect(results).to receive(:add_result).with(
           AuditResults::PC_PO_VERSION_MISMATCH,
           pc_version: pres_copy.version,
           po_version: pres_copy.preserved_object.current_version
@@ -128,11 +126,9 @@ RSpec.describe CatalogToMoab do
 
     context 'catalog version == moab version (happy path)' do
       it 'adds a VERSION_MATCHES result' do
-        pohandler_results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
-        allow(AuditResults).to receive(:new).and_return(pohandler_results)
-        expect(pohandler_results).to receive(:add_result).with(
-          AuditResults::VERSION_MATCHES, 'PreservedCopy'
-        )
+        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
+        allow(AuditResults).to receive(:new).and_return(results)
+        expect(results).to receive(:add_result).with(AuditResults::VERSION_MATCHES, 'PreservedCopy')
         c2m.check_catalog_version
       end
 
@@ -182,12 +178,10 @@ RSpec.describe CatalogToMoab do
       end
 
       it 'adds an UNEXPECTED_VERSION result' do
-        pohandler_results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
-        expect(pohandler_results).to receive(:add_result).with(
-          AuditResults::UNEXPECTED_VERSION, 'PreservedCopy'
-        )
-        allow(pohandler_results).to receive(:add_result).with(any_args)
-        allow(AuditResults).to receive(:new).and_return(pohandler_results)
+        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
+        expect(results).to receive(:add_result).with(AuditResults::UNEXPECTED_VERSION, 'PreservedCopy')
+        allow(results).to receive(:add_result).with(any_args)
+        allow(AuditResults).to receive(:new).and_return(results)
         c2m.check_catalog_version
       end
       it 'calls PreservedObjectHandler.update_version_after_validation' do
@@ -246,12 +240,10 @@ RSpec.describe CatalogToMoab do
       end
 
       it 'adds an UNEXPECTED_VERSION result' do
-        pohandler_results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
-        expect(pohandler_results).to receive(:add_result).with(
-          AuditResults::UNEXPECTED_VERSION, 'PreservedCopy'
-        )
-        allow(pohandler_results).to receive(:add_result).with(any_args)
-        allow(AuditResults).to receive(:new).and_return(pohandler_results)
+        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
+        expect(results).to receive(:add_result).with(AuditResults::UNEXPECTED_VERSION, 'PreservedCopy')
+        allow(results).to receive(:add_result).with(any_args)
+        allow(AuditResults).to receive(:new).and_return(results)
         c2m.check_catalog_version
       end
 
@@ -282,22 +274,20 @@ RSpec.describe CatalogToMoab do
           expect(new_status).to eq PreservedCopy::INVALID_MOAB_STATUS
         end
         it 'adds an INVALID_MOAB result' do
-          pohandler_results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
-          expect(pohandler_results).to receive(:add_result).with(
-            AuditResults::INVALID_MOAB, anything
-          )
-          allow(pohandler_results).to receive(:add_result).with(any_args)
-          allow(AuditResults).to receive(:new).and_return(pohandler_results)
+          results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
+          expect(results).to receive(:add_result).with(AuditResults::INVALID_MOAB, anything)
+          allow(results).to receive(:add_result).with(any_args)
+          allow(AuditResults).to receive(:new).and_return(results)
           c2m.check_catalog_version
         end
       end
       it 'adds a PC_STATUS_CHANGED result' do
-        pohandler_results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
-        expect(pohandler_results).to receive(:add_result).with(
+        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil)
+        expect(results).to receive(:add_result).with(
           AuditResults::PC_STATUS_CHANGED, a_hash_including(:old_status, :new_status)
         )
-        allow(pohandler_results).to receive(:add_result).with(any_args)
-        allow(AuditResults).to receive(:new).and_return(pohandler_results)
+        allow(results).to receive(:add_result).with(any_args)
+        allow(AuditResults).to receive(:new).and_return(results)
         c2m.check_catalog_version
       end
 

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AuditResults do
   let(:druid) { 'ab123cd4567' }
   let(:actual_version) { 6 }
   let(:endpoint) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
-  let(:pohr) { described_class.new(druid, actual_version, endpoint) }
+  let(:audit_results) { described_class.new(druid, actual_version, endpoint) }
 
   context '.logger_severity_level' do
     it 'PC_PO_VERSION_MISMATCH is an ERROR' do
@@ -16,16 +16,16 @@ RSpec.describe AuditResults do
   context '#new' do
     it 'assigns msg_prefix' do
       exp = "PreservedObjectHandler(#{druid}, #{actual_version}, #{endpoint.endpoint_name})"
-      expect(pohr.msg_prefix).to eq exp
+      expect(audit_results.msg_prefix).to eq exp
     end
     it 'sets result_array attr to []' do
-      expect(pohr.result_array).to eq []
+      expect(audit_results.result_array).to eq []
     end
     it 'sets druid attr to arg' do
-      expect(pohr.druid).to eq druid
+      expect(audit_results.druid).to eq druid
     end
     it 'sets actual_version attr to arg' do
-      expect(pohr.actual_version).to eq actual_version
+      expect(audit_results.actual_version).to eq actual_version
     end
   end
 
@@ -36,27 +36,27 @@ RSpec.describe AuditResults do
 
       before do
         addl_hash = { pc_version: 1, po_version: 2 }
-        pohr.add_result(result_code, addl_hash)
+        audit_results.add_result(result_code, addl_hash)
       end
       it 'with msg_prefix' do
-        expect(Rails.logger).to receive(:log).with(Logger::ERROR, a_string_matching(Regexp.escape(pohr.msg_prefix)))
-        pohr.report_results
+        expect(Rails.logger).to receive(:log).with(Logger::ERROR, a_string_matching(Regexp.escape(audit_results.msg_prefix)))
+        audit_results.report_results
       end
       it 'with severity assigned by .logger_severity_level' do
         expect(described_class).to receive(:logger_severity_level).with(result_code).and_return(Logger::FATAL)
         expect(Rails.logger).to receive(:log).with(Logger::FATAL, a_string_matching(version_not_matched_str))
-        pohr.report_results
+        audit_results.report_results
       end
       it 'for every result' do
         result_code2 = AuditResults::PC_STATUS_CHANGED
         status_details = { old_status: PreservedCopy::INVALID_MOAB_STATUS, new_status: PreservedCopy::OK_STATUS }
-        pohr.add_result(result_code2, status_details)
+        audit_results.add_result(result_code2, status_details)
         severity_level = described_class.logger_severity_level(result_code)
         expect(Rails.logger).to receive(:log).with(severity_level, a_string_matching(version_not_matched_str))
         severity_level = described_class.logger_severity_level(result_code2)
         status_changed_str = "PreservedCopy status changed from #{PreservedCopy::INVALID_MOAB_STATUS}"
         expect(Rails.logger).to receive(:log).with(severity_level, a_string_matching(status_changed_str))
-        pohr.report_results
+        audit_results.report_results
       end
     end
 
@@ -67,74 +67,74 @@ RSpec.describe AuditResults do
           "Version directory name not in 'v00xx' format: original-v1",
           "Version v0005: No files present in manifest dir"
         ]
-        pohr.add_result(result_code, moab_valid_errs)
-        wf_err_msg = pohr.send(:result_code_msg, result_code, moab_valid_errs)
+        audit_results.add_result(result_code, moab_valid_errs)
+        wf_err_msg = audit_results.send(:result_code_msg, result_code, moab_valid_errs)
         expect(WorkflowErrorsReporter).to receive(:update_workflow).with(druid, 'moab-valid', wf_err_msg)
-        pohr.report_results
+        audit_results.report_results
       end
       it "does not send results that aren't in WORKFLOW_REPORT_CODES" do
         code = AuditResults::CREATED_NEW_OBJECT
-        pohr.add_result(code)
+        audit_results.add_result(code)
         expect(WorkflowErrorsReporter).not_to receive(:update_workflow)
-        pohr.report_results
+        audit_results.report_results
       end
       it 'sends results in WORKFLOW_REPORT_CODES errors' do
         code = AuditResults::PC_PO_VERSION_MISMATCH
         addl_hash = { pc_version: 1, po_version: 2 }
-        pohr.add_result(code, addl_hash)
-        wf_err_msg = pohr.send(:result_code_msg, code, addl_hash)
+        audit_results.add_result(code, addl_hash)
+        wf_err_msg = audit_results.send(:result_code_msg, code, addl_hash)
         expect(WorkflowErrorsReporter).to receive(:update_workflow).with(
           druid, 'preservation-audit', a_string_starting_with(wf_err_msg)
         )
-        pohr.report_results
+        audit_results.report_results
       end
       it 'multiple errors are concatenated together with || separator' do
         code1 = AuditResults::PC_PO_VERSION_MISMATCH
         result_msg_args1 = { pc_version: 1, po_version: 2 }
-        pohr.add_result(code1, result_msg_args1)
-        wf_err_msg1 = pohr.send(:result_code_msg, code1, result_msg_args1)
+        audit_results.add_result(code1, result_msg_args1)
+        wf_err_msg1 = audit_results.send(:result_code_msg, code1, result_msg_args1)
         code2 = AuditResults::OBJECT_ALREADY_EXISTS
         result_msg_args2 = 'foo'
-        pohr.add_result(code2, result_msg_args2)
-        wf_err_msg2 = pohr.send(:result_code_msg, code2, result_msg_args2)
+        audit_results.add_result(code2, result_msg_args2)
+        wf_err_msg2 = audit_results.send(:result_code_msg, code2, result_msg_args2)
         expect(WorkflowErrorsReporter).to receive(:update_workflow).with(
           druid, 'preservation-audit', a_string_starting_with("#{wf_err_msg1} || #{wf_err_msg2}")
         )
-        pohr.report_results
+        audit_results.report_results
       end
       it 'includes a truncated stack trace at the end' do
         code = AuditResults::PC_PO_VERSION_MISMATCH
         addl_hash = { pc_version: 1, po_version: 2 }
-        pohr.add_result(code, addl_hash)
+        audit_results.add_result(code, addl_hash)
         exp_regex = Regexp.new(" || \
           .*preservation_catalog/app/services/audit_results.rb \
           .*preservation_catalog/spec/services/audit_results_spec.rb .*in <top (required)>")
         expect(WorkflowErrorsReporter).to receive(:update_workflow).with(
           druid, 'preservation-audit', a_string_ending_with(exp_regex)
         )
-        pohr.report_results
+        audit_results.report_results
       end
     end
   end
 
   context '#add_result' do
     it 'adds a hash entry to the result_array' do
-      expect(pohr.result_array.size).to eq 0
+      expect(audit_results.result_array.size).to eq 0
       code = AuditResults::PC_PO_VERSION_MISMATCH
       addl_hash = { pc_version: 1, po_version: 2 }
-      pohr.add_result(code, addl_hash)
-      expect(pohr.result_array.size).to eq 1
-      exp_msg = "#{pohr.msg_prefix} #{AuditResults::RESPONSE_CODE_TO_MESSAGES[code] % addl_hash}"
-      expect(pohr.result_array.first).to eq code => exp_msg
+      audit_results.add_result(code, addl_hash)
+      expect(audit_results.result_array.size).to eq 1
+      exp_msg = "#{audit_results.msg_prefix} #{AuditResults::RESPONSE_CODE_TO_MESSAGES[code] % addl_hash}"
+      expect(audit_results.result_array.first).to eq code => exp_msg
     end
     it 'can take a single result code argument' do
       # see above
     end
     it 'can take a second msg_args argument' do
       code = AuditResults::VERSION_MATCHES
-      pohr.add_result(code, 'foo')
-      expect(pohr.result_array.size).to eq 1
-      expect(pohr.result_array.first).to eq code => "#{pohr.msg_prefix} actual version (6) matches foo db version"
+      audit_results.add_result(code, 'foo')
+      expect(audit_results.result_array.size).to eq 1
+      expect(audit_results.result_array.first).to eq code => "#{audit_results.msg_prefix} actual version (6) matches foo db version"
     end
   end
 
@@ -142,29 +142,29 @@ RSpec.describe AuditResults do
     before do
       code = AuditResults::PC_PO_VERSION_MISMATCH
       result_msg_args = { pc_version: 1, po_version: 2 }
-      pohr.add_result(code, result_msg_args)
+      audit_results.add_result(code, result_msg_args)
       code = AuditResults::PC_STATUS_CHANGED
       result_msg_args = { old_status: PreservedCopy::OK_STATUS, new_status: PreservedCopy::INVALID_MOAB_STATUS }
-      pohr.add_result(code, result_msg_args)
+      audit_results.add_result(code, result_msg_args)
       code = AuditResults::CREATED_NEW_OBJECT
-      pohr.add_result(code)
+      audit_results.add_result(code)
       code = AuditResults::INVALID_MOAB
-      pohr.add_result(code, 'foo')
+      audit_results.add_result(code, 'foo')
     end
     it 'removes results matching DB_UPDATED_CODES' do
-      expect(pohr.result_array.size).to eq 4
-      pohr.remove_db_updated_results
-      expect(pohr.result_array.size).to eq 2
-      pohr.result_array.each do |result_hash|
+      expect(audit_results.result_array.size).to eq 4
+      audit_results.remove_db_updated_results
+      expect(audit_results.result_array.size).to eq 2
+      audit_results.result_array.each do |result_hash|
         expect(AuditResults::DB_UPDATED_CODES).not_to include(result_hash.keys.first)
       end
-      expect(pohr.result_array).not_to include(a_hash_including(AuditResults::CREATED_NEW_OBJECT))
-      expect(pohr.result_array).not_to include(a_hash_including(AuditResults::PC_STATUS_CHANGED))
+      expect(audit_results.result_array).not_to include(a_hash_including(AuditResults::CREATED_NEW_OBJECT))
+      expect(audit_results.result_array).not_to include(a_hash_including(AuditResults::PC_STATUS_CHANGED))
     end
     it 'keeps results not matching DB_UPDATED_CODES' do
-      pohr.remove_db_updated_results
-      expect(pohr.result_array).to include(a_hash_including(AuditResults::PC_PO_VERSION_MISMATCH))
-      expect(pohr.result_array).to include(a_hash_including(AuditResults::INVALID_MOAB))
+      audit_results.remove_db_updated_results
+      expect(audit_results.result_array).to include(a_hash_including(AuditResults::PC_PO_VERSION_MISMATCH))
+      expect(audit_results.result_array).to include(a_hash_including(AuditResults::INVALID_MOAB))
     end
   end
 end

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe AuditResults do
         audit_results.add_result(result_code, addl_hash)
       end
       it 'with msg_prefix' do
-        expected = audit_results.send(:msg_prefix)
+        audit_results.check_name = 'FooCheck'
+        expected = "FooCheck(#{druid}, fixture_sr1)"
         expect(Rails.logger).to receive(:log).with(Logger::ERROR, a_string_matching(Regexp.escape(expected)))
         audit_results.report_results
       end

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe PreservedObjectHandler do
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
   let(:pc) { PreservedCopy.find_by(preserved_object: po, endpoint: ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name})" }
-  let(:db_update_failed_prefix_regex_escaped) { Regexp.escape("#{exp_msg_prefix} db update failed") }
+  let(:db_update_failed_prefix) { "db update failed" }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
 
   describe '#check_existence' do
@@ -32,9 +31,8 @@ RSpec.describe PreservedObjectHandler do
 
       context "incoming and db versions match" do
         let(:po_handler) { described_class.new(druid, 2, 1, ep) }
-        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, #{ep.endpoint_name})" }
-        let(:version_matches_po_msg) { "#{exp_msg_prefix} actual version (2) matches PreservedObject db version" }
-        let(:version_matches_pc_msg) { "#{exp_msg_prefix} actual version (2) matches PreservedCopy db version" }
+        let(:version_matches_po_msg) { "actual version (2) matches PreservedObject db version" }
+        let(:version_matches_pc_msg) { "actual version (2) matches PreservedCopy db version" }
 
         context 'PreservedCopy' do
           context 'changed' do
@@ -100,8 +98,8 @@ RSpec.describe PreservedObjectHandler do
       end
 
       context "incoming version > db version" do
-        let(:version_gt_pc_msg) { "#{exp_msg_prefix} actual version (#{incoming_version}) greater than PreservedCopy db version" }
-        let(:version_gt_po_msg) { "#{exp_msg_prefix} actual version (#{incoming_version}) greater than PreservedObject db version" }
+        let(:version_gt_pc_msg) { "actual version (#{incoming_version}) greater than PreservedCopy db version" }
+        let(:version_gt_po_msg) { "actual version (#{incoming_version}) greater than PreservedObject db version" }
 
         it 'calls Stanford::StorageObjectValidator.validation_errors for moab' do
           mock_sov = instance_double(Stanford::StorageObjectValidator)
@@ -219,9 +217,6 @@ RSpec.describe PreservedObjectHandler do
           let(:invalid_po_handler) { described_class.new(invalid_druid, incoming_version, incoming_size, invalid_ep) }
           let(:invalid_po) { PreservedObject.find_by(druid: invalid_druid) }
           let(:invalid_pc) { PreservedCopy.find_by(preserved_object: invalid_po) }
-          let(:exp_msg_prefix) do
-            "PreservedObjectHandler(#{invalid_druid}, #{incoming_version}, #{invalid_ep.endpoint_name})"
-          end
 
           before do
             # add storage root with the invalid moab to the Endpoints table
@@ -394,7 +389,7 @@ RSpec.describe PreservedObjectHandler do
 
           context 'DB_UPDATE_FAILED error' do
             it 'prefix' do
-              expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix_regex_escaped)))
+              expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix)))
             end
             it 'specific exception raised' do
               expect(results).to include(a_hash_including(result_code => a_string_matching('ActiveRecord::ActiveRecordError')))
@@ -434,8 +429,8 @@ RSpec.describe PreservedObjectHandler do
     end
 
     context 'object not in db' do
-      let(:exp_po_not_exist_msg) { "#{exp_msg_prefix} PreservedObject db object does not exist" }
-      let(:exp_obj_created_msg) { "#{exp_msg_prefix} added object to db as it did not exist" }
+      let(:exp_po_not_exist_msg) { "PreservedObject db object does not exist" }
+      let(:exp_obj_created_msg) { "added object to db as it did not exist" }
 
       context 'presume validity and test other common behavior' do
         before do
@@ -467,8 +462,6 @@ RSpec.describe PreservedObjectHandler do
         end
 
         context 'moab is valid' do
-          let(:exp_msg_prefix) { "PreservedObjectHandler(#{valid_druid}, #{incoming_version}, #{ep.endpoint_name})" }
-
           it 'PreservedObject created' do
             po_args = {
               druid: valid_druid,
@@ -533,7 +526,7 @@ RSpec.describe PreservedObjectHandler do
 
               context 'DB_UPDATE_FAILED error' do
                 it 'prefix' do
-                  expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix_regex_escaped)))
+                  expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix)))
                 end
                 it 'specific exception raised' do
                   expect(results).to include(a_hash_including(result_code => a_string_matching('ActiveRecord::ActiveRecordError')))
@@ -550,8 +543,7 @@ RSpec.describe PreservedObjectHandler do
           let(:storage_dir) { 'spec/fixtures/bad_root01/bad_moab_storage_trunk' }
           let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
           let(:invalid_druid) { 'xx000xx0000' }
-          let(:exp_msg_prefix) { "PreservedObjectHandler(#{invalid_druid}, #{incoming_version}, #{ep.endpoint_name})" }
-          let(:exp_moab_errs_msg) { "#{exp_msg_prefix} Invalid moab, validation errors: [\"Missing directory: [\\\"data\\\", \\\"manifests\\\"] Version: v0001\"]" }
+          let(:exp_moab_errs_msg) { "Invalid moab, validation errors: [\"Missing directory: [\\\"data\\\", \\\"manifests\\\"] Version: v0001\"]" }
           let(:po_handler) { described_class.new(invalid_druid, incoming_version, incoming_size, ep) }
 
           before do
@@ -633,7 +625,7 @@ RSpec.describe PreservedObjectHandler do
 
               context 'DB_UPDATE_FAILED error' do
                 it 'prefix' do
-                  expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix_regex_escaped)))
+                  expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix)))
                 end
                 it 'specific exception raised' do
                   expect(results).to include(a_hash_including(result_code => a_string_matching('ActiveRecord::ActiveRecordError')))

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe PreservedObjectHandler do
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
   let(:pc) { PreservedCopy.find_by(preserved_object: po, endpoint: ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name})" }
-  let(:db_update_failed_prefix_regex_escaped) { Regexp.escape("#{exp_msg_prefix} db update failed") }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
 
   describe '#confirm_version' do
@@ -48,9 +46,8 @@ RSpec.describe PreservedObjectHandler do
 
       context "incoming and db versions match" do
         let(:po_handler) { described_class.new(druid, 2, 1, ep) }
-        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 2, #{ep.endpoint_name})" }
-        let(:version_matches_po_msg) { "#{exp_msg_prefix} actual version (2) matches PreservedObject db version" }
-        let(:version_matches_pc_msg) { "#{exp_msg_prefix} actual version (2) matches PreservedCopy db version" }
+        let(:version_matches_po_msg) { "actual version (2) matches PreservedObject db version" }
+        let(:version_matches_pc_msg) { "actual version (2) matches PreservedCopy db version" }
 
         context 'PreservedCopy' do
           context 'changed' do
@@ -139,13 +136,8 @@ RSpec.describe PreservedObjectHandler do
       context 'incoming version does NOT match db version' do
         let(:druid) { 'bj102hs9687' } # for shared_examples 'calls AuditResults.report_results'
         let(:po_handler) { described_class.new(druid, 1, 666, ep) }
-        let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, 1, #{ep.endpoint_name})" }
-        let(:unexpected_version_pc_msg) {
-          "#{exp_msg_prefix} actual version (1) has unexpected relationship to PreservedCopy db version; ERROR!"
-        }
-        let(:updated_pc_db_status_msg) {
-          "#{exp_msg_prefix} PreservedCopy status changed from ok to unexpected_version_on_storage"
-        }
+        let(:unexpected_version_pc_msg) { "actual version (1) has unexpected relationship to PreservedCopy db version; ERROR!" }
+        let(:updated_pc_db_status_msg) { "PreservedCopy status changed from ok to unexpected_version_on_storage" }
 
         it_behaves_like 'calls AuditResults.report_results', :confirm_version
 

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe PreservedObjectHandler do
   let(:incoming_size) { 9876 }
   let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
   let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name})" }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
-  let(:exp_msg) { "#{exp_msg_prefix} added object to db as it did not exist" }
+  let(:exp_msg) { "added object to db as it did not exist" }
 
   describe '#create' do
     it 'creates PreservedObject and PreservedCopy in database' do
@@ -144,7 +143,6 @@ RSpec.describe PreservedObjectHandler do
       let(:storage_dir) { 'spec/fixtures/bad_root01/bad_moab_storage_trunk' }
       let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
       let(:invalid_druid) { 'xx000xx0000' }
-      let(:exp_msg_prefix) { "PreservedObjectHandler(#{invalid_druid}, #{incoming_version}, #{ep.endpoint_name})" }
       let(:po_handler) { described_class.new(invalid_druid, incoming_version, incoming_size, ep) }
 
       # add storage root with invalid moab to the Endpoints table
@@ -212,7 +210,6 @@ RSpec.describe PreservedObjectHandler do
 
     context 'returns' do
       let!(:result) { po_handler.create_after_validation }
-      let(:exp_msg_prefix) { "PreservedObjectHandler(#{valid_druid}, #{incoming_version}, #{ep.endpoint_name})" }
 
       it '1 result' do
         expect(result).to be_an_instance_of Array

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe PreservedObjectHandler do
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
   let(:pc) { PreservedCopy.find_by(preserved_object: po, endpoint: ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep})" }
-  let(:db_update_failed_prefix_regex_escaped) { Regexp.escape("#{exp_msg_prefix} db update failed") }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
 
   describe '#initialize' do

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -9,11 +9,10 @@ RSpec.describe PreservedObjectHandler do
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ep) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }
   let(:pc) { PreservedCopy.find_by(preserved_object: po, endpoint: ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name})" }
-  let(:updated_status_msg_regex) { Regexp.new(Regexp.escape("#{exp_msg_prefix} PreservedCopy status changed from")) }
-  let(:db_update_failed_prefix_regex_escaped) { Regexp.escape("#{exp_msg_prefix} db update failed") }
-  let(:version_gt_pc_msg) { "#{exp_msg_prefix} actual version (#{incoming_version}) greater than PreservedCopy db version" }
-  let(:version_gt_po_msg) { "#{exp_msg_prefix} actual version (#{incoming_version}) greater than PreservedObject db version" }
+  let(:updated_status_msg_regex) { Regexp.new("PreservedCopy status changed from") }
+  let(:db_update_failed_prefix) { "db update failed" }
+  let(:version_gt_pc_msg) { "actual version (#{incoming_version}) greater than PreservedCopy db version" }
+  let(:version_gt_po_msg) { "actual version (#{incoming_version}) greater than PreservedObject db version" }
 
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
 
@@ -144,7 +143,7 @@ RSpec.describe PreservedObjectHandler do
 
             context 'DB_UPDATE_FAILED error' do
               it 'prefix' do
-                expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix_regex_escaped)))
+                expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix)))
               end
               it 'specific exception raised' do
                 expect(results).to include(a_hash_including(result_code => a_string_matching('ActiveRecord::ActiveRecordError')))
@@ -180,7 +179,7 @@ RSpec.describe PreservedObjectHandler do
 
             context 'DB_UPDATE_FAILED error' do
               it 'prefix' do
-                expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix_regex_escaped)))
+                expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix)))
               end
               it 'specific exception raised' do
                 expect(results).to include(a_hash_including(result_code => a_string_matching('ActiveRecord::ActiveRecordError')))
@@ -497,7 +496,7 @@ RSpec.describe PreservedObjectHandler do
 
               context 'DB_UPDATE_FAILED error' do
                 it 'prefix' do
-                  expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix_regex_escaped)))
+                  expect(results).to include(a_hash_including(result_code => a_string_matching(db_update_failed_prefix)))
                 end
                 it 'specific exception raised' do
                   expect(results).to include(a_hash_including(result_code => a_string_matching('ActiveRecord::ActiveRecordError')))

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -47,6 +47,7 @@ RSpec.shared_examples 'calls AuditResults.report_results' do |method_sym|
   it '' do
     mock_results = instance_double(AuditResults)
     allow(mock_results).to receive(:add_result)
+    allow(mock_results).to receive(:check_name=)
     expect(mock_results).to receive(:report_results)
     expect(AuditResults).to receive(:new).and_return(mock_results)
     po_handler.send(method_sym)

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -23,10 +23,9 @@ RSpec.shared_examples "attributes validated" do |method_sym|
     end
     context 'result message includes' do
       let(:msg) { result.first[AuditResults::INVALID_ARGUMENTS] }
-      let(:exp_msg_prefix) { "PreservedObjectHandler(#{bad_druid}, #{bad_version}, #{bad_endpoint.endpoint_name if bad_endpoint})" }
 
       it "prefix" do
-        expect(msg).to match(Regexp.escape("#{exp_msg_prefix} encountered validation error(s): "))
+        expect(msg).to match(Regexp.escape("encountered validation error(s): "))
       end
       it "druid error" do
         expect(msg).to match(bad_druid_msg)
@@ -56,7 +55,7 @@ end
 
 RSpec.shared_examples 'druid not in catalog' do |method_sym|
   let(:druid) { 'rr111rr1111' }
-  let(:escaped_exp_msg) { Regexp.escape(exp_msg_prefix) + ".* PreservedObject.* db object does not exist" }
+  let(:exp_msg) { "PreservedObject.* db object does not exist" }
   let(:results) do
     allow(Rails.logger).to receive(:log)
     po_handler.send(method_sym)
@@ -64,7 +63,7 @@ RSpec.shared_examples 'druid not in catalog' do |method_sym|
 
   it 'OBJECT_DOES_NOT_EXIST error' do
     code = AuditResults::OBJECT_DOES_NOT_EXIST
-    expect(results).to include(a_hash_including(code => a_string_matching(escaped_exp_msg)))
+    expect(results).to include(a_hash_including(code => a_string_matching(exp_msg)))
   end
 end
 
@@ -72,7 +71,7 @@ RSpec.shared_examples 'PreservedCopy does not exist' do |method_sym|
   before do
     PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
   end
-  let(:exp_msg) { "#{exp_msg_prefix} #<ActiveRecord::RecordNotFound: foo> db object does not exist" }
+  let(:exp_msg) { "#<ActiveRecord::RecordNotFound: foo> db object does not exist" }
   let(:results) do
     allow(Rails.logger).to receive(:log)
     po = instance_double(PreservedObject)
@@ -93,8 +92,7 @@ end
 
 RSpec.shared_examples 'unexpected version' do |method_sym, actual_version|
   let(:po_handler) { described_class.new(druid, actual_version, 1, ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{actual_version}, #{ep.endpoint_name if ep})" }
-  let(:version_msg_prefix) { "#{exp_msg_prefix} actual version (#{actual_version})" }
+  let(:version_msg_prefix) { "actual version (#{actual_version})" }
   let(:unexpected_version_msg) { "#{version_msg_prefix} has unexpected relationship to PreservedCopy db version; ERROR!" }
 
   context 'PreservedCopy' do
@@ -185,10 +183,9 @@ end
 
 RSpec.shared_examples 'unexpected version with validation' do |method_sym, incoming_version, new_status|
   let(:po_handler) { described_class.new(druid, incoming_version, 1, ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name if ep})" }
-  let(:version_msg_prefix) { "#{exp_msg_prefix} actual version (#{incoming_version})" }
+  let(:version_msg_prefix) { "actual version (#{incoming_version})" }
   let(:unexpected_version_msg) { "#{version_msg_prefix} has unexpected relationship to PreservedCopy db version; ERROR!" }
-  let(:updated_status_msg_regex) { Regexp.new(Regexp.escape("#{exp_msg_prefix} PreservedCopy status changed from")) }
+  let(:updated_status_msg_regex) { Regexp.new("PreservedCopy status changed from") }
 
   context 'PreservedCopy' do
     context 'changed' do
@@ -287,8 +284,8 @@ RSpec.shared_examples 'unexpected version with validation' do |method_sym, incom
 end
 
 RSpec.shared_examples 'update for invalid moab' do |method_sym|
-  let(:updated_status_msg_regex) { Regexp.new(Regexp.escape("#{exp_msg_prefix} PreservedCopy status changed from")) }
-  let(:invalid_moab_msg) { "#{exp_msg_prefix} Invalid moab, validation errors: [\"Missing directory: [\\\"data\\\", \\\"manifests\\\"] Version: v0001\"]" }
+  let(:updated_status_msg_regex) { Regexp.new("PreservedCopy status changed from") }
+  let(:invalid_moab_msg) { "Invalid moab, validation errors: [\"Missing directory: [\\\"data\\\", \\\"manifests\\\"] Version: v0001\"]" }
 
   context 'PreservedCopy' do
     context 'changed' do
@@ -347,8 +344,7 @@ end
 
 RSpec.shared_examples 'PreservedObject current_version does not match online PC version' do |method_sym, incoming_version, pc_v, po_v|
   let(:po_handler) { described_class.new(druid, incoming_version, 1, ep) }
-  let(:exp_msg_prefix) { "PreservedObjectHandler(#{druid}, #{incoming_version}, #{ep.endpoint_name if ep})" }
-  let(:version_mismatch_msg) { "#{exp_msg_prefix} PreservedCopy online moab version #{pc_v} does not match PreservedObject current_version #{po_v}" }
+  let(:version_mismatch_msg) { "PreservedCopy online moab version #{pc_v} does not match PreservedObject current_version #{po_v}" }
 
   it 'does not update PreservedCopy' do
     orig = pc.updated_at


### PR DESCRIPTION
2 reviewers?
3 reviewers so everyone understands the changes??

~~WIP until #544 is merged;  then will rebase this on master~~
~~WIP until caller is in log msg_prefix ...~~

- audit_results:  
    - msg_prefix only in logs, not result messages
    - add check_name attribute so it can be included in log msg_prefix
- specs:  use better var names for audit_results object

Connects to #539