### PR TITLE
Reduce duplication in lib/audit/checksum class

### DIFF
--- a/lib/audit/checksum.rb
+++ b/lib/audit/checksum.rb
@@ -8,21 +8,21 @@ class Checksum
   # rubocop:disable Style/EmptyMethod:
   # TODO: implement this;  we begin with a placeholder
 
-  def self.checksum_validate_disk(last_checked_b4, endpoint, algorithm="MD5")
+  def self.validate_disk(last_checked_b4, endpoint, algorithm="MD5")
   end
 
-  def self.checksum_validate_disk_profiled(last_checked_b4, endpoint, algorithm)
+  def self.validate_disk_profiled(last_checked_b4, endpoint, algorithm)
     profiler = Profiler.new
-    profiler.prof { checksum_validate_disk(last_checked_b4, endpoint, algorithm) }
+    profiler.prof { validate_disk(last_checked_b4, endpoint, algorithm) }
     profiler.print_results_flat('CV_checksum_validation_on_dir')
   end
 
-  def self.checksum_validate_disk_all_endpoints(last_checked_b4, algorithm="md5")
+  def self.validate_disk_all_endpoints(last_checked_b4, algorithm="md5")
   end
 
-  def self.checksum_validate_disk_all_endpoints_profiled(last_checked_b4, algorithm)
+  def self.validate_disk_all_endpoints_profiled(last_checked_b4, algorithm)
     profiler = Profiler.new
-    profiler.prof { checksum_validate_disk_all_endpoints(last_checked_b4, algorithm) }
+    profiler.prof { validate_disk_all_endpoints(last_checked_b4, algorithm) }
     profiler.print_results_flat('CV_checksum_validation_all_endpoints')
   end
 

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -6,13 +6,13 @@ require_relative "../../../lib/audit/checksum.rb"
 
 RSpec.describe Checksum do
 
-  describe ".checksum_validate_disk" do
-    described_class.checksum_validate_disk('2018-02-05 21:37:23 UTC', 'services-disk04', 'MD5')
+  describe ".validate_disk" do
+    described_class.validate_disk('2018-02-05 21:37:23 UTC', 'services-disk04', 'MD5')
     skip 'we should figure out what they are and test them'
   end
 
-  describe ".checksum_validate_disk_profiled" do
-    let(:subject) { described_class.checksum_validate_disk_profiled(Time.now.utc, 'services-disk04', 'MD5') }
+  describe ".validate_disk_profiled" do
+    let(:subject) { described_class.validate_disk_profiled(Time.now.utc, 'services-disk04', 'MD5') }
 
     it "spins up a profiler, calling profiling and printing methods on it" do
       mock_profiler = instance_double(Profiler)
@@ -22,26 +22,26 @@ RSpec.describe Checksum do
       subject
     end
 
-    it "calls .checksum_validate_disk" do
-      expect(described_class).to receive(:checksum_validate_disk)
+    it "calls .validate_disk" do
+      expect(described_class).to receive(:validate_disk)
       subject
     end
   end
 
-  describe ".checksum_validate_disk_all_endpoints" do
-    it 'calls checksum_validate_disk once per endpoint' do
-      described_class.checksum_validate_disk_all_endpoints('2018-02-05 21:37:23 UTC', 'MD5')
+  describe ".validate_disk_all_endpoints" do
+    it 'calls validate_disk once per endpoint' do
+      described_class.validate_disk_all_endpoints('2018-02-05 21:37:23 UTC', 'MD5')
       skip 'we should figure out what they are and test them'
     end
 
-    it 'calls checksum_validate_disk with the right arguments' do
-      described_class.checksum_validate_disk_all_endpoints('2018-02-05 21:37:23 UTC', 'MD5')
+    it 'calls validate_disk with the right arguments' do
+      described_class.validate_disk_all_endpoints('2018-02-05 21:37:23 UTC', 'MD5')
       skip 'we should figure out what they are and test them'
     end
   end
 
-  describe ".checksum_validate_disk_all_endpoints_profiled" do
-    let(:subject) { described_class.checksum_validate_disk_all_endpoints_profiled(Time.now.utc, 'MD5') }
+  describe ".validate_disk_all_endpoints_profiled" do
+    let(:subject) { described_class.validate_disk_all_endpoints_profiled(Time.now.utc, 'MD5') }
 
     it "spins up a profiler, calling profiling and printing methods on it" do
       mock_profiler = instance_double(Profiler)
@@ -50,8 +50,8 @@ RSpec.describe Checksum do
       expect(mock_profiler).to receive(:print_results_flat).with('CV_checksum_validation_all_endpoints')
       subject
     end
-    it "calls .checksum_validate_disk_all_endpoints" do
-      expect(described_class).to receive(:checksum_validate_disk_all_endpoints)
+    it "calls .validate_disk_all_endpoints" do
+      expect(described_class).to receive(:validate_disk_all_endpoints)
       subject
     end
   end


### PR DESCRIPTION
  Fixes #572 
  Should just need 1 pair of eyes, granted that the approach discussed in #572 is acceptable to all.