### PR TITLE
Checksum validate disk all endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,7 +62,7 @@ Metrics/AbcSize:
     - 'app/services/preserved_object_handler.rb' # methods still readable; shameless green
     - 'app/services/audit_results.rb' # method still readable
     - 'lib/audit/catalog_to_moab.rb' # .check_version_all_dirs is decidedly readable
-    - 'lib/audit/checksum.rb' # # .validate_disk_all)dirs is decidedly readable
+    - 'lib/audit/checksum.rb' # .validate_disk_all_dirs is decidedly readable
     - 'lib/audit/moab_to_catalog.rb' # .xxx_for_all_storage_roots is decidedly readable
 
 Metrics/BlockLength:
@@ -131,7 +131,7 @@ Naming/FileName:
 Performance/HashEachMethods:
   Exclude:
     - lib/audit/catalog_to_moab.rb # it's a tiny config object; code is clearer as is
-    - lib/audit/checksum.rb #it's a tiny config object; code is clearer as is
+    - lib/audit/checksum.rb # it's a tiny config object; code is clearer as is
     - lib/audit/moab_to_catalog.rb # it's a tiny config object; code is clearer as is
 
 # --- Rails ---

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,7 @@ Metrics/AbcSize:
     - 'app/services/preserved_object_handler.rb' # methods still readable; shameless green
     - 'app/services/audit_results.rb' # method still readable
     - 'lib/audit/catalog_to_moab.rb' # .check_version_all_dirs is decidedly readable
+    - 'lib/audit/checksum.rb' # # .validate_disk_all)dirs is decidedly readable
     - 'lib/audit/moab_to_catalog.rb' # .xxx_for_all_storage_roots is decidedly readable
 
 Metrics/BlockLength:
@@ -130,6 +131,7 @@ Naming/FileName:
 Performance/HashEachMethods:
   Exclude:
     - lib/audit/catalog_to_moab.rb # it's a tiny config object; code is clearer as is
+    - lib/audit/checksum.rb #it's a tiny config object; code is clearer as is
     - lib/audit/moab_to_catalog.rb # it's a tiny config object; code is clearer as is
 
 # --- Rails ---
@@ -140,6 +142,7 @@ Rails/HasAndBelongsToMany:
 Rails/Output:
   Exclude:
     - 'lib/audit/catalog_to_moab.rb' # use puts statements for following progress of long job
+    - 'lib/audit/checksum.rb' # use puts statements for following progress of long job
     - 'lib/audit/moab_to_catalog.rb' # use puts statements for following progress of long job
 
 # --- RSpec ---

--- a/README.md
+++ b/README.md
@@ -177,26 +177,27 @@ this will generate a log at, for example,
 #### Single Root
 - Without profiling
 ```ruby
-RAILS_ENV=production bundle exec rake cv_single_endpoint['2018-01-22 22:54:48 UTC',fixture_sr1,'MD5']
+RAILS_ENV=production bundle exec rake cv_single_dir['2018-01-22 22:54:48 UTC','spec/fixtures/storage_root01/moab_storage_trunk']
 ```
 - With profiling
 ```ruby
-RAILS_ENV=production bundle exec rake cv_single_endpoint['2018-01-22 22:54:48 UTC',fixture_sr1,'MD5',profile]
+RAILS_ENV=production bundle exec rake cv_single_dir['2018-01-22 22:54:48 UTC','spec/fixtures/storage_root01/moab_storage_trunk',profile]
 ```
 this will generate a log at, for example,
-```log/profile_cv_single_endpoint2018-01-01T14:25:31-flat.txt```
+```log/profile_cv_single_dir2018-01-01T14:25:31-flat.txt```
 
 #### All Roots
 - Without profiling:
 ```ruby
-RAILS_ENV=production bundle exec rake cv_all_endpoints['2018-01-22 22:54:48 UTC','MD5']
+RAILS_ENV=production bundle exec rake cv_all_dirs['2018-01-22 22:54:48 UTC']
 ```
 - With profiling:
 ```ruby
-RAILS_ENV=production bundle exec rake cv_all_endpoints['2018-01-22 22:54:48 UTC','MD5',profile]
+RAILS_ENV=production bundle exec rake cv_all_dirs['2018-01-22 22:54:48 UTC',profile]
 ```
 this will generate a log at, for example,
