### PR TITLE
HostSettings specifies storage_roots by hostname for sharding

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -89,7 +89,7 @@ task :m2c_exist_single_root, [:storage_root, :profile] => [:environment] do |_t,
     exit
   end
   root = args[:storage_root].to_sym
-  storage_dir = "#{Settings.moab.storage_roots[root]}/#{Settings.moab.storage_trunk}"
+  storage_dir = "#{HostSettings.storage_roots[root]}/#{Settings.moab.storage_trunk}"
   puts "#{Time.now.utc.iso8601} Running Moab to Catalog Existence Check for #{storage_dir}"
   $stdout.flush # sometimes above is not visible (flushed) until last puts (when run finishes)
   if args[:profile] == 'profile'
@@ -127,7 +127,7 @@ task :c2m_check_version_on_dir, [:last_checked_b4_date, :storage_root, :profile]
     exit
   end
   root = args[:storage_root].to_sym
-  storage_dir = "#{Settings.moab.storage_roots[root]}/#{Settings.moab.storage_trunk}"
+  storage_dir = "#{HostSettings.storage_roots[root]}/#{Settings.moab.storage_trunk}"
   last_checked = args[:last_checked_b4_date].to_s
   begin
     if args[:profile] == 'profile'

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -19,7 +19,7 @@ class Endpoint < ApplicationRecord
   # NOTE: this adds new entries from the config, and leaves existing entries alone, but won't delete anything.
   # TODO: figure out deletion based on config?
   def self.seed_storage_root_endpoints_from_config(endpoint_type, preservation_policies)
-    Settings.moab.storage_roots.map do |storage_root_name, storage_root_location|
+    HostSettings.storage_roots.map do |storage_root_name, storage_root_location|
       find_or_create_by!(endpoint_name: storage_root_name.to_s) do |endpoint|
         endpoint.endpoint_type = endpoint_type
         endpoint.endpoint_node = Settings.endpoints.storage_root_defaults.endpoint_node

--- a/app/models/host_settings.rb
+++ b/app/models/host_settings.rb
@@ -1,0 +1,17 @@
+# Lets us consolidate shared_configs for almost identical machines
+class HostSettings
+  # @return [Config::Options] key/value pairs of name: file_path
+  def self.storage_roots
+    Settings.storage_root_map[storage_root_lookup_name]
+  end
+
+  # @return [String] hostname depending on environment
+  def self.storage_root_lookup_name
+    Rails.env.production? ? parsed_hostname : 'default'
+  end
+
+  # @return [String] modified hostname
+  def self.parsed_hostname
+    Socket.gethostname.underscore.remove('.stanford.edu')
+  end
+end

--- a/config/initializers/moab_config.rb
+++ b/config/initializers/moab_config.rb
@@ -2,7 +2,7 @@ require 'moab'
 require 'moab/stanford'
 
 Moab::Config.configure do
-  storage_roots(Settings.moab.storage_roots.map { |_storage_root_name, storage_root_location| storage_root_location })
+  storage_roots(HostSettings.storage_roots.map { |_storage_root_name, storage_root_location| storage_root_location })
   storage_trunk(Settings.moab.storage_trunk)
   path_method(Settings.moab.path_method.to_sym)
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,6 @@
+# named storage roots are in the storage_root_map (see config/settings for examples).
+# the storage_root_map contains lookups of storage roots per host.
+# see sul-dlss/shared_configs for the storage_root_map of all hosts we deploy to.
 endpoint_types:
   online_nfs:
     endpoint_class: online
@@ -11,14 +14,6 @@ endpoints:
     recovery_cost: 1
 
 moab:
