### PR TITLE
Reduce unnecessary requires

### DIFF
--- a/app/services/checksum_validator.rb
+++ b/app/services/checksum_validator.rb
@@ -1,5 +1,3 @@
-require 'moab_validation_handler.rb'
-
 # code for validating Moab checksums
 class ChecksumValidator
   include ::MoabValidationHandler

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -6,11 +6,6 @@
 #
 # inspired by http://www.thegreatcodeadventure.com/smarter-rails-services-with-active-record-modules/
 class PreservedObjectHandler
-
-  require 'active_record_utils.rb'
-  require 'audit_results.rb'
-  require 'moab_validation_handler.rb'
-
   include ::MoabValidationHandler
   include ActiveModel::Validations
 

--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../lib/profiler.rb'
+require 'profiler'
 require 'ruby-prof'
 
 RSpec.describe Profiler do

--- a/spec/load_fixtures_helper.rb
+++ b/spec/load_fixtures_helper.rb
@@ -1,4 +1,4 @@
-require 'rails_helper.rb'
+require 'rails_helper'
 
 RSpec.configure do |rspec|
   # This config option will be enabled by default on RSpec 4,


### PR DESCRIPTION
Inside `app` everything is auto/eager-loaded by Rails, so you never need to explicitly require anything else that lives inside `app`.

The way `lib` is invoked most typically is via `autoload_path` or in pure Ruby, `ruby -I ./lib` or the `RUBYLIB` ENV var. So components should be available to each other if naming conventions are followed.

We don't actually follow naming conventions fully (e.g. `Checksum` is not in an `Audit` module), *but* for referencing peers in the same directory that doesn't matter.