-```log/profile_cv_all_endpoints2018-01-01T14:25:31-flat.txt```
+```log/profile_cv_all_dirs2018-01-01T14:25:31-flat.txt```
+
 ## Development
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -170,30 +170,29 @@ this will generate a log at, for example,
 ### Run Checksum Validation for a single root or for all storage roots
 - Parse all manifestInventory.xml and most recent signatureCatalog.xml for stored checksums and verify against computed checksums.
 
-- To run rake tasks below, give a date, the name of the endpoint (e.g. from settings/development.yml) and an algorithm (md5, sha1, sha256) as arguments.
+- To run rake tasks below, give the name of the endpoint (e.g. from settings/development.yml)
 
-- Note: Must enter date/timestamp (UTC) argument as a string.
 
 #### Single Root
 - Without profiling
 ```ruby
-RAILS_ENV=production bundle exec rake cv_single_dir['2018-01-22 22:54:48 UTC','spec/fixtures/storage_root01/moab_storage_trunk']
+RAILS_ENV=production bundle exec rake cv_single_endpoint[fixture_sr3]
 ```
 - With profiling
 ```ruby
-RAILS_ENV=production bundle exec rake cv_single_dir['2018-01-22 22:54:48 UTC','spec/fixtures/storage_root01/moab_storage_trunk',profile]
+RAILS_ENV=production bundle exec rake cv_single_endpoint[fixture_sr3,profile]
 ```
 this will generate a log at, for example,
-```log/profile_cv_single_dir2018-01-01T14:25:31-flat.txt```
+```log/profile_cv_single_endpoint2018-01-01T14:25:31-flat.txt```
 
 #### All Roots
 - Without profiling:
 ```ruby
-RAILS_ENV=production bundle exec rake cv_all_dirs['2018-01-22 22:54:48 UTC']
+RAILS_ENV=production bundle exec rake cv_all_endpoints
 ```
 - With profiling:
 ```ruby
-RAILS_ENV=production bundle exec rake cv_all_dirs['2018-01-22 22:54:48 UTC',profile]
+RAILS_ENV=production bundle exec rake cv_all_endpoints[profile]
 ```
 this will generate a log at, for example,
 ```log/profile_cv_all_dirs2018-01-01T14:25:31-flat.txt```

