### PR TITLE
proper unix exit codes for rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -202,7 +202,15 @@ end
 desc "Fire off checksum validation via druid"
 task :cv_druid, [:druid] => [:environment] do |_t, args|
   druid = args[:druid].to_sym
-  Checksum.validate_druid(druid)
+
+  cv_results_lists = Checksum.validate_druid(druid)
+  cv_results_lists.each do |aud_res|
+    puts aud_res.to_json unless aud_res.contains_result_code?(AuditResults::MOAB_CHECKSUM_VALID)
+  end
+
   puts "#{Time.now.utc.iso8601} Checksum Validation on #{druid} is done."
   $stdout.flush
+
+  # exit with non-zero status if any of the pres copies failed checksum validation
+  exit 1 if cv_results_lists.detect { |aud_res| !aud_res.contains_result_code?(AuditResults::MOAB_CHECKSUM_VALID) }
 end

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ desc 'populate the catalog with the contents of the online storage roots'
 task :seed_catalog, [:profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
     p "Usage: rake seed_catalog || rake seed_catalog[profile]"
-    exit
+    exit 1
   end
 
   puts "#{Time.now.utc.iso8601} Seeding the database from all storage roots..."
@@ -59,7 +59,7 @@ desc "Populate single endpoint db data"
 task :populate, [:storage_root, :profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
     p "Usage: rake populate[fixture_sr1] || rake populate[fixture_sr1,profile]"
-    exit
+    exit 1
   end
   root = args[:storage_root]
   if args[:storage_root] != 'profile'
@@ -86,7 +86,7 @@ desc "Fire off M2C existence check on a single storage root"
 task :m2c_exist_single_root, [:storage_root, :profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
     p "Usage: rake m2c_exist_single_root[fixture_sr1] || rake m2c_exist_single_root[fixture_sr1,profile]"
-    exit
+    exit 1
   end
   root = args[:storage_root].to_sym
   storage_dir = "#{Settings.moab.storage_roots[root]}/#{Settings.moab.storage_trunk}"
@@ -107,7 +107,7 @@ desc "Fire off M2C existence check on all storage roots"
 task :m2c_exist_all_storage_roots, [:profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
     p "Usage: rake m2c_exist_all_storage_roots || rake m2c_exist_all_storage_roots[profile]"
-    exit
+    exit 1
   end
 
   if args[:profile] == 'profile'
@@ -124,7 +124,7 @@ desc "Fire off c2m version check on a single storage root"
 task :c2m_check_version_on_dir, [:last_checked_b4_date, :storage_root, :profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
     p "usage: rake c2m_check_version_on_dir[last_checked_b4_date, fixture_sr1] || rake c2m_check_version_on_dir[last_checked_b4_date,fixture_sr1,profile]"
-    exit
+    exit 1
   end
   root = args[:storage_root].to_sym
   storage_dir = "#{Settings.moab.storage_roots[root]}/#{Settings.moab.storage_trunk}"
@@ -148,7 +148,7 @@ desc "Fire off c2m version check on all storage roots"
 task :c2m_check_version_all_dirs, [:last_checked_b4_date, :profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
     p "usage: rake c2m_check_version_all_dirs[last_checked_b4_date] || rake c2m_check_version_all_dirs[last_checked_b4_date,profile]"
-    exit
+    exit 1
   end
   last_checked = args[:last_checked_b4_date].to_s
   begin
@@ -170,7 +170,7 @@ desc "Fire off checksum validation on a single storage root"
 task :cv_single_endpoint, [:storage_root, :profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
     p "usage: rake cv_single_endpoint[storage_root] || rake cv_single_endpoint[storage_root,profile]"
-    exit
+    exit 1
   end
   storage_root = args[:storage_root].to_sym
   if args[:profile] == 'profile'
@@ -187,7 +187,7 @@ desc "Fire off checksum validation on all storage roots"
 task :cv_all_endpoints, [:profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?
     p "usage: rake cv_all_endpoints || rake cv_all_endpoints[profile]"
-    exit
+    exit 1
   end
   if args[:profile] == 'profile'
     puts "When done, check log/profile_cv_validate_disk_all_endpoints[TIMESTAMP].txt for profiling details"

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -145,6 +145,10 @@ class AuditResults
     result_array
   end
 
+  def contains_result_code?(code)
+    result_array.detect { |result_hash| result_hash.keys.include?(code) } != nil
+  end
+
   private
 
   def result_hash(code, msg_args=nil)

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -108,6 +108,8 @@ class AuditResults
   attr_reader :result_array, :druid, :endpoint
   attr_accessor :actual_version, :check_name
 
+  delegate :to_json, to: :result_array
+
   def initialize(druid, actual_version, endpoint, check_name=nil)
     @druid = druid
     @actual_version = actual_version

--- a/lib/audit/checksum.rb
+++ b/lib/audit/checksum.rb
@@ -53,14 +53,17 @@ class Checksum
     Rails.logger.info start_msg
     pres_copies = PreservedCopy.joins(:preserved_object).where(preserved_objects: { druid: druid })
     Rails.logger.debug("Found #{pres_copies.size} preserved copies.")
+    checksum_results_lists = []
     pres_copies.each do |pc|
       endpoint_name = pc.endpoint.endpoint_name
       cv = ChecksumValidator.new(pc, endpoint_name)
       cv.validate_checksums
+      checksum_results_lists << cv.checksum_results
     end
     end_msg = "#{Time.now.utc.iso8601} CV validate_druid ended for #{druid}"
     puts end_msg
     Rails.logger.info end_msg
+    checksum_results_lists
   end
 
 end

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -116,5 +116,12 @@ RSpec.describe Checksum do
       expect(Rails.logger).to receive(:debug).with(error_msg)
       described_class.validate_druid(druid)
     end
+
+    it 'returns the checksum results lists for each PreservedCopy that was checked' do
+      checksum_results_lists = described_class.validate_druid('bz514sm9647')
+      expect(checksum_results_lists.size).to eq 1 # should just be one PC for the druid
+      checksum_results = checksum_results_lists.first
+      expect(checksum_results.contains_result_code?(AuditResults::MOAB_CHECKSUM_VALID)).to eq true
+    end
   end
 end

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -280,4 +280,17 @@ RSpec.describe AuditResults do
       expect(audit_results.contains_result_code?(other_code)).to eq false
     end
   end
+
+  context '#to_json' do
+    it 'returns valid JSON for the current result_array' do
+      audit_results.add_result(AuditResults::PC_PO_VERSION_MISMATCH, pc_version: 1, po_version: 2)
+      json_text = audit_results.to_json
+      json_parsed = JSON.parse(json_text)
+
+      exp_msg = "PreservedCopy online Moab version 1 does not match PreservedObject current_version 2"
+      expect(json_parsed.length).to eq 1
+      expect(json_parsed.first.keys).to eq [AuditResults::PC_PO_VERSION_MISMATCH.to_s]
+      expect(json_parsed.first[AuditResults::PC_PO_VERSION_MISMATCH.to_s]).to eq exp_msg
+    end
+  end
 end

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -269,4 +269,15 @@ RSpec.describe AuditResults do
       expect(audit_results.result_array).to include(a_hash_including(AuditResults::INVALID_MOAB))
     end
   end
+
+  context '#contains_result_code?' do
+    it 'returns true if the result code is there, false if not' do
+      expect(audit_results.result_array.size).to eq 0
+      added_code = AuditResults::PC_PO_VERSION_MISMATCH
+      other_code = AuditResults::VERSION_MATCHES
+      audit_results.add_result(added_code, pc_version: 1, po_version: 2)
+      expect(audit_results.contains_result_code?(added_code)).to eq true
+      expect(audit_results.contains_result_code?(other_code)).to eq false
+    end
+  end
 end


### PR DESCRIPTION
* invalid usage of Rake tasks should return non-zero error code 
* AuditResults: add method for detecting whether results include a given code
* AuditResults: add #to_json method and test 
* non-zero exit code from cv_druid rake task if validation fails for any examined pres copy

closes #633