### PR TITLE
[WIP] ensure last_checked_b4_date is in the correct format

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,6 +132,10 @@ Rails/Output:
     - 'lib/audit/catalog_to_moab.rb' # use puts statements for following progress of long job
     - 'lib/audit/moab_to_catalog.rb' # use puts statements for following progress of long job
 
+Rails/TimeZone:
+  Exclude:
+    - 'app/models/preserved_copy.rb' # use Time.parse without zone
+
 # --- RSpec ---
 
 RSpec/BeforeAfterAll:

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -32,6 +32,7 @@ class PreservedCopy < ApplicationRecord
   validates :version, presence: true
 
   scope :least_recent_version_audit, lambda { |last_checked_b4_date, storage_dir|
+    last_checked_b4_date = PreservedCopy.normalize_date(last_checked_b4_date)
     joins(:endpoint)
       .where(endpoints: { storage_location: storage_dir })
       .where('last_version_audit IS NULL or last_version_audit < ?', last_checked_b4_date)
@@ -61,5 +62,15 @@ class PreservedCopy < ApplicationRecord
 
   def matches_po_current_version?
     version == preserved_object.current_version
+  end
+
+  # Input: Takes a Time object, String, or Nil
+  # Output: If String method will return a time object,
+  # if nil, method will return the start of the Epoch Time Object
+  # and if Time object, it will return the same Time object.
+  def self.normalize_date(timestamp)
+    timestamp = '1970-01-01T00:00:00Z' if timestamp.nil?
+    timestamp = Time.parse(timestamp) unless timestamp.instance_of?(Time)
+    timestamp
   end
 end

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -55,4 +55,11 @@ class PreservedCopy < ApplicationRecord
   def matches_po_current_version?
     version == preserved_object.current_version
   end
+
+  def self.least_recent_version_audit(last_checked_b4_date, storage_dir)
+    joins(:endpoint)
+      .where(endpoints: { storage_location: storage_dir })
+      .where('last_version_audit IS NULL or last_version_audit < ?', last_checked_b4_date)
+      .order('last_version_audit IS NOT NULL, last_version_audit ASC')
+  end
 end

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -7,11 +7,7 @@ class CatalogToMoab
   # allows for sharding/parallelization by storage_dir
   def self.check_version_on_dir(last_checked_b4_date, storage_dir)
     # TODO: ensure last_checked_version_b4_date is in the right format for query - see #485
-    pcs = PreservedCopy
-          .joins(:endpoint)
-          .where(endpoints: { storage_location: storage_dir })
-          .where('last_version_audit IS NULL or last_version_audit < ?', last_checked_b4_date)
-          .order('last_version_audit IS NOT NULL, last_version_audit ASC')
+    pcs = PreservedCopy.least_recent_version_audit(last_checked_b4_date, storage_dir)
     pcs.find_each do |pc|
       c2m = CatalogToMoab.new(pc, storage_dir)
       c2m.check_catalog_version
@@ -92,7 +88,15 @@ class CatalogToMoab
     end
 
     preserved_copy.update_audit_timestamps(ran_moab_validation?, true)
+<<<<<<< HEAD
     preserved_copy.save!
+=======
+    # This may not be the best way to save the preserved_copy!
+    preserved_copy.save!
+    # TODO: We need to save preserved copy.  Do we want to use something like
+    #  PreservedObjectHandler.update_db_object? - see #478
+    # update_db_object(preserved_copy) - see #478
+>>>>>>> Refactor to spec for ordering in c2m SQL query
   end
 
   private

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -88,15 +88,7 @@ class CatalogToMoab
     end
 
     preserved_copy.update_audit_timestamps(ran_moab_validation?, true)
-<<<<<<< HEAD
     preserved_copy.save!
-=======
-    # This may not be the best way to save the preserved_copy!
-    preserved_copy.save!
-    # TODO: We need to save preserved copy.  Do we want to use something like
-    #  PreservedObjectHandler.update_db_object? - see #478
-    # update_db_object(preserved_copy) - see #478
->>>>>>> Refactor to spec for ordering in c2m SQL query
   end
 
   private

--- a/spec/lib/audit/catalog_to_moab_class_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_class_spec.rb
@@ -26,24 +26,50 @@ RSpec.describe CatalogToMoab do
       expect(c2m_mock).to receive(:check_catalog_version).exactly(2).times
       described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir)
     end
-    it 'checks a PreservedCopy previously audited before one that is not audited' do
-      last_checked_version_b4_date = Time.now.utc
-      pcs_before_check = PreservedCopy.least_recent_version_audit(last_checked_version_b4_date, storage_dir)
-      before_druids = pcs_before_check.map { |pc| pc.preserved_object.druid }
-      last_pc = pcs_before_check.last
 
-      described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir)
+    context 'for nil or past last_version_audit dates' do
+      let(:last_checked_version_b4_date) { Time.now.utc }
+      let(:pcs_before_check) { PreservedCopy.least_recent_version_audit(last_checked_version_b4_date, storage_dir) }
 
