### PR TITLE
Remove unnecessary require statement

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,6 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
-require 'rake'
 Rails.application.load_tasks
 Rake::Task["db:reset"].invoke
 


### PR DESCRIPTION
The tasks are loaded by `load_tasks`, so we know Rake is already available.