### PR TITLE
Logger chain

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,12 @@ module PreservationCatalog
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    # Double-output logging, both to Rails.logger and STDOUT.  Helps avoid puts statements.
+    # If you don't want that, just use Rails.logger (or another Logger instance)
+    # @return [Logger]
+    def self.logger
+      @logger ||= Logger.new(STDOUT).extend(ActiveSupport::Logger.broadcast(Rails.logger))
+    end
   end
 end

--- a/lib/audit/catalog_to_moab.rb
+++ b/lib/audit/catalog_to_moab.rb
@@ -5,11 +5,12 @@ require 'profiler.rb'
 
 # Catalog to Moab existence check code
 class CatalogToMoab
+  class << self
+    delegate :logger, to: PreservationCatalog::Application
+  end
 
   def self.check_version_on_dir(last_checked_b4_date, storage_dir, limit=Settings.c2m_sql_limit)
-    start_msg = "#{Time.now.utc.iso8601} C2M check_version starting for #{storage_dir}"
-    puts start_msg
-    Rails.logger.info start_msg
+    logger.info "#{Time.now.utc.iso8601} C2M check_version starting for #{storage_dir}"
 
     # pcs_to_audit_relation is an AR Relation; it could return a lot of results, so we want to process it in
     # batches.  we can't use ActiveRecord's .find_each, because that'll disregard the order .least_recent_version_audit
@@ -20,10 +21,8 @@ class CatalogToMoab
       c2m = CatalogToMoab.new(pc, storage_dir)
       c2m.check_catalog_version
     end
-
-    end_msg = "#{Time.now.utc.iso8601} C2M check_version ended for #{storage_dir}"
-    puts end_msg
-    Rails.logger.info end_msg
+  ensure
+    logger.info "#{Time.now.utc.iso8601} C2M check_version ended for #{storage_dir}"
   end
 
   def self.check_version_on_dir_profiled(last_checked_b4_date, storage_dir)
@@ -33,15 +32,12 @@ class CatalogToMoab
   end
 
   def self.check_version_all_dirs(last_checked_b4_date)
-    start_msg = "#{Time.now.utc.iso8601} C2M check_version_all_dirs starting"
-    puts start_msg
-    Rails.logger.info start_msg
+    logger.info "#{Time.now.utc.iso8601} C2M check_version_all_dirs starting"
     HostSettings.storage_roots.each do |_strg_root_name, strg_root_location|
       check_version_on_dir(last_checked_b4_date, "#{strg_root_location}/#{Settings.moab.storage_trunk}")
     end
-    end_msg = "#{Time.now.utc.iso8601} C2M check_version_all_dirs ended"
-    puts end_msg
-    Rails.logger.info end_msg
+  ensure
+    logger.info "#{Time.now.utc.iso8601} C2M check_version_all_dirs ended"
   end
 
   def self.check_version_all_dirs_profiled(last_checked_b4_date)

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -1,15 +1,15 @@
 require 'profiler.rb'
 
-##
 # finds Moab objects on a single Moab storage_dir and interacts with Catalog (db)
 #   according to method called
 class MoabToCatalog
+  class << self
+    delegate :logger, to: PreservationCatalog::Application
+  end
 
   # NOTE: shameless green! code duplication with seed_catalog_for_dir
   def self.check_existence_for_dir(storage_dir)
-    start_msg = "#{Time.now.utc.iso8601} M2C check_existence starting for '#{storage_dir}'"
-    puts start_msg
-    Rails.logger.info start_msg
+    logger.info "#{Time.now.utc.iso8601} M2C check_existence starting for '#{storage_dir}'"
     results = []
     endpoint = Endpoint.find_by!(storage_location: storage_dir)
     Stanford::MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
@@ -17,10 +17,9 @@ class MoabToCatalog
       po_handler = PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, endpoint)
       results.concat po_handler.check_existence
     end
-    end_msg = "#{Time.now.utc.iso8601} M2C check_existence ended for '#{storage_dir}'"
-    puts end_msg
-    Rails.logger.info end_msg
     results
+  ensure
+    logger.info "#{Time.now.utc.iso8601} M2C check_existence ended for '#{storage_dir}'"
   end
 
   def self.check_existence_for_dir_profiled(storage_dir)
@@ -31,9 +30,7 @@ class MoabToCatalog
 
   # NOTE: shameless green! code duplication with check_existence_for_dir
   def self.seed_catalog_for_dir(storage_dir)
