### PR TITLE
Robots sends the storage_location without the storage_trunk, so When …

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -11,7 +11,7 @@ class CatalogController < ApplicationController
     druid = poh_params[:druid]
     incoming_version = poh_params[:incoming_version].to_i
     incoming_size = poh_params[:incoming_size].to_i
-    endpoint = Endpoint.find_by(storage_location: poh_params[:storage_location])
+    endpoint = Endpoint.find_by(storage_location: "#{poh_params[:storage_location]}/#{Moab::Config.storage_trunk}")
     @poh = PreservedObjectHandler.new(druid, incoming_version, incoming_size, endpoint)
     poh.create
     status_code =
@@ -33,7 +33,7 @@ class CatalogController < ApplicationController
     druid = poh_params[:druid]
     incoming_version = poh_params[:incoming_version].to_i
     incoming_size = poh_params[:incoming_size].to_i
-    endpoint = Endpoint.find_by(storage_location: poh_params[:storage_location])
+    endpoint = Endpoint.find_by(storage_location: "#{poh_params[:storage_location]}/#{Moab::Config.storage_trunk}")
     @poh = PreservedObjectHandler.new(druid, incoming_version, incoming_size, endpoint)
     poh.update_version
     status_code =


### PR DESCRIPTION
…we were making a POST or PATCH, we were getting validation errors. Need to interpolate the storage_trunk at the end of the storage_location to be able to get the Endpoint object in order for creating and updating