### PR TITLE
[WIP] Create route ReST Calls (first pass)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,6 +65,7 @@ Metrics/AbcSize:
     - 'lib/audit/catalog_to_moab.rb' # .check_version_all_dirs is decidedly readable
     - 'lib/audit/checksum.rb' # .validate_disk_all_dirs is decidedly readable
     - 'lib/audit/moab_to_catalog.rb' # .xxx_for_all_storage_roots is decidedly readable
+    - 'app/controllers/catalog_controller.rb' # #create method is readable
 
 Metrics/BlockLength:
   Exclude:

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,36 +3,34 @@
 # to add an existing moab object to the catalog, or to update an entry for a moab object
 # that's already in the catalog.
 class CatalogController < ApplicationController
-  before_action :set_id
 
-  def add_preserved_object
-    PreservedObject.create!(
-      druid: @id, size: moab_size(@id), current_version: Stanford::StorageServices.current_version(@id)
-    )
-  end
+  attr_accessor :poh
 
-  def update_preserved_object
-    preserved_obj = PreservedObject.find_by(druid: @id)
-    preserved_obj.update_attributes(
-      druid: @id, size: moab_size(@id), current_version: Stanford::StorageServices.current_version(@id)
-    )
+  # POST /catalog
+  def create
+    druid = poh_params[:druid]
+    incoming_version = poh_params[:incoming_version].to_i
+    incoming_size = poh_params[:incoming_size].to_i
+    endpoint = Endpoint.find_by(endpoint_name: poh_params[:endpoint_name])
+    @poh = PreservedObjectHandler.new(druid, incoming_version, incoming_size, endpoint)
+    poh.create
+    status_code =
+      if poh.handler_results.contains_result_code?(:created_new_object)
+        :created # 201
+      elsif poh.handler_results.contains_result_code?(:db_obj_already_exists)
+        :conflict # 409
+      elsif poh.handler_results.contains_result_code?(:invalid_arguments)
+        :not_acceptable # 406
+      else
+        :internal_server_error # 500
+      end
+    render status: status_code, json: poh.handler_results.to_json
   end
 
   private
 
-  def set_id
-    @id = catalog_params[:id]
-    head(:unprocessable_entity) if @id.blank?
-  end
-
-  def catalog_params
-    params.permit(:id)
-  end
-
-  def moab_size(id)
-    # TODO: make this actually get the size once there's a method for that.
-    # for now, just using the id to quiet rubocop complaint.
-    # https://github.com/sul-dlss/moab-versioning/issues/21
-    42 || id
+  # strong params / whitelist params
+  def poh_params
+    params.permit(:druid, :incoming_version, :incoming_size, :endpoint_name)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,6 @@
 Rails.application.routes.draw do
-  get 'moab_storage/index'
-
-  get 'moab_storage/show/:id', to: 'moab_storage#show'
-
-  post 'catalog/add_preserved_object', to: 'catalog#add_preserved_object'
-  patch 'catalog/update_preserved_object', to: 'catalog#update_preserved_object'
+  resources :catalog, only: [:create]
+  resources :moab_storage, only: %i[index show]
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,46 +1,95 @@
 require 'rails_helper'
-
 RSpec.describe CatalogController, type: :controller do
-  describe 'POST #add_preserved_object' do
-    context 'with valid params' do
-      it 'saves the object with the expected field values' do
-        allow(Stanford::StorageServices).to receive(:current_version).and_return(6)
-        allow(subject).to receive(:moab_size).and_return(555)
-        id = 'ab123cd45678'
+  describe 'POST #create' do
+    let(:size) { 2342 }
+    let(:ver) { 3 }
+    let(:endpoint_name) { 'fixture_sr1' }
+    let(:druid) { 'bj102hs9687' }
 
