### PR TITLE
Allow `config.active_job` to succeed in production.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -4,7 +4,7 @@ require_relative 'boot'
 require 'rails'
 require 'active_record/railtie'
 require 'action_controller/railtie'
-require 'active_job'
+require 'active_job/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
The configuration attribute didn't exist w/o loading the railtie, resulting in a `NoMethodError` (only in production environment).