-    start_msg = "#{Time.now.utc.iso8601} Seeding starting for '#{storage_dir}'"
-    puts start_msg
-    Rails.logger.info start_msg
+    logger.info "#{Time.now.utc.iso8601} Seeding starting for '#{storage_dir}'"
     results = []
     endpoint = Endpoint.find_by!(storage_location: storage_dir)
     Stanford::MoabStorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
@@ -41,23 +38,19 @@ class MoabToCatalog
       po_handler = PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, endpoint)
       results << po_handler.create_after_validation
     end
-    end_msg = "#{Time.now.utc.iso8601} Seeding ended for '#{storage_dir}'"
-    puts end_msg
-    Rails.logger.info end_msg
     results
+  ensure
+    logger.info "#{Time.now.utc.iso8601} Seeding ended for '#{storage_dir}'"
   end
 
   # Shameless green. In order to run several seed "jobs" in parallel, we would have to refactor.
   def self.seed_catalog_for_all_storage_roots
-    start_msg = "#{Time.now.utc.iso8601} Seeding for all storage roots starting"
-    puts start_msg
-    Rails.logger.info start_msg
+    logger.info "#{Time.now.utc.iso8601} Seeding for all storage roots starting"
     HostSettings.storage_roots.each do |_strg_root_name, strg_root_location|
       seed_catalog_for_dir("#{strg_root_location}/#{Settings.moab.storage_trunk}")
     end
-    end_msg = "#{Time.now.utc.iso8601} Seeding for all storage roots ended'"
-    puts end_msg
-    Rails.logger.info end_msg
+  ensure
+    logger.info "#{Time.now.utc.iso8601} Seeding for all storage roots ended'"
   end
 
   def self.seed_catalog_for_all_storage_roots_profiled
@@ -68,15 +61,12 @@ class MoabToCatalog
 
   # Shameless green. Code duplication with seed_catalog_for_all_storage_roots
   def self.check_existence_for_all_storage_roots
-    start_msg = "#{Time.now.utc.iso8601} M2C check_existence for all storage roots starting'"
-    puts start_msg
-    Rails.logger.info start_msg
+    logger.info "#{Time.now.utc.iso8601} M2C check_existence for all storage roots starting'"
     HostSettings.storage_roots.each do |_strg_root_name, strg_root_location|
       check_existence_for_dir("#{strg_root_location}/#{Settings.moab.storage_trunk}")
     end
-    end_msg = "#{Time.now.utc.iso8601} M2C check_existence for all storage roots ended'"
-    puts end_msg
-    Rails.logger.info end_msg
+  ensure
+    logger.info "#{Time.now.utc.iso8601} M2C check_existence for all storage roots ended'"
   end
 
   def self.check_existence_for_all_storage_roots_profiled

--- a/spec/lib/audit/catalog_to_moab_class_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_class_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 require_relative '../../../lib/audit/catalog_to_moab.rb'
 require_relative '../../load_fixtures_helper.rb'
 
@@ -5,6 +6,8 @@ RSpec.describe CatalogToMoab do
   let(:last_checked_version_b4_date) { (Time.now.utc - 1.day).iso8601 }
   let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
   let(:limit) { Settings.c2m_sql_limit }
+
+  before { allow(described_class.logger).to receive(:info) } # silence STDOUT chatter
 
   context '.check_version_on_dir' do
     include_context 'fixture moabs in db'

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Checksum do
   let(:endpoint_name) { 'fixture_sr1' }
   let(:limit) { Settings.c2m_sql_limit }
 
+  before { allow(described_class.logger).to receive(:info) } # silence STDOUT chatter
+
   context '.validate_disk' do
     include_context 'fixture moabs in db'
     let(:subject) { described_class.validate_disk(endpoint_name, limit) }

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe MoabToCatalog do
 
   before do
     PreservationPolicy.seed_from_config
+    allow(described_class.logger).to receive(:info) # silence STDOUT chatter
   end
 
   describe ".check_existence_for_all_storage_roots" do


### PR DESCRIPTION
Previously, code was calling both `Rails.logger` (to file) and `puts` (to `STDOUT`) with the same messages.  I consolidated those lines by having a single logger that outputs to both.

This cleans up:
- the code
- our test output, by keeping the `puts` statements from firing during `rspec` or CI

