### PR TITLE
Remove unnecessary interpolation in Checksum.validate_druid

### DIFF
--- a/lib/audit/checksum.rb
+++ b/lib/audit/checksum.rb
@@ -52,7 +52,7 @@ class Checksum
     puts start_msg
     Rails.logger.info start_msg
     pres_copies = PreservedCopy.joins(:preserved_object).where(preserved_objects: { druid: druid })
-    Rails.logger.error("Found #{pres_copies.size} preserved copies.") if pres_copies.empty?
+    Rails.logger.debug("Found #{pres_copies.size} preserved copies.")
     pres_copies.each do |pc|
       endpoint_name = pc.endpoint.endpoint_name
       cv = ChecksumValidator.new(pc, endpoint_name)

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -108,10 +108,12 @@ RSpec.describe Checksum do
       described_class.validate_druid(druid)
     end
 
-    it "rescues if druid does not exist" do
+    it "logs a debug message" do
       druid = 'xx000xx0500'
       error_msg = "Found 0 preserved copies."
-      expect(Rails.logger).to receive(:error).with(error_msg)
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:debug)
+      expect(Rails.logger).to receive(:debug).with(error_msg)
       described_class.validate_druid(druid)
     end
   end


### PR DESCRIPTION
- Logging this to tell users: If the druid inputted came up with 0 pre copies log this as an error. We are 
expecting at least 1 preserved copy for a given druid.

- I can change it to 
` Rails.logger.debug("Found #{pres_copies.size}.")` as a general statement too, without the conditional.