### PR TITLE
remove rubocop from default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Rails.application.load_tasks
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
-task default: [:spec, :rubocop]
+task default: :spec
 
 task :travis_setup_postgres do
   sh("psql -U postgres -f db/scripts/pres_test_setup.sql")


### PR DESCRIPTION
Let's try a few weeks with mandatory rubocop NOT a part of the build.  Let's see if it helps keep our focus on critical path tasks.