-      last_pc.reload.last_version_audit = (last_pc.last_version_audit - 2.days)
-      last_pc.save
+      it 'checks an unaudited PreservedCopy before one that has been audited' do
+        before_druids = pcs_before_check.map { |pc| pc.preserved_object.druid }
+        last_pc = pcs_before_check.last # last_version_audit is nil
 
-      # the test breaks unless we use Time.now.utc next
-      pcs_after_check = PreservedCopy.least_recent_version_audit(Time.now.utc, storage_dir)
-      after_druids = pcs_after_check.map { |pc| pc.preserved_object.druid }
+        described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir)
 
-      expect(before_druids.first).to eq(after_druids.second)
-      expect(before_druids.second).to eq(after_druids.third)
-      expect(before_druids.third).to eq(after_druids.first)
+        last_pc.reload.last_version_audit = (last_pc.last_version_audit - 2.days)
+        last_pc.save # last_version_audit is no longer nil
+
+        # the test breaks unless we use Time.now.utc next
+        pcs_after_check = PreservedCopy.least_recent_version_audit(Time.now.utc, storage_dir)
+        after_druids = pcs_after_check.map { |pc| pc.preserved_object.druid }
+
+        expect(before_druids.first).to eq(after_druids.second)
+        expect(before_druids.second).to eq(after_druids.third)
+        expect(before_druids.third).to eq(after_druids.first)
+      end
+      it 'processes dates from oldest to newest order' do
+        before_druids = pcs_before_check.map { |pc| pc.preserved_object.druid }
+        first_pc = pcs_before_check.first
+        second_pc = pcs_before_check.second
+        last_pc = pcs_before_check.last
+
+        described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir)
+
+        first_pc.reload.last_version_audit = (first_pc.last_version_audit - 1.day)
+        first_pc.save
+        second_pc.reload.last_version_audit = (second_pc.last_version_audit - 2.days)
+        second_pc.save
+        last_pc.reload.last_version_audit = (last_pc.last_version_audit - 3.days)
+        last_pc.save
+
+        # the test breaks unless we use Time.now.utc next
+        pcs_after_check = PreservedCopy.least_recent_version_audit(Time.now.utc, storage_dir)
+        after_druids = pcs_after_check.map { |pc| pc.preserved_object.druid }
+        expect(before_druids.first).to eq(after_druids.last)
+        expect(before_druids.second).to eq(after_druids.second)
+        expect(before_druids.last).to eq(after_druids.first)
+      end
     end
   end
 

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -194,4 +194,18 @@ RSpec.describe PreservedCopy, type: :model do
       expect(preserved_copy.matches_po_current_version?).to be false
     end
   end
+
+  context '.least_recent_version_audit(last_checked_b4_date, storage_dir)' do
+    let(:db_query) {
+      described_class.least_recent_version_audit(Time.now.utc, 'spec/fixtures/storage_root01/moab_storage_trunk')
+    }
+
+    it 'returns an ActiveRecord::Relation' do
+      expect(db_query).to be_a(ActiveRecord::Relation)
+    end
+
+    it 'returns the preserved_copy in the db' do
+      expect(db_query).to include(preserved_copy)
+    end
+  end
 end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -203,5 +203,17 @@ RSpec.describe PreservedCopy, type: :model do
     it 'returns all PreservedCopy objects, in any order' do
       expect(db_query).to match_array([preserved_copy])
     end
+
+    context '.normalize_date(date)' do
+      it 'given a String timestamp, returns a Time object' do
+        expect(described_class.send(:normalize_date, '2018-01-22T18:54:48')).to be_an_instance_of(Time)
+      end
+      it 'given a Time Object, returns the same Time object' do
+        expect(described_class.send(:normalize_date, Time.now.utc)).to be_an_instance_of(Time)
+      end
+      it 'given nil, returns the start of teh Epoch Time object' do
+        expect(described_class.send(:normalize_date, nil)).to be_an_instance_of(Time)
+      end
+    end
   end
 end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -200,12 +200,8 @@ RSpec.describe PreservedCopy, type: :model do
       described_class.least_recent_version_audit(Time.now.utc, 'spec/fixtures/storage_root01/moab_storage_trunk')
     }
 
-    it 'returns an ActiveRecord::Relation' do
-      expect(db_query).to be_a(ActiveRecord::Relation)
-    end
-
-    it 'returns the preserved_copy in the db' do
-      expect(db_query).to include(preserved_copy)
+    it 'returns all PreservedCopy objects, in any order' do
+      expect(db_query).to match_array([preserved_copy])
     end
   end
 end


### PR DESCRIPTION
#### NOTE: Do not Merge this until #519 is merged. Will rebase on master and edit code to display changes made in #519
- probably only needs 1 pair of eyes
- adds `.normalize_date(timestamp)` so `last_checked_b4_date` can either be a Time object, String, or nil.
- RSpec tests for this method
- Rubocop exception

closes #485 