### PR TITLE
Selectable checksum test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    moab-versioning (4.2.0)
+    moab-versioning (4.2.1)
       confstruct
       druid-tools (>= 1.0.0)
       json

--- a/config/initializers/moab_config.rb
+++ b/config/initializers/moab_config.rb
@@ -5,4 +5,5 @@ Moab::Config.configure do
   storage_roots(HostSettings.storage_roots.map { |_storage_root_name, storage_root_location| storage_root_location })
   storage_trunk(Settings.moab.storage_trunk)
   path_method(Settings.moab.path_method.to_sym)
+  checksum_algos(Settings.checksum_algos.map(&:to_sym))
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,3 +35,5 @@ provlog:
 
 workflow_services_url: ''
 c2m_sql_limit: 1000
+
+checksum_algos: ['md5'] # 'sha1' 'sha256'

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -304,4 +304,29 @@ RSpec.describe ChecksumValidator do
       end
     end
   end
+
+  context 'checksums are configurable' do
+    it 'all three checksums at once' do
+      allow(Moab::Config).to receive(:checksum_algos).and_return(%i[md5 sha1 sha256])
+      expect(Digest::MD5).to receive(:new).and_call_original.at_least(:once)
+      expect(Digest::SHA1).to receive(:new).and_call_original.at_least(:once)
+      expect(Digest::SHA2).to receive(:new).and_call_original.at_least(:once)
+      cv.validate_checksums
+    end
+
+    it 'defaults to md5 only' do
+      expect(Digest::MD5).to receive(:new).and_call_original.at_least(:once)
+      expect(Digest::SHA1).not_to receive(:new).and_call_original
+      expect(Digest::SHA2).not_to receive(:new).and_call_original
+      cv.validate_checksums
+    end
+
+    it 'sha256 only' do
+      allow(Moab::Config).to receive(:checksum_algos).and_return([:sha256])
+      expect(Digest::MD5).not_to receive(:new).and_call_original
+      expect(Digest::SHA1).not_to receive(:new).and_call_original
+      expect(Digest::SHA2).to receive(:new).and_call_original.at_least(:once)
+      cv.validate_checksums
+    end
+  end
 end


### PR DESCRIPTION
1st Commit is some RSpec refactoring that was done during code club w/ @atz. I can separate this out into another commit if wanted.

2nd Commit contains moab-versioning update and adding the configurable checksum w/ RSpec tests.
 ( I can move the whole`context 'checksums are configurable' do..` bock into the `context #validate_checkums' do` block if wanted as well. )


ad hoc paired w/ @jmartin-sul  for 2nd commit.

closes #663 