### PR TITLE
Add db:seed to cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,15 @@ rake spec
 ## Deploying
 
 Capistrano is used to deploy.
+
+To run `rake db:seed` in a deploy environment:
+
+```sh
+bundle exec cap stage db_seed # for the stage servers
+```
+
+or
+
+```sh
+bundle exec cap prod db_seed # for the prod servers
+```

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,3 +36,16 @@ set :honeybadger_env, fetch(:stage)
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5
+
+after 'deploy:migrate', 'db_seed'
+
+desc 'Run rake db:seed'
+task :db_seed do
+  on roles(:all) do
+    within current_path do
+      with rails_env: fetch(:rails_env) do
+        execute :rake, 'db:seed'
+      end
+    end
+  end
+end


### PR DESCRIPTION
  Adds a capistrano task to call seed_catalog
  and perform it after migrations on a deploy

  Fixes #736 
