### PR TITLE
Date format

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -136,6 +136,10 @@ Rails/Output:
     - 'lib/audit/catalog_to_moab.rb' # use puts statements for following progress of long job
     - 'lib/audit/moab_to_catalog.rb' # use puts statements for following progress of long job
 
+Rails/TimeZone:
+  Exclude:
+    - 'app/models/preserved_copy.rb' # use Time.parse without zone
+
 # --- RSpec ---
 
 RSpec/BeforeAfterAll:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -136,10 +136,6 @@ Rails/Output:
     - 'lib/audit/catalog_to_moab.rb' # use puts statements for following progress of long job
     - 'lib/audit/moab_to_catalog.rb' # use puts statements for following progress of long job
 
-Rails/TimeZone:
-  Exclude:
-    - 'app/models/preserved_copy.rb' # use Time.parse without zone
-
 # --- RSpec ---
 
 RSpec/BeforeAfterAll:

--- a/Rakefile
+++ b/Rakefile
@@ -128,14 +128,18 @@ task :c2m_check_version_on_dir, [:last_checked_b4_date, :storage_root, :profile]
   root = args[:storage_root].to_sym
   storage_dir = "#{Settings.moab.storage_roots[root]}/#{Settings.moab.storage_trunk}"
   last_checked = args[:last_checked_b4_date].to_sym
-
-  if args[:profile] == 'profile'
-    puts "When done, check log/profile_c2m_check_version_on_dir[TIMESTAMP].txt for profiling details"
-    CatalogToMoab.check_version_on_dir_profiled(last_checked, storage_dir)
-  elsif args[:profile].nil?
-    CatalogToMoab.check_version_on_dir(last_checked, storage_dir)
+  begin
+    if args[:profile] == 'profile'
+      puts "When done, check log/profile_c2m_check_version_on_dir[TIMESTAMP].txt for profiling details"
+      CatalogToMoab.check_version_on_dir_profiled(last_checked, storage_dir)
+    elsif args[:profile].nil?
+      CatalogToMoab.check_version_on_dir(last_checked, storage_dir)
+    end
+    puts "#{Time.now.utc.iso8601} Catalog to Moab version check on #{storage_dir} is done."
+  rescue TypeError, ArgumentError
+    p "You've entered an incorrect timestamp format #{last_checked}."
+    p "Please enter correct timestamp format (UTC) (2018-02-01T18:54:48Z)"
   end
-  puts "#{Time.now.utc.iso8601} Catalog to Moab version check on #{storage_dir} is done."
   $stdout.flush
 end
 