-  # this is a list of named storage roots.  the names are used to seed the endpoints table.
-  # any named storage roots added in the root settings.yml will always be inherited by env specific configs, even
-  # if they aren't listed directly in the settings/*.yml file for an environment. so list storage roots directly in
-  # the relevant settings file for the env, including for vanilla unit test env.
-  # storage_roots:
-    # name: '/location/on/disk'  # e.g.
-    # fixture_sr1: 'spec/fixtures/storage_root01'
-    # fixture_sr2: 'spec/fixtures/storage_root02'
   # storage_trunk is the name of the directory under a storage_root which contains
   # the druid trees:  e.g. 'spec/fixtures/moab_storage_root' will contain all the druid
   # trees for this configuration.  if there are multiple storage roots, each will have

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,8 +1,15 @@
-moab:
-  # this is a list of named storage roots.  the names are used to seed the endpoints table.
-  storage_roots:
-    # name: '/location/on/disk'  # e.g.
+# the keys of storage_root_map represent deployed hosts and point to their storage_roots
+# these host values are just examples or fixtures, for real values, see sul-dlss/shared_configs
+storage_root_map:
+  default:
     fixture_sr1: 'spec/fixtures/storage_root01'
     fixture_sr2: 'spec/fixtures/storage_root02'
     fixture_sr3: 'spec/fixtures/checksum_root01'
+  preservation_catalog_prod:
+    fixture_sr1: 'spec/fixtures/storage_root01'
+    fixture_sr2: 'spec/fixtures/storage_root02'
+    fixture_sr3: 'spec/fixtures/checksum_root01'
+  preservation_catalog_prod_a:
+    fixture_sr1: 'spec/fixtures/storage_root01'
+    fixture_sr2: 'spec/fixtures/storage_root02'
 workflow_services_url: 'https://sul-lyberservices-test.stanford.edu/workflow/'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,8 +1,15 @@
-moab:
-  # this is a list of named storage roots.  the names are used to seed the endpoints table.
-  storage_roots:
-    # name: '/location/on/disk'  # e.g.
+# the keys of storage_root_map represent deployed hosts and point to their storage_roots
+# these host values are just examples or fixtures, for real values, see sul-dlss/shared_configs
+storage_root_map:
+  default:
     fixture_sr1: 'spec/fixtures/storage_root01'
     fixture_sr2: 'spec/fixtures/storage_root02'
     fixture_sr3: 'spec/fixtures/checksum_root01'
     fixture_empty: 'spec/fixtures/empty'
+  preservation_catalog_prod:
+    fixture_sr1: 'spec/fixtures/storage_root01'
+    fixture_sr2: 'spec/fixtures/storage_root02'
+    fixture_sr3: 'spec/fixtures/checksum_root01'
+  preservation_catalog_prod_a:
+    fixture_sr1: 'spec/fixtures/storage_root01'
+    fixture_sr2: 'spec/fixtures/storage_root02'

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -35,7 +35,7 @@ class CatalogToMoab
     start_msg = "#{Time.now.utc.iso8601} C2M check_version_all_dirs starting"
     puts start_msg
     Rails.logger.info start_msg
-    Settings.moab.storage_roots.each do |_strg_root_name, strg_root_location|
+    HostSettings.storage_roots.each do |_strg_root_name, strg_root_location|
       check_version_on_dir(last_checked_b4_date, "#{strg_root_location}/#{Settings.moab.storage_trunk}")
     end
     end_msg = "#{Time.now.utc.iso8601} C2M check_version_all_dirs ended"

--- a/lib/audit/checksum.rb
+++ b/lib/audit/checksum.rb
@@ -33,7 +33,7 @@ class Checksum
     start_msg = "#{Time.now.utc.iso8601} CV validate_disk_all_endpoints starting"
     puts start_msg
     Rails.logger.info start_msg
-    Settings.moab.storage_roots.each do |strg_root_name, _strg_root_location|
+    HostSettings.storage_roots.each do |strg_root_name, _strg_root_location|
       validate_disk(strg_root_name)
     end
     end_msg = "#{Time.now.utc.iso8601} CV validate_disk_all_endpoints ended"

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -52,7 +52,7 @@ class MoabToCatalog
     start_msg = "#{Time.now.utc.iso8601} Seeding for all storage roots starting"
     puts start_msg
     Rails.logger.info start_msg
-    Settings.moab.storage_roots.each do |_strg_root_name, strg_root_location|
+    HostSettings.storage_roots.each do |_strg_root_name, strg_root_location|
       seed_catalog_for_dir("#{strg_root_location}/#{Settings.moab.storage_trunk}")
     end
     end_msg = "#{Time.now.utc.iso8601} Seeding for all storage roots ended'"