-        allow(PreservedObject).to receive(:create!)
-        post :add_preserved_object, params: { id: id }
-        expect(PreservedObject).to have_received(:create!).with(druid: id, size: 555, current_version: 6)
+    context 'with valid params' do
+      let(:pres_copy) { PreservedCopy.first }
+      let(:pres_obj) { PreservedObject.first }
+
+      before do
+        post :create, params: { druid: druid, incoming_version: ver, incoming_size: size, endpoint_name: endpoint_name }
+      end
+
+      it 'saves PreservedObject and PreservedCopy in db' do
+        po = PreservedObject.find_by(druid: druid)
+        pc = PreservedCopy.find_by(preserved_object: po)
+        expect(po).to be_an_instance_of PreservedObject
+        expect(pc).to be_an_instance_of PreservedCopy
+      end
+      it 'PreservedCopy and PreservedObject have correct attributes' do
+        expect(pres_copy.endpoint.endpoint_name).to eq endpoint_name
+        expect(pres_copy.version).to eq ver
+        expect(pres_copy.size).to eq size
+        expect(pres_obj.druid).to eq druid
+      end
+
+      it 'response contains create_new_object code ' do
+        exp_msg = [{ AuditResults::CREATED_NEW_OBJECT => "added object to db as it did not exist" }]
+        expect(response.body).to eq exp_msg.to_json
+      end
+
+      it 'returns a created response code' do
+        expect(response).to have_http_status(:created)
       end
     end
 
     context 'with invalid params' do
-      it 'returns the unprocessable entity http status code' do
-        post :add_preserved_object
-        expect(response).to have_http_status(422)
+      before do
+        post :create, params: { druid: nil, incoming_version: ver, incoming_size: size, endpoint_name: endpoint_name }
+      end
+
+      it 'does not save PreservedObject or PreservedCopy in db' do
+        po = PreservedObject.find_by(druid: druid)
+        pc = PreservedCopy.find_by(preserved_object: po)
+        expect(po).to be_nil
+        expect(pc).to be_nil
+      end
+
+      it 'response contains error message' do
+        errors = ["Druid can't be blank", "Druid is invalid"]
+        exp_msg = [{ AuditResults::INVALID_ARGUMENTS => "encountered validation error(s): #{errors}" }]
+        expect(response.body).to include(exp_msg.to_json)
+      end
+
+      it 'returns a not acceptable response code' do
+        expect(response).to have_http_status(:not_acceptable)
       end
     end
-  end
 
-  describe 'PATCH #update' do
-    context 'with valid params' do
-      it 'updates the object with the expected field values' do
-        allow(Stanford::StorageServices).to receive(:current_version).and_return(6)
-        allow(subject).to receive(:moab_size).and_return(555)
-        id = 'ab123cd45678'
+    context 'object already exists' do
+      before do
+        post :create, params: { druid: druid, incoming_version: ver, incoming_size: size, endpoint_name: endpoint_name }
+        post :create, params: { druid: druid, incoming_version: ver, incoming_size: size, endpoint_name: endpoint_name }
+      end
 
-        preserved_obj = instance_double(PreservedObject)
-        allow(PreservedObject).to receive(:find_by).with(druid: id).and_return(preserved_obj)
+      it 'response contains error message' do
+        exp_msg = [{ AuditResults::DB_OBJ_ALREADY_EXISTS => "PreservedObject db object already exists" }]
+        expect(response.body).to eq exp_msg.to_json
+      end
 
-        allow(preserved_obj).to receive(:update_attributes)
-        patch :update_preserved_object, params: { id: id }
-        expect(preserved_obj).to have_received(:update_attributes).with(druid: id, size: 555, current_version: 6)
+      it 'returns a conflict response code' do
+        expect(response).to have_http_status(:conflict)
       end
     end
-    context 'with invalid params' do
-      it 'returns the unprocessable entity http status code' do
-        patch :update_preserved_object
-        expect(response).to have_http_status(422)
+
+    context 'db update failed' do
+      before do
+        allow(PreservedObject).to receive(:create!).with(hash_including(druid: druid))
+                                                   .and_raise(ActiveRecord::ActiveRecordError, 'foo')
+        post :create, params: { druid: druid, incoming_version: ver, incoming_size: size, endpoint_name: endpoint_name }
+      end
+
+      it 'response contains error message' do
+        code = AuditResults::DB_UPDATE_FAILED.to_json
+        expect(response.body).to include(code)
+      end
+
+      it 'returns an internal server error response code' do
+        expect(response).to have_http_status(:internal_server_error)
       end
     end
   end


### PR DESCRIPTION
This is just a first pass PR to see what other devs think and if they have any thoughts on what I should change. 

`catalog_controller.rb` - `def create` method w/ the http_status return codes. Thought it would be useful if we returned useful http codes...I can change them to other http codes if someone doesn't like them.  I added these codes because I was getting a 204 (no content) return code whether success or failure of object creation. 

`audit_results.rb` - `contains_result_code?(code)` is used by `CatalogController#create` ( PR John put up I merged into my branch)

connects #109 