@@ -146,13 +150,17 @@ task :c2m_check_version_all_dirs, [:last_checked_b4_date, :profile] => [:environ
     exit
   end
   last_checked = args[:last_checked_b4_date].to_sym
-
-  if args[:profile] == 'profile'
-    puts "When done, check log/profile_c2m_check_version_all_roots[TIMESTAMP].txt for profiling details"
-    CatalogToMoab.check_version_all_dirs_profiled(last_checked)
-  elsif args[:profile].nil?
-    CatalogToMoab.check_version_all_dirs(last_checked)
+  begin
+    if args[:profile] == 'profile'
+      puts "When done, check log/profile_c2m_check_version_all_roots[TIMESTAMP].txt for profiling details"
+      CatalogToMoab.check_version_all_dirs_profiled(last_checked)
+    elsif args[:profile].nil?
+      CatalogToMoab.check_version_all_dirs(last_checked)
+    end
+    puts "#{Time.now.utc.iso8601} Catalog to Moab version check on all roots is done."
+  rescue TypeError, ArgumentError
+    p "You've entered an incorrect timestamp format #{last_checked}."
+    p "Please enter correct timestamp format (UTC) (2018-02-01T18:54:48Z)"
   end
-  puts "#{Time.now.utc.iso8601} Catalog to Moab version check on all roots is done."
   $stdout.flush
 end

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -71,7 +71,7 @@ class PreservedCopy < ApplicationRecord
   # and if Time object, it will return the same Time object.
   private_class_method def self.normalize_date(timestamp)
     timestamp = '1970-01-01T00:00:00Z' if timestamp.nil?
-    timestamp = Time.parse(timestamp) unless timestamp.instance_of?(Time)
+    timestamp = Time.parse(timestamp).utc unless timestamp.instance_of?(Time)
     timestamp
   end
 end

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -65,12 +65,7 @@ class PreservedCopy < ApplicationRecord
     version == preserved_object.current_version
   end
 
-  # Input: Takes a Time object, String, or Nil
-  # Output: If String method will return a time object,
-  # if nil, method will return the start of the Epoch Time Object
-  # and if Time object, it will return the same Time object.
   private_class_method def self.normalize_date(timestamp)
-    timestamp = '1970-01-01T00:00:00Z' if timestamp.nil?
     timestamp = Time.parse(timestamp).utc unless timestamp.instance_of?(Time)
     timestamp
   end

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -33,6 +33,7 @@ class PreservedCopy < ApplicationRecord
   validates :version, presence: true
 
   scope :least_recent_version_audit, lambda { |last_checked_b4_date, storage_dir|
+    last_checked_b4_date = normalize_date(last_checked_b4_date)
     joins(:endpoint)
       .where(endpoints: { storage_location: storage_dir })
       .where('last_version_audit IS NULL or last_version_audit < ?', last_checked_b4_date)
@@ -62,5 +63,15 @@ class PreservedCopy < ApplicationRecord
 
   def matches_po_current_version?
     version == preserved_object.current_version
+  end
+
+  # Input: Takes a Time object, String, or Nil
+  # Output: If String method will return a time object,
+  # if nil, method will return the start of the Epoch Time Object
+  # and if Time object, it will return the same Time object.
+  private_class_method def self.normalize_date(timestamp)
+    timestamp = '1970-01-01T00:00:00Z' if timestamp.nil?
+    timestamp = Time.parse(timestamp) unless timestamp.instance_of?(Time)
+    timestamp
   end
 end

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -6,7 +6,6 @@ class CatalogToMoab
 
   # allows for sharding/parallelization by storage_dir
   def self.check_version_on_dir_of_batch(last_checked_b4_date, storage_dir, limit)
-    # TODO: ensure last_checked_version_b4_date is in the right format for query - see #485
     pcs = PreservedCopy.least_recent_version_audit(last_checked_b4_date, storage_dir).limit(limit)
     pcs.each do |pc|
       c2m = CatalogToMoab.new(pc, storage_dir)

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -26,7 +26,6 @@ class CatalogToMoab
   end
 
   def self.check_version_all_dirs(last_checked_b4_date)
-    # FIXME: ensure last_checked_version_b4_date is in the right format - see #485
     Settings.moab.storage_roots.each do |strg_root_name, strg_root_location|
       start_msg = "#{Time.now.utc.iso8601} C2M check_version starting for '#{strg_root_name}' at #{strg_root_location}"
       puts start_msg

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -234,5 +234,17 @@ RSpec.describe PreservedCopy, type: :model do
     it 'returns no PreservedCopies with future timestamps' do
       expect(pcs_ordered_by_query).not_to include future_timestamp_pc
     end
+
+    context '.normalize_date(timestamp)' do
+      it 'given a String timestamp, returns a Time object' do
+        expect(described_class.send(:normalize_date, '2018-01-22T18:54:48')).to be_an_instance_of(Time)
+      end
+      it 'given a Time Object, returns the same Time object' do
+        expect(described_class.send(:normalize_date, Time.now.utc)).to be_an_instance_of(Time)
+      end
+      it 'given nil, returns the start of teh Epoch Time object' do
+        expect(described_class.send(:normalize_date, nil)).to be_an_instance_of(Time)
+      end
+    end
   end
 end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -242,8 +242,20 @@ RSpec.describe PreservedCopy, type: :model do
       it 'given a Time Object, returns the same Time object' do
         expect(described_class.send(:normalize_date, Time.now.utc)).to be_an_instance_of(Time)
       end
-      it 'given nil, returns the start of teh Epoch Time object' do
-        expect(described_class.send(:normalize_date, nil)).to be_an_instance_of(Time)
+      it 'given nil, returns a TypeError' do
+        expect { described_class.send(:normalize_date, nil) }.to raise_error(TypeError, /no implicit conversion/)
+      end
+      it 'given an unparseable date returns an ArgumentError' do
+        expect { described_class.send(:normalize_date, 'an 6') }.to raise_error(ArgumentError, /no time information/)
+      end
+      it 'given day only returns a Time object with 08:00:00 UTC time' do
+        expect(described_class.send(:normalize_date, '2018-02-02')).to be_an_instance_of(Time)
+      end
+      it 'given a month only returns Time object with 2018-04-01 07:00:00 UTC time' do
+        expect(described_class.send(:normalize_date, 'April')).to be_an_instance_of(Time)
+      end
+      it 'given a year only returns an ArgumentError' do
+        expect { described_class.send(:normalize_date, '2014') }.to raise_error(ArgumentError, /argument out of range/)
       end
     end
   end


### PR DESCRIPTION
- probably only needs 1 pair of eyes
- adds .normalize_date(timestamp) so last_checked_b4_date can either be a Time object, String, or nil.
- RSpec tests for this method
- ~~Rubocop exception~~
closes #485