### PR TITLE
Object creation is not an error

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -144,13 +144,13 @@ class AuditResults
   def report_errors_to_workflows(candidate_workflow_results)
     return if candidate_workflow_results.empty?
     value_array = []
-    value_array << workflows_msg_prefix
     candidate_workflow_results.each do |result_hash|
       result_hash.each_value do |val|
         value_array << val
       end
     end
-    WorkflowErrorsReporter.update_workflow(druid, 'preservation-audit', value_array.join(" || "))
+    msg = "#{workflows_msg_prefix} #{value_array.join(' && ')}"
+    WorkflowErrorsReporter.update_workflow(druid, 'preservation-audit', msg)
   end
 
   def log_result(result)

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -56,7 +56,6 @@ class AuditResults
     ACTUAL_VERS_LT_DB_OBJ,
     DB_UPDATE_FAILED,
     DB_OBJ_ALREADY_EXISTS,
-    DB_OBJ_DOES_NOT_EXIST,
     UNEXPECTED_VERSION,
     PC_PO_VERSION_MISMATCH,
     MOAB_NOT_FOUND,
@@ -81,7 +80,7 @@ class AuditResults
     when CREATED_NEW_OBJECT then Logger::INFO
     when DB_UPDATE_FAILED then Logger::ERROR
     when DB_OBJ_ALREADY_EXISTS then Logger::ERROR
-    when DB_OBJ_DOES_NOT_EXIST then Logger::ERROR
+    when DB_OBJ_DOES_NOT_EXIST then Logger::WARN
     when PC_STATUS_CHANGED then Logger::INFO
     when UNEXPECTED_VERSION then Logger::ERROR
     when INVALID_MOAB then Logger::ERROR

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -77,11 +77,9 @@ class PreservedObjectHandler
           if incoming_version == pres_copy.version
             set_status_as_seen_on_disk(pres_copy, true) unless pres_copy.status == PreservedCopy::OK_STATUS
             handler_results.add_result(AuditResults::VERSION_MATCHES, 'PreservedCopy')
-            handler_results.add_result(AuditResults::VERSION_MATCHES, 'PreservedObject')
           elsif incoming_version > pres_copy.version
             set_status_as_seen_on_disk(pres_copy, true) unless pres_copy.status == PreservedCopy::OK_STATUS
             handler_results.add_result(AuditResults::ACTUAL_VERS_GT_DB_OBJ, db_obj_name: 'PreservedCopy', db_obj_version: pres_copy.version)
-            handler_results.add_result(AuditResults::ACTUAL_VERS_GT_DB_OBJ, db_obj_name: 'PreservedObject', db_obj_version: pres_object.current_version)
             if moab_validation_errors.empty?
               pres_copy.upd_audstamps_version_size(ran_moab_validation?, incoming_version, incoming_size)
               pres_object.current_version = incoming_version
@@ -92,7 +90,6 @@ class PreservedObjectHandler
           else # incoming_version < pres_copy.version
             set_status_as_seen_on_disk(pres_copy, false)
             handler_results.add_result(AuditResults::ACTUAL_VERS_LT_DB_OBJ, db_obj_name: 'PreservedCopy', db_obj_version: pres_copy.version)
-            handler_results.add_result(AuditResults::ACTUAL_VERS_LT_DB_OBJ, db_obj_name: 'PreservedObject', db_obj_version: pres_object.current_version)
           end
           pres_copy.update_audit_timestamps(ran_moab_validation?, true)
           pres_copy.save!
@@ -233,7 +230,6 @@ class PreservedObjectHandler
         # add results without db updates
         code = AuditResults::ACTUAL_VERS_GT_DB_OBJ
         handler_results.add_result(code, db_obj_name: 'PreservedCopy', db_obj_version: pres_copy.version)
-        handler_results.add_result(code, db_obj_name: 'PreservedObject', db_obj_version: pres_object.current_version)
 
         pres_copy.upd_audstamps_version_size(ran_moab_validation?, incoming_version, incoming_size)
         update_status(pres_copy, status) if status && ran_moab_validation?
@@ -244,7 +240,7 @@ class PreservedObjectHandler
         if set_status_to_unexp_version
           status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
         end
-        update_pc_unexpected_version(pres_copy, pres_object, status)
+        update_pc_unexpected_version(pres_copy, status)
       end
     end
 
@@ -292,10 +288,9 @@ class PreservedObjectHandler
     update_status(pres_copy, PreservedCopy::OK_STATUS)
   end
 
-  def update_pc_unexpected_version(pres_copy, pres_object, new_status)
+  def update_pc_unexpected_version(pres_copy, new_status)
     handler_results.add_result(AuditResults::UNEXPECTED_VERSION, db_obj_name: 'PreservedCopy', db_obj_version: pres_copy.version)
     version_comparison_results(pres_copy, pres_copy.version)
