### PR TITLE
Host settings robustness

### DIFF
--- a/app/models/host_settings.rb
+++ b/app/models/host_settings.rb
@@ -1,8 +1,8 @@
 # Lets us consolidate shared_configs for almost identical machines
 class HostSettings
-  # @return [Config::Options] key/value pairs of name: file_path
+  # @return [Config::Options, Hash] key/value pairs of name: file_path
   def self.storage_roots
-    Settings.storage_root_map[storage_root_lookup_name]
+    Settings.storage_root_map[storage_root_lookup_name] || {}
   end
 
   # @return [String] hostname depending on environment

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,6 +33,9 @@ preservation_policies:
 provlog:
   enable: false
 
+storage_root_map: # empty here, override in #{RAILS_ENV}.yml
+  default: {}
+
 workflow_services_url: ''
 c2m_sql_limit: 1000
 

--- a/spec/models/host_settings_spec.rb
+++ b/spec/models/host_settings_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe HostSettings do
+  it 'depends on Settings.storage_root_map' do
+    expect(Settings.storage_root_map).to be
+  end
+
   describe '.storage_roots' do
     it 'gets the correct values' do
       expect(described_class).to receive(:storage_root_lookup_name).and_call_original
@@ -8,6 +12,14 @@ RSpec.describe HostSettings do
                                                        fixture_sr2: 'spec/fixtures/storage_root02',
                                                        fixture_sr3: 'spec/fixtures/checksum_root01',
                                                        fixture_empty: 'spec/fixtures/empty')
+    end
+
+    context 'on unrecognized systems' do
+      it 'does not bork, just returns empty hash' do
+        allow(described_class).to receive(:storage_root_lookup_name).and_return('foobar123')
+        expect { described_class.storage_roots }.not_to raise_error
+        expect(described_class.storage_roots).to eq({})
+      end
     end
   end
 


### PR DESCRIPTION
Add baseline empty storage_root_map to Settings.yml and provide failover.

Because the lookup is based on system name, we should anticipate that it will be invoked on systems not yet present in the configuration (even if that is a dev system). Returning an empty hash is preferable to raising an uninformative `NoMethodError`.