### PR TITLE
miscellaneous polish (shared ActiveRecord helper methods, readme, log file names)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -226,3 +226,7 @@ Style/StringLiterals:
 Style/SymbolArray:
   Exclude:
     - 'Rakefile' # because [:spec, :rubocop] isn't a big deal
+
+Style/TernaryParentheses:
+  Exclude:
+    - spec/lib/active_record_utils_spec.rb # reads better with parens

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ RAILS_ENV=production bundle exec rake cv_single_endpoint[fixture_sr3]
 RAILS_ENV=production bundle exec rake cv_single_endpoint[fixture_sr3,profile]
 ```
 this will generate a log at, for example,
-```log/profile_cv_single_endpoint2018-01-01T14:25:31-flat.txt```
+```log/profile_cv_validate_disk2018-01-01T14:25:31-flat.txt```
 
 #### All Roots
 - Without profiling:
@@ -195,7 +195,7 @@ RAILS_ENV=production bundle exec rake cv_all_endpoints
 RAILS_ENV=production bundle exec rake cv_all_endpoints[profile]
 ```
 this will generate a log at, for example,
-```log/profile_cv_all_dirs2018-01-01T14:25:31-flat.txt```
+```log/profile_cv_validate_disk_all_endpoints2018-01-01T14:25:31-flat.txt```
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -174,7 +174,7 @@ task :cv_single_endpoint, [:storage_root, :profile] => [:environment] do |_t, ar
   end
   storage_root = args[:storage_root].to_sym
   if args[:profile] == 'profile'
-    puts "When done, check log/profile_cv_single_endpoint[TIMESTAMP] for profiling details"
+    puts "When done, check log/profile_cv_validate_disk[TIMESTAMP] for profiling details"
     Checksum.validate_disk_profiled(storage_root)
   elsif args[:profile].nil?
     Checksum.validate_disk(storage_root)
@@ -190,7 +190,7 @@ task :cv_all_endpoints, [:profile] => [:environment] do |_t, args|
     exit
   end
   if args[:profile] == 'profile'
-    puts "When done, check log/profile_cv_all_endpoints[TIMESTAMP].txt for profiling details"
+    puts "When done, check log/profile_cv_validate_disk_all_endpoints[TIMESTAMP].txt for profiling details"
     Checksum.validate_disk_all_endpoints_profiled
   elsif args[:profile].nil?
     Checksum.validate_disk_all_endpoints

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -285,6 +285,10 @@ class PreservedObjectHandler
     end
 
     # TODO: do the check that'd set INVALID_CHECKSUM_STATUS
+    #  and actually, maybe we should either 1) trigger it async, or 2) break out the status
+    #  update, otherwise checksumming could get enclosed in a DB transaction, and that seems
+    #  like a real bad idea, cuz that transaction might be open a looooooong time.
+    # see https://github.com/sul-dlss/preservation_catalog/issues/612
 
     update_status(pres_copy, PreservedCopy::OK_STATUS)
   end

--- a/lib/active_record_utils.rb
+++ b/lib/active_record_utils.rb
@@ -1,0 +1,42 @@
+##
+# some usefule re-usable ActiveRecord patterns
+class ActiveRecordUtils
+  # Executes the given block in an ActiveRecord transaction.  Traps common ActiveRecord exceptions.
+  # @param [AuditResults] for appending a result when the block raises a common AR exception.
+  # @return true if transaction completed without error; false if ActiveRecordError was raised
+  def self.with_transaction_and_rescue(audit_results)
+    begin
+      ApplicationRecord.transaction { yield }
+      return true
+    rescue ActiveRecord::RecordNotFound => e
+      audit_results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, e.inspect)
+    rescue ActiveRecord::ActiveRecordError => e
+      audit_results.add_result(
+        AuditResults::DB_UPDATE_FAILED, "#{e.inspect} #{e.message} #{e.backtrace.inspect}"
+      )
+    end
+    false
+  end
+
+  # Process all results of the given AR relation, batch_size records at a time (runs the given block on each result).
+  # Somewhat similar purpose to find_each and similar methods, but with two big differences:
+  # - Respects the order of the given relation
+  # - Grabs the *first* batch_size results on every while loop iteration.  The assumption is that the given block
+  #   will update each record such that the query won't return it on the next iteration (e.g. relation is a query
+  #   for objects that need to be fixity checked, and the block marks each object it encounters as checked). In
+  #   other words, the "window" doesn't advance over the result set on each iteration, rather the result set
+  #   is expected to "lose" the previously processed results on each iteration.
+  # see also http://api.rubyonrails.org/classes/ActiveRecord/Batches.html
+  def self.process_in_batches(relation, batch_size)
+    # Note that this will try to re-run the query for as many batches as were available when the count was
+    # first obtained.  As the above link reminds us, "By its nature, batch processing is subject to race conditions
+    # if other processes are modifying the database."
+    num_to_process = relation.count
+    while num_to_process > 0
+      relation.limit(batch_size).each do |row|
+        yield row
+      end
+      num_to_process -= batch_size
+    end
+  end
+end

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -1,31 +1,25 @@
+require 'active_record_utils.rb'
 require 'druid-tools'
 require 'profiler.rb'
 
 # Catalog to Moab existence check code
 class CatalogToMoab
 