-    version_comparison_results(pres_object, pres_object.current_version)
 
     update_status(pres_copy, new_status) if new_status
     pres_copy.update_audit_timestamps(ran_moab_validation?, true)
@@ -314,7 +309,6 @@ class PreservedObjectHandler
       if incoming_version == pres_copy.version
         set_status_as_seen_on_disk(pres_copy, true) unless pres_copy.status == PreservedCopy::OK_STATUS
         handler_results.add_result(AuditResults::VERSION_MATCHES, 'PreservedCopy')
-        handler_results.add_result(AuditResults::VERSION_MATCHES, 'PreservedObject')
       else
         set_status_as_seen_on_disk(pres_copy, false)
         handler_results.add_result(AuditResults::UNEXPECTED_VERSION, db_obj_name: 'PreservedCopy', db_obj_version: pres_copy.version)

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -136,10 +136,19 @@ RSpec.describe AuditResults do
         result_msg_args2 = 'foo'
         audit_results.add_result(code2, result_msg_args2)
         result_msg2 = audit_results.send(:result_code_msg, code2, result_msg_args2)
-        expect(WorkflowErrorsReporter).to receive(:update_workflow).with(
-          druid, 'preservation-audit', a_string_matching("#{result_msg1} || #{result_msg2}")
+        allow(WorkflowErrorsReporter).to receive(:update_workflow).with(
+          druid, 'preservation-audit', instance_of(String)
         )
         audit_results.report_results
+        expect(WorkflowErrorsReporter).to have_received(:update_workflow).with(
+          druid, 'preservation-audit', a_string_matching(result_msg1)
+        )
+        expect(WorkflowErrorsReporter).to have_received(:update_workflow).with(
+          druid, 'preservation-audit', a_string_matching(/ \&\& /)
+        )
+        expect(WorkflowErrorsReporter).to have_received(:update_workflow).with(
+          druid, 'preservation-audit', a_string_matching(result_msg2)
+        )
       end
       it 'message sent includes endpoint information' do
         code = AuditResults::DB_UPDATE_FAILED

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe PreservedObjectHandler do
 
       context "incoming and db versions match" do
         let(:po_handler) { described_class.new(druid, 2, 1, ep) }
-        let(:version_matches_po_msg) { "actual version (2) matches PreservedObject db version" }
         let(:version_matches_pc_msg) { "actual version (2) matches PreservedCopy db version" }
 
         context 'PreservedCopy' do
@@ -85,21 +84,19 @@ RSpec.describe PreservedObjectHandler do
         context 'returns' do
           let!(:results) { po_handler.check_existence }
 
-          it '2 results' do
+          it '1 result' do
             expect(results).to be_an_instance_of Array
-            expect(results.size).to eq 2
+            expect(results.size).to eq 1
           end
           it 'VERSION_MATCHES results' do
             code = AuditResults::VERSION_MATCHES
             expect(results).to include(a_hash_including(code => version_matches_pc_msg))
-            expect(results).to include(a_hash_including(code => version_matches_po_msg))
           end
         end
       end
 
       context "incoming version > db version" do
         let(:version_gt_pc_msg) { "actual version (#{incoming_version}) greater than PreservedCopy db version (2)" }
-        let(:version_gt_po_msg) { "actual version (#{incoming_version}) greater than PreservedObject db version (2)" }
 
         it 'calls Stanford::StorageObjectValidator.validation_errors for moab' do
           mock_sov = instance_double(Stanford::StorageObjectValidator)
@@ -198,14 +195,13 @@ RSpec.describe PreservedObjectHandler do
             before do
               allow(po_handler).to receive(:moab_validation_errors).and_return([])
             end
-            it '2 results' do
+            it '1 result' do
               expect(results).to be_an_instance_of Array
-              expect(results.size).to eq 2
+              expect(results.size).to eq 1
             end
             it 'ACTUAL_VERS_GT_DB_OBJ results' do
               code = AuditResults::ACTUAL_VERS_GT_DB_OBJ
               expect(results).to include(a_hash_including(code => version_gt_pc_msg))
-              expect(results).to include(a_hash_including(code => version_gt_po_msg))
             end
           end
         end
@@ -298,14 +294,13 @@ RSpec.describe PreservedObjectHandler do
           context 'returns' do
             let!(:results) { invalid_po_handler.check_existence }
 
-            it '4 results' do
+            it '3 results' do
               expect(results).to be_an_instance_of Array
-              expect(results.size).to eq 4
+              expect(results.size).to eq 3
             end
             it 'ACTUAL_VERS_GT_DB_OBJ results' do
               code = AuditResults::ACTUAL_VERS_GT_DB_OBJ
               expect(results).to include(a_hash_including(code => version_gt_pc_msg))
-              expect(results).to include(a_hash_including(code => version_gt_po_msg))
             end
             it 'INVALID_MOAB result' do
               expect(results).to include(a_hash_including(AuditResults::INVALID_MOAB))

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe PreservedObjectHandler do
 
       context "incoming and db versions match" do
         let(:po_handler) { described_class.new(druid, 2, 1, ep) }
-        let(:version_matches_po_msg) { "actual version (2) matches PreservedObject db version" }
         let(:version_matches_pc_msg) { "actual version (2) matches PreservedCopy db version" }
 
         context 'PreservedCopy' do
@@ -96,14 +95,13 @@ RSpec.describe PreservedObjectHandler do
         context 'returns' do
           let!(:results) { po_handler.confirm_version }
 
-          it '2 results' do
+          it '1 result' do
             expect(results).to be_an_instance_of Array
-            expect(results.size).to eq 2
+            expect(results.size).to eq 1
           end
           it 'VERSION_MATCHES results' do
             code = AuditResults::VERSION_MATCHES
             expect(results).to include(a_hash_including(code => version_matches_pc_msg))
-            expect(results).to include(a_hash_including(code => version_matches_po_msg))
           end
         end
       end

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -86,16 +86,14 @@ RSpec.describe PreservedObjectHandler do
         context 'returns' do
           let!(:results) { po_handler.update_version }
 
-          it '2 results' do
+          it '1 results' do
             expect(results).to be_an_instance_of Array
-            expect(results.size).to eq 2
+            expect(results.size).to eq 1
           end
           it 'ACTUAL_VERS_GT_DB_OBJ results' do
             code = AuditResults::ACTUAL_VERS_GT_DB_OBJ
             version_gt_pc_msg = "actual version (#{incoming_version}) greater than PreservedCopy db version (2)"
             expect(results).to include(a_hash_including(code => version_gt_pc_msg))
-            version_gt_po_msg = "actual version (#{incoming_version}) greater than PreservedObject db version (2)"
-            expect(results).to include(a_hash_including(code => version_gt_po_msg))
           end
         end
       end

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -152,7 +152,7 @@ RSpec.shared_examples 'unexpected version' do |method_sym, actual_version|
 
     it "number of results" do
       expect(results).to be_an_instance_of Array
-      expect(results.size).to eq 4
+      expect(results.size).to eq 3
     end
     it 'UNEXPECTED_VERSION result' do
       code = AuditResults::UNEXPECTED_VERSION
@@ -167,7 +167,6 @@ RSpec.shared_examples 'unexpected version' do |method_sym, actual_version|
       ]
       obj_version_results = results.select { |r| codes.include?(r.keys.first) }
       msgs = obj_version_results.map { |r| r.values.first }
