### PR TITLE
Introduce okcomputer, 2 types of checks and tests to match

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'config' # Settings to manage configs on different instances
 gem 'faraday' # ReST calls
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'jbuilder', '~> 2.5' # Build JSON APIs with ease.
+gem 'okcomputer'
 gem 'pg' # postgres database
 # pry is useful for debugging, even in prod
 gem 'pry-byebug' # call 'binding.pry' anywhere in the code to stop execution and get a pry-byebug console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     nokogiri-happymapper (0.6.0)
       nokogiri (~> 1.5)
+    okcomputer (1.17.1)
     parallel (1.12.1)
     parser (2.5.0.5)
       ast (~> 2.4.0)
@@ -311,6 +312,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   moab-versioning
   newrelic_rpm
+  okcomputer
   pg
   pry-byebug
   pry-rails

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -41,8 +41,7 @@ class PreservedCopy < ApplicationRecord
   }
 
   scope :least_recent_version_audit, lambda { |last_checked_b4_date|
-    last_checked_b4_date = normalize_date(last_checked_b4_date)
-    where('last_version_audit IS NULL or last_version_audit < ?', last_checked_b4_date)
+    where('last_version_audit IS NULL or last_version_audit < ?', normalize_date(last_checked_b4_date))
       .order('last_version_audit IS NOT NULL, last_version_audit ASC')
     # possibly counter-intuitive: the .order sorts so that null values come first (because IS NOT NULL evaluates
     # to 0 for nulls, which sorts before 1 for non-nulls, which are then sorted by last_version_audit)
@@ -87,7 +86,7 @@ class PreservedCopy < ApplicationRecord
   end
 
   private_class_method def self.normalize_date(timestamp)
-    timestamp = Time.parse(timestamp).utc unless timestamp.instance_of?(Time)
-    timestamp
+    return timestamp if timestamp.is_a?(Time) || timestamp.is_a?(ActiveSupport::TimeWithZone)
+    Time.parse(timestamp).utc
   end
 end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,47 @@
+require 'okcomputer'
+
+OkComputer.mount_at = 'status' # use /status or /status/all or /status/<name-of-check>
+OkComputer.check_in_parallel = true
+
+# check models to see if at least they have some data
+class TablesHaveDataCheck < OkComputer::Check
+  def check
+    msg = [
+      Endpoint,
+      PreservationPolicy
+    ].map { |klass| table_check(klass) }.join(' ')
+    mark_message msg
+  end
+
+  # @return [String] message
+  private def table_check(klass)
+    # has at least 1 record, using select(:id) to avoid returning all data
+    return "#{klass.name} has data." if klass.select(:id).first!.present?
+    mark_failure
+    "#{klass.name} has no data."
+  rescue ActiveRecord::RecordNotFound
+    mark_failure
+    "#{klass.name} has no data."
+  rescue => e # rubocop:disable Lint/RescueWithoutErrorClass
+    mark_failure
+    "#{e.class.name} received: #{e.message}."
+  end
+end
+OkComputer::Registry.register "feature-tables-have-data", TablesHaveDataCheck.new
+
+# check PreservedCopy#last_version_audit to ensure it isn't too old
+class VersionAuditWindowCheck < OkComputer::Check
+  def check
+    if PreservedCopy.least_recent_version_audit(clause).first
+      mark_message "PreservedCopy\#last_version_audit older than #{clause}. "
+      mark_failure
+    else
+      mark_message "PreservedCopy\#last_version_audit all newer than #{clause}. "
+    end
+  end
+
+  private def clause
+    14.days.ago
+  end
+end
+OkComputer::Registry.register "version-audit-window-check", VersionAuditWindowCheck.new

--- a/spec/lib/okcomputer_spec.rb
+++ b/spec/lib/okcomputer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'OkComputer custom checks' do # rubocop:disable RSpec/DescribeClass
+  subject { described_class.new }
+
+  describe TablesHaveDataCheck do
+    it { is_expected.to be_successful }
+    context 'without data' do
+      before { allow(PreservationPolicy).to receive(:select).with(:id).and_return([]) }
+      it { is_expected.not_to be_successful }
+    end
+  end
+
+  describe VersionAuditWindowCheck do
+    it { is_expected.to be_successful }
+    context 'with old data' do
+      before { allow(PreservedCopy).to receive(:least_recent_version_audit).with(any_args).and_return([double]) }
+      it { is_expected.not_to be_successful }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,20 +11,8 @@ require 'rake'
 Rails.application.load_tasks
 Rake::Task["db:reset"].invoke
 
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+# auto-require all ruby files in the support directory
+Dir[Rails.root.join('spec', 'support', '*.rb')].each { |f| require f }
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/okcomputer_check_matcher.rb
+++ b/spec/support/okcomputer_check_matcher.rb
@@ -1,0 +1,32 @@
+# Taken from okcomputer's own tests
+# https://github.com/sportngin/okcomputer/blob/master/spec/support/check_matcher.rb
+
+RSpec::Matchers.define :have_message do |message|
+  match do |actual|
+    actual.check
+    actual.message.include? message
+  end
+
+  failure_message do |actual|
+    "expected '#{actual.message}' to include '#{message}'"
+  end
+
+  failure_message_when_negated do |actual|
+    "expected '#{actual.message}' to not include '#{message}'"
+  end
+end
+
+RSpec::Matchers.define :be_successful do |_message|
+  match do |actual|
+    actual.check
+    actual.success?
+  end
+
+  failure_message do |actual|
+    "expected #{actual.inspect} to be successful"
+  end
+
+  failure_message_when_negated do |actual|
+    "expected '#{actual}' to not be successful"
+  end
+end


### PR DESCRIPTION
- RSpec matchers from okcomputer
- use `spec/support` dir for add'l test scaffolding
- Amend activerecord scope to accept `ActiveSupport::TimeWithZone` objects, which are of course compatible with ActiveRecord querying. These are returned by statements like `2.days.ago`.

Fixes #574 