### PR TITLE
Gemfile: the :not_travis gems are still needed in the :development and :production envs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,8 @@ gem 'ruby-prof' # to profile methods
 gem 'moab-versioning' # work with Moab Objects
 gem 'druid-tools' # for druid validation and druid-tree parsing
 
-# gem group for travis NOT to load
-group :not_travis do
+# group for gems travis doesn't need to install, but useful in non- test/CI environments (i.e. prod and dev)
+group :production, :development, :not_travis do
   gem 'honeybadger' # for error reporting / tracking / notifications
   gem 'newrelic_rpm' # for production performance modeling
   # useful for debugging, even in prod


### PR DESCRIPTION
fixes a regression introduced in #588 (where pry was no longer loaded by default in the dev env, thus reverting the rails console back to using IRB).  i'd guess that this implies that honeybadger and newrelic wouldn't get loaded up in the dev and prod envs after that PR?  not sure.  but this should fix that too.

a bit of relevant documentation:
> By default, a Rails generated app calls `Bundler.require(:default, Rails.env)` in your `application.rb`, which links the groups in your Gemfile to the Rails environment. If you use other groups (not linked to a Rails environment), you can add them to the call to Bundler.require, if you want them to be automatically required.
  -- https://bundler.io/v1.16/guides/groups.html

so, it makes sense that we'd have this issue, since we don't have a `not_travis` env, and so the stuff in that group wouldn't get loaded in any of our environments.  we wouldn't want to always `require` the `not_travis` env in `application.rb`, because then the ci env would try to load gems that bundler was told not to install in that case.  getting more clever than that (a conditional `require` in `application.rb`) seems like overkill.  this PR should hopefully automagically fix things by linking those gems to an env we use again.