-      expect(msgs).to include(a_string_matching("PreservedObject"))
       expect(msgs).to include(a_string_matching("PreservedCopy"))
     end
     if method_sym == :update_version
@@ -245,17 +244,10 @@ RSpec.shared_examples 'unexpected version with validation' do |method_sym, incom
 
   context 'returns' do
     let!(:results) { po_handler.send(method_sym) }
-    let(:num_results) do
-      if method_sym == :check_existence
-        3
-      elsif method_sym == :update_version_after_validation
-        2
-      end
-    end
 
     it "number of results" do
       expect(results).to be_an_instance_of Array
-      expect(results.size).to eq num_results
+      expect(results.size).to eq 2
     end
     if method_sym == :update_version_after_validation
       it 'UNEXPECTED_VERSION result unless INVALID_MOAB' do
@@ -274,7 +266,6 @@ RSpec.shared_examples 'unexpected version with validation' do |method_sym, incom
       obj_version_results = results.select { |r| codes.include?(r.keys.first) }
       msgs = obj_version_results.map { |r| r.values.first }
       unless results.find { |r| r.keys.first == AuditResults::INVALID_MOAB }
-        expect(msgs).to include(a_string_matching("PreservedObject"))
         expect(msgs).to include(a_string_matching("PreservedCopy"))
       end
     end


### PR DESCRIPTION
- DB_OBJ_DOES_NOT_EXIST result is NOT reported to workflows (it's not really an error)
- DB_OBJ_DOES_NOT_EXIST result is a WARN in rails logs, not ERROR

- also tweaked msg sent to workflows, as there should be no separator between the workflows prefix and the first error message, and the separator '&&' makes more sense than '||'.

- removed some of the duplicate log messages

FIxes #584
Connected to #410