-  # allows for sharding/parallelization by storage_dir
-  # use model scope query (which contains ordering), limit for batching, and .each within a while loop to
-  # process records in order in batches.  Note that .find_each does batches, but disregards order from
-  # the scope, so we must use .each on a limit to process a batch after ordering over the whole set.
   def self.check_version_on_dir(last_checked_b4_date, storage_dir, limit=Settings.c2m_sql_limit)
     start_msg = "#{Time.now.utc.iso8601} C2M check_version starting for #{storage_dir}"
     puts start_msg
     Rails.logger.info start_msg
 
-    # all_processable_copies is an AR relation; fine to run it with a .count or a .limit tacked on, but
-    # don't call .each directly on it and get the whole result set at once.
-    all_processable_copies =
+    # pcs_to_audit_relation is an AR Relation; it could return a lot of results, so we want to process it in
+    # batches.  we can't use ActiveRecord's .find_each, because that'll disregard the order .least_recent_version_audit
+    # specified.  so we use our own batch processing method, which does respect Relation order.
+    pcs_to_audit_relation =
       PreservedCopy.least_recent_version_audit(last_checked_b4_date).by_storage_location(storage_dir)
-    num_to_process = all_processable_copies.count
-    while num_to_process > 0
-      pcs = all_processable_copies.limit(limit)
-      pcs.each do |pc|
-        c2m = CatalogToMoab.new(pc, storage_dir)
-        c2m.check_catalog_version
-      end
-      num_to_process -= limit
+    ActiveRecordUtils.process_in_batches(pcs_to_audit_relation, limit) do |pc|
+      c2m = CatalogToMoab.new(pc, storage_dir)
+      c2m.check_catalog_version
     end
+
     end_msg = "#{Time.now.utc.iso8601} C2M check_version ended for #{storage_dir}"
     puts end_msg
     Rails.logger.info end_msg

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -170,6 +170,10 @@ class CatalogToMoab
     end
 
     # TODO: do the check that'd set INVALID_CHECKSUM_STATUS
+    #  and actually, maybe we should either 1) trigger it async, or 2) break out the status
+    #  update, otherwise checksumming could get enclosed in a DB transaction, and that seems
+    #  like a real bad idea, cuz that transaction might be open a looooooong time.
+    # see https://github.com/sul-dlss/preservation_catalog/issues/612
 
     update_status(PreservedCopy::OK_STATUS)
   end

--- a/lib/audit/checksum.rb
+++ b/lib/audit/checksum.rb
@@ -1,3 +1,4 @@
+require 'active_record_utils.rb'
 require 'profiler.rb'
 
 # Checksum validator code
@@ -8,19 +9,15 @@ class Checksum
     puts start_msg
     Rails.logger.info start_msg
 
-    # pcs_w_expired_fixity_check is an AR relation; fine to run it with a .count or a .limit tacked on, but
-    # don't call .each directly on it and get the whole result set at once. Also, don't call .for_each or
-    # the ordering of the results will be lost.
+    # pcs_w_expired_fixity_check is an AR Relation; it could return a lot of results, so we want to process it in
+    # batches.  we can't use ActiveRecord's .find_each, because that'll disregard the order .fixity_check_expired
+    # specified.  so we use our own batch processing method, which does respect Relation order.
     pcs_w_expired_fixity_check = PreservedCopy.by_endpoint_name(endpoint_name).fixity_check_expired
-    num_to_process = pcs_w_expired_fixity_check.count
-    while num_to_process > 0
-      pcs_for_batch = pcs_w_expired_fixity_check.limit(limit)
-      pcs_for_batch.each do |pc|
-        cv = ChecksumValidator.new(pc, endpoint_name)
-        cv.validate_checksums
-      end
-      num_to_process -= limit
+    ActiveRecordUtils.process_in_batches(pcs_w_expired_fixity_check, limit) do |pc|
+      cv = ChecksumValidator.new(pc, endpoint_name)
+      cv.validate_checksums
     end
+
     end_msg = "#{Time.now.utc.iso8601} CV validate_disk ended for #{endpoint_name}"
     puts end_msg
     Rails.logger.info end_msg

--- a/lib/audit/checksum.rb
+++ b/lib/audit/checksum.rb
@@ -29,7 +29,7 @@ class Checksum
   def self.validate_disk_profiled(endpoint_name)
     profiler = Profiler.new
     profiler.prof { validate_disk(endpoint_name) }
-    profiler.print_results_flat('CV_checksum_validation_on_endpoint')
+    profiler.print_results_flat('cv_validate_disk')
   end
 
   def self.validate_disk_all_endpoints
@@ -47,7 +47,7 @@ class Checksum
   def self.validate_disk_all_endpoints_profiled
     profiler = Profiler.new
     profiler.prof { validate_disk_all_endpoints }
-    profiler.print_results_flat('CV_checksum_validation_all_endpoints')
+    profiler.print_results_flat('cv_validate_disk_all_endpoints')
   end
 
 end