--- a/Rakefile
+++ b/Rakefile
@@ -166,33 +166,33 @@ task :c2m_check_version_all_dirs, [:last_checked_b4_date, :profile] => [:environ
 end
 
 desc "Fire off checksum validation on a single storage root"
-task :cv_single_dir, [:storage_root, :profile] => [:environment] do |_t, args|
+task :cv_single_endpoint, [:storage_root, :profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
-    p "usage: rake cv_single_dir[storage_root] || rake cv_single_dir[storage_root,profile]"
+    p "usage: rake cv_single_endpoint[storage_root] || rake cv_single_endpoint[storage_root,profile]"
     exit
   end
   storage_root = args[:storage_root].to_sym
   if args[:profile] == 'profile'
-    puts "When done, check log/profile_cv_single_dir[TIMESTAMP] for profiling details"
-    ChecksumValidator.checksum_validate_disk(storage_root)
+    puts "When done, check log/profile_cv_single_endpoint[TIMESTAMP] for profiling details"
+    Checksum.validate_disk_profiled(storage_root)
   elsif args[:profile].nil?
-    ChecksumValidator.checksum_validate_disk_profiled(storage_root)
+    Checksum.validate_disk(storage_root)
   end
   puts "#{Time.now.utc.iso8601} Checksum Validation on #{storage_root} is done."
   $stdout.flush
 end
 
 desc "Fire off checksum validation on all storage roots"
-task :cv_all_dirs, [:profile] => [:environment] do |_t, args|
+task :cv_all_endpoints, [:profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
-    p "usage: rake cv_all_dirs || rake cv_all_dirs[profile]"
+    p "usage: rake cv_all_endpoints || rake cv_all_endpoints[profile]"
     exit
   end
   if args[:profile] == 'profile'
-    puts "When done, check log/profile_cv_all_dirs[TIMESTAMP].txt for profiling details"
-    Checksum.checksum_validate_disk_all_dirs
+    puts "When done, check log/profile_cv_all_endpoints[TIMESTAMP].txt for profiling details"
+    Checksum.validate_disk_all_endpoints_profiled
   elsif args[:profile].nil?
-    Checksum.checksum_validate_disk_all_dirs_profiled
+    Checksum.validate_disk_all_endpoints
   end
   puts "#{Time.now.utc.iso8601} Checksum Validation on all storage roots are done."
   $stdout.flush

--- a/Rakefile
+++ b/Rakefile
@@ -165,39 +165,37 @@ task :c2m_check_version_all_dirs, [:last_checked_b4_date, :profile] => [:environ
   $stdout.flush
 end
 
-desc "Fire off checksum validation on a single endpoint"
-task :cv_single_endpoint, [:last_checked_b4, :endpoint, :algorithm, :profile] => [:environment] do |_t, args|
+desc "Fire off checksum validation on a single storage root"
+task :cv_single_dir, [:last_checked_b4, :storage_dir, :profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
-    p "usage: rake cv_single_endpoint[last_checked_b4, endpoint, algorithm] || rake cv_single_endpoint[last_checked_b4, endpoint, algorithm, profile]"
+    p "usage: rake cv_single_dir[last_checked_b4,storage_dir] || rake cv_single_dir[last_checked_b4,storage_dir,profile]"
     exit
   end
   last_checked = args[:last_checked_b4].to_sym
-  endpoint = args[:endpoint].to_sym
-  algorithm = args[:algorithm].to_sym
+  storage_dir = args[:storage_dir].to_sym
   if args[:profile] == 'profile'
-    puts "When done, check log/profile_cv_single_endpoint[TIMESTAMP] for profiling details"
-    ChecksumValidator.checksum_validate_disk(last_checked, endpoint, algorithm)
+    puts "When done, check log/profile_cv_single_dir[TIMESTAMP] for profiling details"
+    ChecksumValidator.checksum_validate_disk(last_checked, storage_dir)
   elsif args[:profile].nil?
-    ChecksumValidator.checksum_validate_disk_profiled(last_checked, endpoint, algorithm)
+    ChecksumValidator.checksum_validate_disk_profiled(last_checked, storage_dir)
   end
-  puts "#{Time.now.utc.iso8601} Checksum Validation on #{endpoint} is done."
+  puts "#{Time.now.utc.iso8601} Checksum Validation on #{storage_dir} is done."
   $stdout.flush
 end
 
-desc "Fire off checksum validation on all endpoints"
-task :cv_all_endpoints, [:last_checked_b4, :algorithm, :profile] => [:environment] do |_t, args|
+desc "Fire off checksum validation on all storage roots"
+task :cv_all_dirs, [:last_checked_b4, :profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
-    p "usage: rake cv_all_endpoints[last_checked_b4, algorithm] || rake cv_all_endpoints[last_checked_b4, algorithm, profile]"
+    p "usage: rake cv_all_dir[last_checked_b4] || rake cv_all_dirs[last_checked_b4,profile]"
     exit
   end
   last_checked = args[:last_checked_b4].to_sym
-  algorithm = args[:algorithm].to_sym
   if args[:profile] == 'profile'
-    puts "When done, check log/profile_cv_all_endpoints[TIMESTAMP].txt for profiling details"
-    Checksum.checksum_validate_disk_all_endpoints(last_checked, algorithm)
+    puts "When done, check log/profile_cv_all_dirs[TIMESTAMP].txt for profiling details"
+    Checksum.checksum_validate_disk_all_dirs(last_checked)
   elsif args[:profile].nil?
-    Checksum.checksum_validate_disk_all_endpoints_profiled(last_checked, algorithm)
+    Checksum.checksum_validate_disk_all_dirs_profiled(last_checked)
   end
-  puts "#{Time.now.utc.iso8601} Checksum Validation on all endpoints are done."
+  puts "#{Time.now.utc.iso8601} Checksum Validation on all storage roots are done."
   $stdout.flush
 end

--- a/Rakefile
+++ b/Rakefile
@@ -166,35 +166,33 @@ task :c2m_check_version_all_dirs, [:last_checked_b4_date, :profile] => [:environ
 end
 
 desc "Fire off checksum validation on a single storage root"
-task :cv_single_dir, [:last_checked_b4, :storage_dir, :profile] => [:environment] do |_t, args|
+task :cv_single_dir, [:storage_root, :profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
-    p "usage: rake cv_single_dir[last_checked_b4,storage_dir] || rake cv_single_dir[last_checked_b4,storage_dir,profile]"
+    p "usage: rake cv_single_dir[storage_root] || rake cv_single_dir[storage_root,profile]"
     exit
   end
-  last_checked = args[:last_checked_b4].to_sym
-  storage_dir = args[:storage_dir].to_sym
+  storage_root = args[:storage_root].to_sym
   if args[:profile] == 'profile'
     puts "When done, check log/profile_cv_single_dir[TIMESTAMP] for profiling details"
-    ChecksumValidator.checksum_validate_disk(last_checked, storage_dir)
+    ChecksumValidator.checksum_validate_disk(storage_root)
   elsif args[:profile].nil?
-    ChecksumValidator.checksum_validate_disk_profiled(last_checked, storage_dir)
+    ChecksumValidator.checksum_validate_disk_profiled(storage_root)
   end
-  puts "#{Time.now.utc.iso8601} Checksum Validation on #{storage_dir} is done."
+  puts "#{Time.now.utc.iso8601} Checksum Validation on #{storage_root} is done."
   $stdout.flush
 end
 
 desc "Fire off checksum validation on all storage roots"
-task :cv_all_dirs, [:last_checked_b4, :profile] => [:environment] do |_t, args|
+task :cv_all_dirs, [:profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
-    p "usage: rake cv_all_dir[last_checked_b4] || rake cv_all_dirs[last_checked_b4,profile]"
+    p "usage: rake cv_all_dirs || rake cv_all_dirs[profile]"
     exit
   end
-  last_checked = args[:last_checked_b4].to_sym
   if args[:profile] == 'profile'
     puts "When done, check log/profile_cv_all_dirs[TIMESTAMP].txt for profiling details"
-    Checksum.checksum_validate_disk_all_dirs(last_checked)
+    Checksum.checksum_validate_disk_all_dirs
   elsif args[:profile].nil?
-    Checksum.checksum_validate_disk_all_dirs_profiled(last_checked)
+    Checksum.checksum_validate_disk_all_dirs_profiled
   end
   puts "#{Time.now.utc.iso8601} Checksum Validation on all storage roots are done."
   $stdout.flush

--- a/lib/audit/checksum.rb
+++ b/lib/audit/checksum.rb
@@ -18,6 +18,15 @@ class Checksum
   end
 
   def self.validate_disk_all_dirs(last_checked_b4)
+    start_msg = "#{Time.now.utc.iso8601} CV validate_disk_all_dirs starting"
+    puts start_msg
+    Rails.logger.info start_msg
+    Settings.moab.storage_roots.each do |_strg_root_name, strg_root_location|
+      validate_disk(last_checked_b4, "#{strg_root_location}/#{Settings.moab.storage_trunk}")
+    end
+    end_msg = "#{Time.now.utc.iso8601} CV validate_disk_all_dirs ended"
+    puts end_msg
+    Rails.logger.info end_msg
   end
 
   def self.validate_disk_all_dirs_profiled(last_checked_b4)

--- a/lib/audit/checksum.rb
+++ b/lib/audit/checksum.rb
@@ -8,31 +8,31 @@ class Checksum
   # rubocop:disable Style/EmptyMethod:
   # TODO: implement this;  we begin with a placeholder
 
-  def self.validate_disk(last_checked_b4, storage_dir)
+  def self.validate_disk(endpoint_name)
   end
 
-  def self.validate_disk_profiled(last_checked_b4, storage_dir)
+  def self.validate_disk_profiled(endpoint_name)
     profiler = Profiler.new
-    profiler.prof { validate_disk(last_checked_b4, storage_dir) }
-    profiler.print_results_flat('CV_checksum_validation_on_dir')
+    profiler.prof { validate_disk(endpoint_name) }
+    profiler.print_results_flat('CV_checksum_validation_on_endpoint')
   end
 
-  def self.validate_disk_all_dirs(last_checked_b4)
-    start_msg = "#{Time.now.utc.iso8601} CV validate_disk_all_dirs starting"
+  def self.validate_disk_all_endpoints
+    start_msg = "#{Time.now.utc.iso8601} CV validate_disk_all_endpoints starting"
     puts start_msg
     Rails.logger.info start_msg
     Settings.moab.storage_roots.each do |_strg_root_name, strg_root_location|
-      validate_disk(last_checked_b4, "#{strg_root_location}/#{Settings.moab.storage_trunk}")
+      validate_disk("#{strg_root_location}/#{Settings.moab.storage_trunk}")
     end
-    end_msg = "#{Time.now.utc.iso8601} CV validate_disk_all_dirs ended"
+    end_msg = "#{Time.now.utc.iso8601} CV validate_disk_all_endpoints ended"
     puts end_msg
     Rails.logger.info end_msg
   end
 
-  def self.validate_disk_all_dirs_profiled(last_checked_b4)
+  def self.validate_disk_all_endpoints_profiled
     profiler = Profiler.new
-    profiler.prof { validate_disk_all_dirs(last_checked_b4) }
-    profiler.print_results_flat('CV_checksum_validation_all_dirs')
+    profiler.prof { validate_disk_all_endpoints }
+    profiler.print_results_flat('CV_checksum_validation_all_endpoints')
   end
 
 end

--- a/lib/audit/checksum.rb
+++ b/lib/audit/checksum.rb
@@ -8,22 +8,22 @@ class Checksum
   # rubocop:disable Style/EmptyMethod:
   # TODO: implement this;  we begin with a placeholder
 
-  def self.validate_disk(last_checked_b4, endpoint, algorithm="MD5")
+  def self.validate_disk(last_checked_b4, storage_dir)
   end
 
-  def self.validate_disk_profiled(last_checked_b4, endpoint, algorithm)
+  def self.validate_disk_profiled(last_checked_b4, storage_dir)
     profiler = Profiler.new
-    profiler.prof { validate_disk(last_checked_b4, endpoint, algorithm) }
+    profiler.prof { validate_disk(last_checked_b4, storage_dir) }
     profiler.print_results_flat('CV_checksum_validation_on_dir')
   end
 
-  def self.validate_disk_all_endpoints(last_checked_b4, algorithm="md5")
+  def self.validate_disk_all_dirs(last_checked_b4)
   end
 
-  def self.validate_disk_all_endpoints_profiled(last_checked_b4, algorithm)
+  def self.validate_disk_all_dirs_profiled(last_checked_b4)
     profiler = Profiler.new
-    profiler.prof { validate_disk_all_endpoints(last_checked_b4, algorithm) }
-    profiler.print_results_flat('CV_checksum_validation_all_endpoints')
+    profiler.prof { validate_disk_all_dirs(last_checked_b4) }
+    profiler.print_results_flat('CV_checksum_validation_all_dirs')
   end
 
 end

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -7,12 +7,12 @@ require_relative "../../../lib/audit/checksum.rb"
 RSpec.describe Checksum do
 
   describe ".validate_disk" do
-    described_class.validate_disk('2018-02-05 21:37:23 UTC', 'services-disk04', 'MD5')
+    described_class.validate_disk('2018-02-05 21:37:23 UTC', "spec/fixtures/storage_root01/moab_storage_trunk")
     skip 'we should figure out what they are and test them'
   end
 
   describe ".validate_disk_profiled" do
-    let(:subject) { described_class.validate_disk_profiled(Time.now.utc, 'services-disk04', 'MD5') }
+    let(:subject) { described_class.validate_disk_profiled(Time.now.utc,  "spec/fixtures/storage_root01/moab_storage_trunk") }
 
     it "spins up a profiler, calling profiling and printing methods on it" do
       mock_profiler = instance_double(Profiler)
@@ -28,30 +28,30 @@ RSpec.describe Checksum do
     end
   end
 
-  describe ".validate_disk_all_endpoints" do
-    it 'calls validate_disk once per endpoint' do
-      described_class.validate_disk_all_endpoints('2018-02-05 21:37:23 UTC', 'MD5')
+  describe ".validate_disk_all_dirs" do
+    it 'calls validate_disk once per storage root' do
+      described_class.validate_disk_all_dirs('2018-02-05 21:37:23 UTC')
       skip 'we should figure out what they are and test them'
     end
 
     it 'calls validate_disk with the right arguments' do
-      described_class.validate_disk_all_endpoints('2018-02-05 21:37:23 UTC', 'MD5')
+      described_class.validate_disk_all_dirs('2018-02-05 21:37:23 UTC')
       skip 'we should figure out what they are and test them'
     end
   end
 
-  describe ".validate_disk_all_endpoints_profiled" do
-    let(:subject) { described_class.validate_disk_all_endpoints_profiled(Time.now.utc, 'MD5') }
+  describe ".validate_disk_all_dirs_profiled" do
+    let(:subject) { described_class.validate_disk_all_dirs_profiled(Time.now.utc) }
 
     it "spins up a profiler, calling profiling and printing methods on it" do
       mock_profiler = instance_double(Profiler)
       expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat).with('CV_checksum_validation_all_endpoints')
+      expect(mock_profiler).to receive(:print_results_flat).with('CV_checksum_validation_all_dirs')
       subject
     end
-    it "calls .validate_disk_all_endpoints" do
-      expect(described_class).to receive(:validate_disk_all_endpoints)
+    it "calls .validate_disk_all_dirs" do
+      expect(described_class).to receive(:validate_disk_all_dirs)
       subject
     end
   end

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 require_relative "../../../lib/audit/checksum.rb"
 # FIXME: remove this rubocop once we start writing tests
-# rubocop:disable RSpec/RepeatedExample
 # TODO: implement this;  we begin with a placeholder
 
 RSpec.describe Checksum do
+  let(:last_checked_b4_date) { "2018-02-26 19:58:50 UTC" }
+  let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
 
   describe ".validate_disk" do
     described_class.validate_disk('2018-02-05 21:37:23 UTC', "spec/fixtures/storage_root01/moab_storage_trunk")
@@ -12,7 +13,7 @@ RSpec.describe Checksum do
   end
 
   describe ".validate_disk_profiled" do
-    let(:subject) { described_class.validate_disk_profiled(Time.now.utc,  "spec/fixtures/storage_root01/moab_storage_trunk") }
+    let(:subject) { described_class.validate_disk_profiled(Time.now.utc, storage_dir) }
 
     it "spins up a profiler, calling profiling and printing methods on it" do
       mock_profiler = instance_double(Profiler)
@@ -29,14 +30,21 @@ RSpec.describe Checksum do
   end
 
   describe ".validate_disk_all_dirs" do
+    let(:subject) { described_class.validate_disk_all_dirs(last_checked_b4_date) }
+
     it 'calls validate_disk once per storage root' do
-      described_class.validate_disk_all_dirs('2018-02-05 21:37:23 UTC')
-      skip 'we should figure out what they are and test them'
+      expect(described_class).to receive(:validate_disk).exactly(Settings.moab.storage_roots.count).times
+      subject
     end
 
     it 'calls validate_disk with the right arguments' do
-      described_class.validate_disk_all_dirs('2018-02-05 21:37:23 UTC')
-      skip 'we should figure out what they are and test them'
+      Settings.moab.storage_roots.each do |storage_root|
+        expect(described_class).to receive(:validate_disk).with(
+          last_checked_b4_date,
+          "#{storage_root[1]}/#{Settings.moab.storage_trunk}"
+        )
+      end
+      subject
     end
   end
 

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -4,22 +4,21 @@ require_relative "../../../lib/audit/checksum.rb"
 # TODO: implement this;  we begin with a placeholder
 
 RSpec.describe Checksum do
-  let(:last_checked_b4_date) { "2018-02-26 19:58:50 UTC" }
-  let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
+  let(:endpoint_name) { 'fixture_sr3' }
 
   describe ".validate_disk" do
-    described_class.validate_disk('2018-02-05 21:37:23 UTC', "spec/fixtures/storage_root01/moab_storage_trunk")
+    described_class.validate_disk('fixture_sr3')
     skip 'we should figure out what they are and test them'
   end
 
   describe ".validate_disk_profiled" do
-    let(:subject) { described_class.validate_disk_profiled(Time.now.utc, storage_dir) }
+    let(:subject) { described_class.validate_disk_profiled('fixture_sr3') }
 
     it "spins up a profiler, calling profiling and printing methods on it" do
       mock_profiler = instance_double(Profiler)
       expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat).with('CV_checksum_validation_on_dir')
+      expect(mock_profiler).to receive(:print_results_flat).with('CV_checksum_validation_on_endpoint')
       subject
     end
 
@@ -29,8 +28,8 @@ RSpec.describe Checksum do
     end
   end
 
-  describe ".validate_disk_all_dirs" do
-    let(:subject) { described_class.validate_disk_all_dirs(last_checked_b4_date) }
+  describe ".validate_disk_all_endpoints" do
+    let(:subject) { described_class.validate_disk_all_endpoints }
 
     it 'calls validate_disk once per storage root' do
       expect(described_class).to receive(:validate_disk).exactly(Settings.moab.storage_roots.count).times
@@ -40,7 +39,6 @@ RSpec.describe Checksum do
     it 'calls validate_disk with the right arguments' do
       Settings.moab.storage_roots.each do |storage_root|
         expect(described_class).to receive(:validate_disk).with(
-          last_checked_b4_date,
           "#{storage_root[1]}/#{Settings.moab.storage_trunk}"
         )
       end
@@ -48,18 +46,18 @@ RSpec.describe Checksum do
     end
   end
 
-  describe ".validate_disk_all_dirs_profiled" do
-    let(:subject) { described_class.validate_disk_all_dirs_profiled(Time.now.utc) }
+  describe ".validate_disk_all_endpoints_profiled" do
+    let(:subject) { described_class.validate_disk_all_endpoints_profiled }
 
     it "spins up a profiler, calling profiling and printing methods on it" do
       mock_profiler = instance_double(Profiler)
       expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat).with('CV_checksum_validation_all_dirs')
+      expect(mock_profiler).to receive(:print_results_flat).with('CV_checksum_validation_all_endpoints')
       subject
     end
-    it "calls .validate_disk_all_dirs" do
-      expect(described_class).to receive(:validate_disk_all_dirs)
+    it "calls .validate_disk_all_endpoints" do
+      expect(described_class).to receive(:validate_disk_all_endpoints)
       subject
     end
   end


### PR DESCRIPTION
- Made it so methods took `endpoint_name` instead of `storage_dir` to be more synonymous to c2m and m2c checks. 
- removed `algorithm` as a parameter since it is not used.
- Updated README with the given changes

connects #578 