### PR TITLE
audit_results: constant names made less confusing and shorter

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -14,12 +14,12 @@ class AuditResults
 
   INVALID_ARGUMENTS = :invalid_arguments
   VERSION_MATCHES = :version_matches
-  ARG_VERSION_GREATER_THAN_DB_OBJECT = :arg_version_greater_than_db
-  ARG_VERSION_LESS_THAN_DB_OBJECT = :arg_version_less_than_db
+  ACTUAL_VERS_GT_DB_OBJ = :actual_vers_gt_db_obj
+  ACTUAL_VERS_LT_DB_OBJ = :actual_vers_lt_db_obj
   CREATED_NEW_OBJECT = :created_new_object
   DB_UPDATE_FAILED = :db_update_failed
-  OBJECT_ALREADY_EXISTS = :object_already_exists
-  OBJECT_DOES_NOT_EXIST = :object_does_not_exist
+  DB_OBJ_ALREADY_EXISTS = :db_obj_already_exists
+  DB_OBJ_DOES_NOT_EXIST = :db_obj_does_not_exist
   PC_STATUS_CHANGED = :pc_status_changed
   UNEXPECTED_VERSION = :unexpected_version
   INVALID_MOAB = :invalid_moab
@@ -29,12 +29,12 @@ class AuditResults
   RESPONSE_CODE_TO_MESSAGES = {
     INVALID_ARGUMENTS => "encountered validation error(s): %{addl}",
     VERSION_MATCHES => "actual version (%{actual_version}) matches %{addl} db version",
-    ARG_VERSION_GREATER_THAN_DB_OBJECT => "actual version (%{actual_version}) greater than %{addl} db version",
-    ARG_VERSION_LESS_THAN_DB_OBJECT => "actual version (%{actual_version}) less than %{addl} db version; ERROR!",
+    ACTUAL_VERS_GT_DB_OBJ => "actual version (%{actual_version}) greater than %{addl} db version",
+    ACTUAL_VERS_LT_DB_OBJ => "actual version (%{actual_version}) less than %{addl} db version; ERROR!",
     CREATED_NEW_OBJECT => "added object to db as it did not exist",
     DB_UPDATE_FAILED => "db update failed: %{addl}",
-    OBJECT_ALREADY_EXISTS => "%{addl} db object already exists",
-    OBJECT_DOES_NOT_EXIST => "%{addl} db object does not exist",
+    DB_OBJ_ALREADY_EXISTS => "%{addl} db object already exists",
+    DB_OBJ_DOES_NOT_EXIST => "%{addl} db object does not exist",
     PC_STATUS_CHANGED => "PreservedCopy status changed from %{old_status} to %{new_status}",
     UNEXPECTED_VERSION => "actual version (%{actual_version}) has unexpected relationship to %{addl} db version; ERROR!",
     INVALID_MOAB => "Invalid moab, validation errors: %{addl}",
@@ -43,10 +43,10 @@ class AuditResults
   }.freeze
 
   WORKFLOW_REPORT_CODES = [
-    ARG_VERSION_LESS_THAN_DB_OBJECT,
+    ACTUAL_VERS_LT_DB_OBJ,
     DB_UPDATE_FAILED,
-    OBJECT_ALREADY_EXISTS,
-    OBJECT_DOES_NOT_EXIST,
+    DB_OBJ_ALREADY_EXISTS,
+    DB_OBJ_DOES_NOT_EXIST,
     UNEXPECTED_VERSION,
     PC_PO_VERSION_MISMATCH,
     ONLINE_MOAB_DOES_NOT_EXIST
@@ -61,12 +61,12 @@ class AuditResults
     case result_code
     when INVALID_ARGUMENTS then Logger::ERROR
     when VERSION_MATCHES then Logger::INFO
-    when ARG_VERSION_GREATER_THAN_DB_OBJECT then Logger::INFO
-    when ARG_VERSION_LESS_THAN_DB_OBJECT then Logger::ERROR
+    when ACTUAL_VERS_GT_DB_OBJ then Logger::INFO
+    when ACTUAL_VERS_LT_DB_OBJ then Logger::ERROR
     when CREATED_NEW_OBJECT then Logger::INFO
     when DB_UPDATE_FAILED then Logger::ERROR
-    when OBJECT_ALREADY_EXISTS then Logger::ERROR
-    when OBJECT_DOES_NOT_EXIST then Logger::ERROR
+    when DB_OBJ_ALREADY_EXISTS then Logger::ERROR
+    when DB_OBJ_DOES_NOT_EXIST then Logger::ERROR
     when PC_STATUS_CHANGED then Logger::INFO
     when UNEXPECTED_VERSION then Logger::ERROR
     when INVALID_MOAB then Logger::ERROR

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe AuditResults do
         result_msg_args1 = { pc_version: 1, po_version: 2 }
         audit_results.add_result(code1, result_msg_args1)
         wf_err_msg1 = audit_results.send(:result_code_msg, code1, result_msg_args1)
-        code2 = AuditResults::OBJECT_ALREADY_EXISTS
+        code2 = AuditResults::DB_OBJ_ALREADY_EXISTS
         result_msg_args2 = 'foo'
         audit_results.add_result(code2, result_msg_args2)
         wf_err_msg2 = audit_results.send(:result_code_msg, code2, result_msg_args2)

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -202,8 +202,8 @@ RSpec.describe PreservedObjectHandler do
               expect(results).to be_an_instance_of Array
               expect(results.size).to eq 2
             end
-            it 'ARG_VERSION_GREATER_THAN_DB_OBJECT results' do
-              code = AuditResults::ARG_VERSION_GREATER_THAN_DB_OBJECT
+            it 'ACTUAL_VERS_GT_DB_OBJ results' do
+              code = AuditResults::ACTUAL_VERS_GT_DB_OBJ
               expect(results).to include(a_hash_including(code => version_gt_pc_msg))
               expect(results).to include(a_hash_including(code => version_gt_po_msg))
             end
@@ -302,8 +302,8 @@ RSpec.describe PreservedObjectHandler do
               expect(results).to be_an_instance_of Array
               expect(results.size).to eq 4
             end
-            it 'ARG_VERSION_GREATER_THAN_DB_OBJECT results' do
-              code = AuditResults::ARG_VERSION_GREATER_THAN_DB_OBJECT
+            it 'ACTUAL_VERS_GT_DB_OBJ results' do
+              code = AuditResults::ACTUAL_VERS_GT_DB_OBJ
               expect(results).to include(a_hash_including(code => version_gt_pc_msg))
               expect(results).to include(a_hash_including(code => version_gt_po_msg))
             end
@@ -494,8 +494,8 @@ RSpec.describe PreservedObjectHandler do
               expect(results).to be_an_instance_of Array
               expect(results.size).to eq 2
             end
-            it 'OBJECT_DOES_NOT_EXIST results' do
-              code = AuditResults::OBJECT_DOES_NOT_EXIST
+            it 'DB_OBJ_DOES_NOT_EXIST results' do
+              code = AuditResults::DB_OBJ_DOES_NOT_EXIST
               expect(results).to include(a_hash_including(code => exp_po_not_exist_msg))
             end
             it 'CREATED_NEW_OBJECT result' do
@@ -591,8 +591,8 @@ RSpec.describe PreservedObjectHandler do
               code = AuditResults::INVALID_MOAB
               expect(results).to include(a_hash_including(code => exp_moab_errs_msg))
             end
-            it 'OBJECT_DOES_NOT_EXIST results' do
-              code = AuditResults::OBJECT_DOES_NOT_EXIST
+            it 'DB_OBJ_DOES_NOT_EXIST results' do
+              code = AuditResults::DB_OBJ_DOES_NOT_EXIST
               expect(results).to include(a_hash_including(code => exp_po_not_exist_msg))
             end
             it 'CREATED_NEW_OBJECT result' do

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe PreservedObjectHandler do
         PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
         po_handler = described_class.new(druid, 3, incoming_size, diff_ep)
         results = po_handler.confirm_version
-        code = AuditResults::OBJECT_DOES_NOT_EXIST
+        code = AuditResults::DB_OBJ_DOES_NOT_EXIST
         exp_str = "ActiveRecord::RecordNotFound: Couldn't find PreservedCopy> db object does not exist"
         expect(results).to include(a_hash_including(code => a_string_matching(exp_str)))
         expect(PreservedObject.find_by(druid: druid).current_version).to eq 2

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe PreservedObjectHandler do
       po_handler.create
       new_po_handler = described_class.new(druid, incoming_version, incoming_size, ep)
       results = new_po_handler.create
-      code = AuditResults::OBJECT_ALREADY_EXISTS
+      code = AuditResults::DB_OBJ_ALREADY_EXISTS
       expect(results).to include(a_hash_including(code => a_string_matching('PreservedObject db object already exists')))
     end
 

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe PreservedObjectHandler do
             expect(results).to be_an_instance_of Array
             expect(results.size).to eq 2
           end
-          it 'ARG_VERSION_GREATER_THAN_DB_OBJECT results' do
-            code = AuditResults::ARG_VERSION_GREATER_THAN_DB_OBJECT
+          it 'ACTUAL_VERS_GT_DB_OBJ results' do
+            code = AuditResults::ACTUAL_VERS_GT_DB_OBJ
             expect(results).to include(a_hash_including(code => version_gt_pc_msg))
             expect(results).to include(a_hash_including(code => version_gt_po_msg))
           end

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -62,8 +62,8 @@ RSpec.shared_examples 'druid not in catalog' do |method_sym|
     po_handler.send(method_sym)
   end
 
-  it 'OBJECT_DOES_NOT_EXIST error' do
-    code = AuditResults::OBJECT_DOES_NOT_EXIST
+  it 'DB_OBJ_DOES_NOT_EXIST error' do
+    code = AuditResults::DB_OBJ_DOES_NOT_EXIST
     expect(results).to include(a_hash_including(code => a_string_matching(exp_msg)))
   end
 end
@@ -85,8 +85,8 @@ RSpec.shared_examples 'PreservedCopy does not exist' do |method_sym|
     po_handler.send(method_sym)
   end
 
-  it 'OBJECT_DOES_NOT_EXIST error' do
-    code = AuditResults::OBJECT_DOES_NOT_EXIST
+  it 'DB_OBJ_DOES_NOT_EXIST error' do
+    code = AuditResults::DB_OBJ_DOES_NOT_EXIST
     expect(results).to include(a_hash_including(code => exp_msg))
   end
 end
@@ -162,8 +162,8 @@ RSpec.shared_examples 'unexpected version' do |method_sym, actual_version|
       # NOTE this is not checking that we have the CORRECT specific code
       codes = [
         AuditResults::VERSION_MATCHES,
-        AuditResults::ARG_VERSION_GREATER_THAN_DB_OBJECT,
-        AuditResults::ARG_VERSION_LESS_THAN_DB_OBJECT
+        AuditResults::ACTUAL_VERS_GT_DB_OBJ,
+        AuditResults::ACTUAL_VERS_LT_DB_OBJ
       ]
       obj_version_results = results.select { |r| codes.include?(r.keys.first) }
       msgs = obj_version_results.map { |r| r.values.first }
@@ -268,8 +268,8 @@ RSpec.shared_examples 'unexpected version with validation' do |method_sym, incom
     it 'specific version results' do
       codes = [
         AuditResults::VERSION_MATCHES,
-        AuditResults::ARG_VERSION_GREATER_THAN_DB_OBJECT,
-        AuditResults::ARG_VERSION_LESS_THAN_DB_OBJECT
+        AuditResults::ACTUAL_VERS_GT_DB_OBJ,
+        AuditResults::ACTUAL_VERS_LT_DB_OBJ
       ]
       obj_version_results = results.select { |r| codes.include?(r.keys.first) }
       msgs = obj_version_results.map { |r| r.values.first }


### PR DESCRIPTION
(again, probably everyone should see this)

AuditResults constant names were confusing me:
- "OBJECT" referring to db vs. moab.
- "actual" which I neglected to migrate to the constants
- THE_INCREDIBLY_LONG_NAMES_I_WROTE_WERE_BOTHERING_ME

Connects to #539