--- a/spec/lib/active_record_utils_spec.rb
+++ b/spec/lib/active_record_utils_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+require 'active_record_utils.rb'
+require 'audit_results.rb'
+
+RSpec.describe ActiveRecordUtils do
+  describe '.with_transaction_and_rescue' do
+    let(:audit_results) { instance_double(AuditResults) }
+
+    it 'returns true when the transaction finishes successfully (and adds no results)' do
+      expect(audit_results).not_to receive(:add_result)
+      tx_result = described_class.with_transaction_and_rescue(audit_results) do
+        Endpoint.count
+      end
+      expect(tx_result).to eq true
+    end
+    it 'adds DB_OBJ_DOES_NOT_EXIST result and returns false when the transaction raises RecordNotFound' do
+      expect(audit_results).to receive(:add_result).with(
+        AuditResults::DB_OBJ_DOES_NOT_EXIST, a_string_matching("Couldn't find Endpoint")
+      )
+      tx_result = described_class.with_transaction_and_rescue(audit_results) do
+        Endpoint.find(-1)
+      end
+      expect(tx_result).to eq false
+    end
+    it 'adds DB_UPDATE_FAILED result and returns false when the transaction raises ActiveRecordError' do
+      expect(audit_results).to receive(:add_result).with(
+        AuditResults::DB_UPDATE_FAILED, a_string_matching('ActiveRecord::InvalidForeignKey')
+      )
+      tx_result = described_class.with_transaction_and_rescue(audit_results) do
+        PreservationPolicy.default_policy.delete
+      end
+      expect(tx_result).to eq false
+    end
+    it 'lets an unexpected error bubble up' do
+      expect do
+        described_class.with_transaction_and_rescue(audit_results) do
+          PreservationPolicy.not_a_real_method
+        end
+      end.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '.process_in_batches' do
+    let(:batch_size) { 2 }
+    let(:num_objs) { 9 }
+    let(:expect_num_batches) do
+      # integer division returns an integer.  add a cleanup batch if there's any remainder.
+      (num_objs % batch_size == 0) ? (num_objs / batch_size) : (num_objs / batch_size + 1)
+    end
+    let(:endpoint) { Endpoint.find_by(endpoint_name: 'fixture_sr1') }
+
+    it 'processes the all of the relation results in order' do
+      pres_copies_to_process = (1..num_objs).map do |n|
+        po = PreservedObject.create!(
+          druid: "zy123cd456#{n}", current_version: 1, preservation_policy: PreservationPolicy.default_policy
+        )
+        PreservedCopy.create!(
+          preserved_object: po,
+          endpoint: endpoint,
+          version: 1,
+          status: PreservedCopy::VALIDITY_UNKNOWN_STATUS
+        )
+      end
+      # we're going to query by creation date descending, since DBs often return in order of create or upd date in
+      # the absence of sort criteria (we just want to be extra sure in testing that our order by clause is respected).
+      expected_ids = pres_copies_to_process.map(&:id).reverse
+
+      relation = PreservedCopy
+                 .where(endpoint: endpoint, status: PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+                 .order(created_at: :desc)
+      allow(relation).to receive(:limit).with(batch_size).and_call_original
+
+      actual_ids = []
+      described_class.process_in_batches(relation, batch_size) do |row|
+        actual_ids << row.id
+        row.update!(status: PreservedCopy::OK_STATUS)
+      end
+
+      expect(relation).to have_received(:limit).with(batch_size).exactly(expect_num_batches).times
+      expect(actual_ids).to eq expected_ids
+    end
+  end
+end

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Checksum do
       mock_profiler = instance_double(Profiler)
       expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat).with('CV_checksum_validation_on_endpoint')
+      expect(mock_profiler).to receive(:print_results_flat).with('cv_validate_disk')
       subject
     end
 
@@ -84,7 +84,7 @@ RSpec.describe Checksum do
       mock_profiler = instance_double(Profiler)
       expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat).with('CV_checksum_validation_all_endpoints')
+      expect(mock_profiler).to receive(:print_results_flat).with('cv_validate_disk_all_endpoints')
       subject
     end
     it "calls .validate_disk_all_endpoints" do


### PR DESCRIPTION
* CV: profiling output should use name of profile method in file name like similar M2C and C2M methods (also fix tests and documentation)
* centralize some re-useable activerecord code
* have C2M use transactions when it does updates that should be grouped atomically

TODO:
- [x] could use some tests for the new class
- [ ] i'm also not thrilled with the name for the new class, but it'll do if no one's got better ideas.
- [x] would also like to use the newly factored out transaction handler to add transactionality to C2M.
  - [x] which will also need tests
- [x] refactor the `limit`/`each` construct out of checksum validation, as was done in this PR already for C2M

fine to do any of those things in this ticket or in follow on tickets.

also, i know utility classes are a thing some people don't like.  happy to hear suggestions for a better approach, though i think this is better than rewriting the code in this PR multiple times across different classes that need to do very similar things.


~~this is now rebased on #606, which should get merged first (because this will refactor a thing from that PR).~~

closes #609 
closes #573 