### PR TITLE
db migration to index po and pc created_at and updated_at dates

### DIFF
--- a/db/migrate/20180218003253_add_index_to_db_dates.rb
+++ b/db/migrate/20180218003253_add_index_to_db_dates.rb
@@ -1,0 +1,8 @@
+class AddIndexToDbDates < ActiveRecord::Migration[5.1]
+  def change
+    add_index :preserved_copies, :created_at
+    add_index :preserved_copies, :updated_at
+    add_index :preserved_objects, :created_at
+    add_index :preserved_objects, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171220010020) do
+ActiveRecord::Schema.define(version: 20180218003253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,12 +62,14 @@ ActiveRecord::Schema.define(version: 20171220010020) do
     t.bigint "size"
     t.integer "status", null: false
     t.datetime "last_version_audit"
+    t.index ["created_at"], name: "index_preserved_copies_on_created_at"
     t.index ["endpoint_id"], name: "index_preserved_copies_on_endpoint_id"
     t.index ["last_checksum_validation"], name: "index_preserved_copies_on_last_checksum_validation"
     t.index ["last_moab_validation"], name: "index_preserved_copies_on_last_moab_validation"
     t.index ["last_version_audit"], name: "index_preserved_copies_on_last_version_audit"
     t.index ["preserved_object_id"], name: "index_preserved_copies_on_preserved_object_id"
     t.index ["status"], name: "index_preserved_copies_on_status"
+    t.index ["updated_at"], name: "index_preserved_copies_on_updated_at"
   end
 
   create_table "preserved_objects", force: :cascade do |t|
@@ -76,8 +78,10 @@ ActiveRecord::Schema.define(version: 20171220010020) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "preservation_policy_id", null: false
+    t.index ["created_at"], name: "index_preserved_objects_on_created_at"
     t.index ["druid"], name: "index_preserved_objects_on_druid", unique: true
     t.index ["preservation_policy_id"], name: "index_preserved_objects_on_preservation_policy_id"
+    t.index ["updated_at"], name: "index_preserved_objects_on_updated_at"
   end
 
   add_foreign_key "endpoints", "endpoint_types"


### PR DESCRIPTION
2 reviewers?

It turns out we have been using updated_at when we query the db for timings and state via the rails console.

So far we've only used `PreservedCopy.updated_at` in those queries, by and large, but I thought we might play it safe.  Happy to index fewer fields with this PR if there's a reason not to index.  (Performance concerns?)

Closes #442

If we deploy to stage and prod with cap, this migration will happen appropriately.  No db data manipulation needed.