@@ -71,7 +71,7 @@ class MoabToCatalog
     start_msg = "#{Time.now.utc.iso8601} M2C check_existence for all storage roots starting'"
     puts start_msg
     Rails.logger.info start_msg
-    Settings.moab.storage_roots.each do |_strg_root_name, strg_root_location|
+    HostSettings.storage_roots.each do |_strg_root_name, strg_root_location|
       check_existence_for_dir("#{strg_root_location}/#{Settings.moab.storage_trunk}")
     end
     end_msg = "#{Time.now.utc.iso8601} M2C check_existence for all storage roots ended'"

--- a/spec/lib/audit/catalog_to_moab_class_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_class_spec.rb
@@ -63,12 +63,12 @@ RSpec.describe CatalogToMoab do
     let(:subject) { described_class.check_version_all_dirs(last_checked_version_b4_date) }
 
     it 'calls .check_version_for_dir once per storage root' do
-      expect(described_class).to receive(:check_version_on_dir).exactly(Settings.moab.storage_roots.entries.count).times
+      expect(described_class).to receive(:check_version_on_dir).exactly(HostSettings.storage_roots.entries.count).times
       subject
     end
 
     it 'calls check_version_for_dir with the right arguments' do
-      Settings.moab.storage_roots.each do |storage_root|
+      HostSettings.storage_roots.each do |storage_root|
         expect(described_class).to receive(:check_version_on_dir).with(
           last_checked_version_b4_date,
           "#{storage_root[1]}/#{Settings.moab.storage_trunk}"

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -63,12 +63,12 @@ RSpec.describe Checksum do
     let(:subject) { described_class.validate_disk_all_endpoints }
 
     it 'calls validate_disk once per storage root' do
-      expect(described_class).to receive(:validate_disk).exactly(Settings.moab.storage_roots.entries.count).times
+      expect(described_class).to receive(:validate_disk).exactly(HostSettings.storage_roots.entries.count).times
       subject
     end
 
     it 'calls validate_disk with the right arguments' do
-      Settings.moab.storage_roots.each_key do |storage_name|
+      HostSettings.storage_roots.each_key do |storage_name|
         expect(described_class).to receive(:validate_disk).with(
           storage_name
         )

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe MoabToCatalog do
     let(:subject) { described_class.check_existence_for_all_storage_roots }
 
     it 'calls check_existence_for_dir once per storage root' do
-      expect(described_class).to receive(:check_existence_for_dir).exactly(Settings.moab.storage_roots.entries.count).times
+      expect(described_class).to receive(:check_existence_for_dir).exactly(HostSettings.storage_roots.entries.count).times
       subject
     end
 
     it 'calls check_existence_for_dir with the right arguments' do
-      Settings.moab.storage_roots.each do |storage_root|
+      HostSettings.storage_roots.each do |storage_root|
         expect(described_class).to receive(:check_existence_for_dir).with("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
       end
       subject
@@ -43,12 +43,12 @@ RSpec.describe MoabToCatalog do
     let(:subject) { described_class.seed_catalog_for_all_storage_roots }
 
     it 'calls seed_catalog_for_dir once per storage root' do
-      expect(described_class).to receive(:seed_catalog_for_dir).exactly(Settings.moab.storage_roots.entries.count).times
+      expect(described_class).to receive(:seed_catalog_for_dir).exactly(HostSettings.storage_roots.entries.count).times
       subject
     end
 
     it 'calls seed_catalog_for_dir with the right arguments' do
-      Settings.moab.storage_roots.each do |storage_root|
+      HostSettings.storage_roots.each do |storage_root|
         expect(described_class).to receive(:seed_catalog_for_dir).with("#{storage_root[1]}/#{Settings.moab.storage_trunk}")
       end
       subject

--- a/spec/load_fixtures_helper.rb
+++ b/spec/load_fixtures_helper.rb
@@ -17,7 +17,7 @@ RSpec.shared_context "fixture moabs in db" do
   end
   after do
     # TODO: danger - if there are objects in the test db we want to keep
-    Settings.moab.storage_roots.each_value do |storage_root|
+    HostSettings.storage_roots.each_value do |storage_root|
       storage_dir = File.join(storage_root, Settings.moab.storage_trunk)
       PreservedCopy.where(endpoint_id: Endpoint.find_by(storage_location: storage_dir).id).each do |pc|
         po_id = pc.preserved_object_id
@@ -50,7 +50,7 @@ def setup
   @storage_dir_to_endpoint_id = {}
   # FIXME: I couldn't get .each_value to work ... try again?
   # rubocop:disable Performance/HashEachMethods
-  Settings.moab.storage_roots.each do |_name, storage_root|
+  HostSettings.storage_roots.each do |_name, storage_root|
     storage_dir = File.join(storage_root, Settings.moab.storage_trunk)
     @moab_storage_dirs << storage_dir
     @storage_dir_to_endpoint_id[storage_dir] = Endpoint.find_by(storage_location: storage_dir).id

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Endpoint, type: :model do
     let(:default_pres_policies) { [PreservationPolicy.default_policy] }
 
     it 'creates a local online endpoint for each storage root' do
-      Settings.moab.storage_roots.each do |storage_root_name, storage_root_location|
+      HostSettings.storage_roots.each do |storage_root_name, storage_root_location|
         storage_root_attrs = {
           endpoint_type: strg_rt_endpoint_type,
           endpoint_node: Settings.endpoints.storage_root_defaults.endpoint_node,
@@ -89,7 +89,7 @@ RSpec.describe Endpoint, type: :model do
         fixture_sr2: 'spec/fixtures/storage_root02',
         fixture_srTest: 'spec/fixtures/storage_root_unit_test'
       )
-      allow(Settings.moab).to receive(:storage_roots).and_return(storage_roots_setting)
+      allow(HostSettings).to receive(:storage_roots).and_return(storage_roots_setting)
 
       # run it a second time
       Endpoint.seed_storage_root_endpoints_from_config(strg_rt_endpoint_type, default_pres_policies)

--- a/spec/models/host_settings_spec.rb
+++ b/spec/models/host_settings_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe HostSettings do
+  describe '.storage_roots' do
+    it 'gets the correct values' do
+      expect(described_class).to receive(:storage_root_lookup_name).and_call_original
+      expect(described_class.storage_roots.to_h).to eq(fixture_sr1: 'spec/fixtures/storage_root01',
+                                                       fixture_sr2: 'spec/fixtures/storage_root02',
+                                                       fixture_sr3: 'spec/fixtures/checksum_root01',
+                                                       fixture_empty: 'spec/fixtures/empty')
+    end
+  end
+
+  describe '.storage_root_lookup_name' do
+    it "returns 'default' when not in production" do
+      expect(described_class.storage_root_lookup_name).to eq('default')
+    end
+    it 'returns parsed hostname when in production' do
+      expect(Rails.env).to receive(:production?).and_return(true)
+      expect(described_class).to receive(:parsed_hostname).and_return('preservation_catalog_prod_a')
+      expect(described_class.storage_root_lookup_name).to eq('preservation_catalog_prod_a')
+    end
+  end
+
+  describe '.parsed_hostname' do
+    it 'makes hyphens into underscores and trims the domain down' do
+      expect(Socket).to receive(:gethostname).and_return('preservation-catalog-prod-a.stanford.edu')
+      expect(described_class.parsed_hostname).to eq('preservation_catalog_prod_a')
+    end
+  end
+end


### PR DESCRIPTION
- HostSettings class (with specs) gets storage_roots for the host configured in `storage_root_map`
- Replaces calls to `Settings.moab.storage_roots` with `HostSettings.storage_roots`
- Adds `storage_root_map` to settings

Paired with @atz and @jmartin-sul 

Early on, `HostSettings.storage_roots` was memoized, but then the test environment would use the laptop's hostname instead of the `default` host configured in `storage_root_map`.  No memoization worked with the existing tests, options for maintaining memoization seemed ugly, so I think of this as a shameless green PR.

I tested this out on a live deployment to the new prod server, and verified that `HostSettings.storage_roots` returns the same roots configured in `shared_configs`.

Maybe needs only one pair of eyes.

Closes #617 