### PR TITLE
seeding, m2c, c2m: better output

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -127,6 +127,11 @@ Naming/FileName:
 
 # --- Performance ---
 
+Performance/HashEachMethods:
+  Exclude:
+    - lib/audit/catalog_to_moab.rb # it's a tiny config object; code is clearer as is
+    - lib/audit/moab_to_catalog.rb # it's a tiny config object; code is clearer as is
+
 # --- Rails ---
 
 Rails/HasAndBelongsToMany:

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -9,6 +9,9 @@ class CatalogToMoab
   # process records in order in batches.  Note that .find_each does batches, but disregards order from
   # the scope, so we must use .each
   def self.check_version_on_dir(last_checked_b4_date, storage_dir, limit=Settings.c2m_sql_limit)
+    start_msg = "#{Time.now.utc.iso8601} C2M check_version starting for #{storage_dir}"
+    puts start_msg
+    Rails.logger.info start_msg
     num_to_process = PreservedCopy.least_recent_version_audit(last_checked_b4_date, storage_dir).count
     while num_to_process > 0
       pcs = PreservedCopy.least_recent_version_audit(last_checked_b4_date, storage_dir).limit(limit)
@@ -18,6 +21,9 @@ class CatalogToMoab
       end
       num_to_process -= limit
     end
+    end_msg = "#{Time.now.utc.iso8601} C2M check_version ended for #{storage_dir}"
+    puts end_msg
+    Rails.logger.info end_msg
   end
 
   def self.check_version_on_dir_profiled(last_checked_b4_date, storage_dir)
@@ -27,15 +33,15 @@ class CatalogToMoab
   end
 
   def self.check_version_all_dirs(last_checked_b4_date)
-    Settings.moab.storage_roots.each do |strg_root_name, strg_root_location|
-      start_msg = "#{Time.now.utc.iso8601} C2M check_version starting for '#{strg_root_name}' at #{strg_root_location}"
-      puts start_msg
-      Rails.logger.info start_msg
+    start_msg = "#{Time.now.utc.iso8601} C2M check_version_all_dirs starting"
+    puts start_msg
+    Rails.logger.info start_msg
+    Settings.moab.storage_roots.each do |_strg_root_name, strg_root_location|
       check_version_on_dir(last_checked_b4_date, "#{strg_root_location}/#{Settings.moab.storage_trunk}")
-      end_msg = "#{Time.now.utc.iso8601} C2M check_version ended for '#{strg_root_name}' at #{strg_root_location}"
-      puts end_msg
-      Rails.logger.info end_msg
     end
+    end_msg = "#{Time.now.utc.iso8601} C2M check_version_all_dirs ended"
+    puts end_msg
+    Rails.logger.info end_msg
   end
 
   def self.check_version_all_dirs_profiled(last_checked_b4_date)

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -7,6 +7,9 @@ class MoabToCatalog
 
   # NOTE: shameless green! code duplication with seed_catalog_for_dir
   def self.check_existence_for_dir(storage_dir)
+    start_msg = "#{Time.now.utc.iso8601} M2C check_existence starting for '#{storage_dir}'"
+    puts start_msg
+    Rails.logger.info start_msg
     results = []
     endpoint = Endpoint.find_by!(storage_location: storage_dir)
     Stanford::MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
@@ -14,6 +17,9 @@ class MoabToCatalog
       po_handler = PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, endpoint)
       results.concat po_handler.check_existence
     end
+    end_msg = "#{Time.now.utc.iso8601} M2C check_existence ended for '#{storage_dir}'"
+    puts end_msg
+    Rails.logger.info end_msg
     results
   end
 
@@ -25,6 +31,9 @@ class MoabToCatalog
 
   # NOTE: shameless green! code duplication with check_existence_for_dir
   def self.seed_catalog_for_dir(storage_dir)
+    start_msg = "#{Time.now.utc.iso8601} Seeding starting for '#{storage_dir}'"
+    puts start_msg
+    Rails.logger.info start_msg
     results = []
     endpoint = Endpoint.find_by!(storage_location: storage_dir)
     Stanford::MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
@@ -32,20 +41,23 @@ class MoabToCatalog
       po_handler = PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, endpoint)
       results << po_handler.create_after_validation
     end
+    end_msg = "#{Time.now.utc.iso8601} Seeding ended for '#{storage_dir}'"
+    puts end_msg
+    Rails.logger.info end_msg
     results
   end
 
   # Shameless green. In order to run several seed "jobs" in parallel, we would have to refactor.
   def self.seed_catalog_for_all_storage_roots
-    Settings.moab.storage_roots.each do |strg_root_name, strg_root_location|
-      start_msg = "#{Time.now.utc.iso8601} Seeding starting for '#{strg_root_name}'"
-      puts start_msg
-      Rails.logger.info start_msg
+    start_msg = "#{Time.now.utc.iso8601} Seeding for all storage roots starting"
+    puts start_msg
+    Rails.logger.info start_msg
+    Settings.moab.storage_roots.each do |_strg_root_name, strg_root_location|
       seed_catalog_for_dir("#{strg_root_location}/#{Settings.moab.storage_trunk}")
-      end_msg = "#{Time.now.utc.iso8601} Seeding ended for '#{strg_root_name}'"
-      puts end_msg
-      Rails.logger.info end_msg
     end
+    end_msg = "#{Time.now.utc.iso8601} Seeding for all storage roots ended'"
+    puts end_msg
+    Rails.logger.info end_msg
   end
 
   def self.seed_catalog_for_all_storage_roots_profiled
@@ -56,15 +68,15 @@ class MoabToCatalog
 
   # Shameless green. Code duplication with seed_catalog_for_all_storage_roots
   def self.check_existence_for_all_storage_roots
-    Settings.moab.storage_roots.each do |strg_root_name, strg_root_location|
-      start_msg = "#{Time.now.utc.iso8601} M2C check_existence starting for '#{strg_root_name}'"
-      puts start_msg
-      Rails.logger.info start_msg
+    start_msg = "#{Time.now.utc.iso8601} M2C check_existence for all storage roots starting'"
+    puts start_msg
+    Rails.logger.info start_msg
+    Settings.moab.storage_roots.each do |_strg_root_name, strg_root_location|
       check_existence_for_dir("#{strg_root_location}/#{Settings.moab.storage_trunk}")
-      end_msg = "#{Time.now.utc.iso8601} M2C check_existence ended for '#{strg_root_name}'"
-      puts end_msg
-      Rails.logger.info end_msg
     end
+    end_msg = "#{Time.now.utc.iso8601} M2C check_existence for all storage roots ended'"
+    puts end_msg
+    Rails.logger.info end_msg
   end
 
   def self.check_existence_for_all_storage_roots_profiled


### PR DESCRIPTION
Since I've been perusing logs for info for our new stats chart, I discovered that we had no beginning and ending markers when we ran a check for a single root.  This PR fixes this oversight.

1 reviewer, unless anyone has strong opinions about directory names vs root names showing up in output.