### PR TITLE
De-dup results when catalog_version < moab_version

### DIFF
--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -83,8 +83,6 @@ class CatalogToMoab
       results.report_results
     elsif catalog_version < moab_version
       set_status_as_seen_on_disk(true)
-      results.add_result(AuditResults::UNEXPECTED_VERSION, preserved_copy.class.name)
-      # TODO: avoid repetitious results ... (leave out line above??) - see #484
       pohandler = PreservedObjectHandler.new(druid, moab_version, moab.size, preserved_copy.endpoint)
       pohandler.update_version_after_validation # results reported by this call
     else # catalog_version > moab_version

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -177,13 +177,6 @@ RSpec.describe CatalogToMoab do
         allow(moab).to receive(:current_version_id).and_return(4)
       end
 
-      it 'adds an UNEXPECTED_VERSION result' do
-        results = instance_double(AuditResults, report_results: nil, :actual_version= => nil, :check_name= => nil)
-        expect(results).to receive(:add_result).with(AuditResults::UNEXPECTED_VERSION, 'PreservedCopy')
-        allow(results).to receive(:add_result).with(any_args)
-        allow(AuditResults).to receive(:new).and_return(results)
-        c2m.check_catalog_version
-      end
       it 'calls PreservedObjectHandler.update_version_after_validation' do
         pohandler = instance_double(PreservedObjectHandler)
         expect(PreservedObjectHandler).to receive(:new).and_return(pohandler)


### PR DESCRIPTION
  When we remove the unexpected_version result, rspec complains:
  
  ```
  expected: (:unexpected_version, "PreservedCopy")
              got: (:actual_vers_gt_db_obj, "PreservedCopy") (1 time)
                   (:actual_vers_gt_db_obj, "PreservedObject") (1 time)
  ```
  The two `actual_ver` messages seem sufficient. Fixes #484