### PR TITLE
Aws worker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) do |repo_name|
 end
 
 # general Ruby/Rails gems
+gem 'aws-sdk-s3', '~> 1.9.1'
 gem 'config' # Settings to manage configs on different instances
 gem 'faraday' # ReST calls
 gem 'honeybadger' # for error reporting / tracking / notifications

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,19 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     arel (8.0.0)
     ast (2.4.0)
+    aws-partitions (1.83.0)
+    aws-sdk-core (3.20.2)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.5.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.9.1)
+      aws-sdk-core (~> 3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.2)
     builder (3.2.3)
     bundler-audit (0.6.0)
       bundler (~> 1.2)
@@ -145,6 +158,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jmespath (1.4.0)
     json (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -316,6 +330,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1.9.1)
   capistrano-passenger
   capistrano-rails
   config

--- a/app/jobs/endpoint_delivery_base.rb
+++ b/app/jobs/endpoint_delivery_base.rb
@@ -1,19 +1,14 @@
 # A common base for Endpoint delivery jobs in a Rails context.
-# Prepopulates the `zip` attribute.
+# Prepopulates the `zip` with a DruidVersionZip object
 class EndpointDeliveryBase < ApplicationJob
   attr_accessor :zip
 
   before_perform do |job|
-    job.zip = job.class.fetch_zip(job.arguments.first, job.arguments.second)
+    job.zip = DruidVersionZip.new(job.arguments.first, job.arguments.second)
   end
 
   # In Job subclass, implement this method:
   # @param [String] druid
   # @param [Integer] version
   # def perform(druid, version)
-
-  # @return [tbd] the zipfile
-  def self.fetch_zip(_druid, _version)
-    # get the zip
-  end
 end

--- a/app/jobs/s3_endpoint_delivery_job.rb
+++ b/app/jobs/s3_endpoint_delivery_job.rb
@@ -12,12 +12,12 @@ class S3EndpointDeliveryJob < EndpointDeliveryBase
   # @todo once zip construction is formalized, insert reproducible call in zip_cmd
   def perform(druid, version)
     return if s3_object.exists?
-    s3_object.put(body: zip.file, metadata: { zip_cmd: 'zip -X ...', checksum_md5: zip.md5 })
+    s3_object.put(body: zip.file, content_md5: zip.md5, metadata: { zip_cmd: 'zip -X ...', checksum_md5: zip.md5 })
     ResultsRecorderJob.perform_later(druid, version, 's3', '12345ABC') # value will be from zip.checksum
   end
 
   # @return [Aws::S3::Object]
   def s3_object
-    @object ||= bucket.object(zip.s3_key)
+    @s3_object ||= bucket.object(zip.s3_key)
   end
 end

--- a/app/jobs/s3_endpoint_delivery_job.rb
+++ b/app/jobs/s3_endpoint_delivery_job.rb
@@ -9,13 +9,15 @@ class S3EndpointDeliveryJob < EndpointDeliveryBase
 
   # @param [String] druid
   # @param [Integer] version
+  # @todo once zip construction is formalized, insert reproducible call in zip_cmd
   def perform(druid, version)
-    return if object.exists?
-    object.put(zip.file)
+    return if s3_object.exists?
+    s3_object.put(body: zip.file, metadata: { zip_cmd: 'zip -X ...', checksum_md5: zip.md5 })
     ResultsRecorderJob.perform_later(druid, version, 's3', '12345ABC') # value will be from zip.checksum
   end
 
-  def object
+  # @return [Aws::S3::Object]
+  def s3_object
     @object ||= bucket.object(zip.s3_key)
   end
 end

--- a/app/jobs/s3_endpoint_delivery_job.rb
+++ b/app/jobs/s3_endpoint_delivery_job.rb
@@ -1,5 +1,3 @@
-# require aws/s3 lib
-#
 # Responsibilities:
 # "Speak S3"
 # Check if corresponding zip exists in S3.
@@ -8,6 +6,10 @@
 class S3EndpointDeliveryJob < EndpointDeliveryBase
   queue_as :s3_enpoint_delivery
   # note: EndpointDeliveryBase gives us `zip`
+
+  class << self
+    delegate :client, to: PreservationCatalog::S3
+  end
 
   # @param [String] druid
   # @param [Integer] version

--- a/app/jobs/s3_endpoint_delivery_job.rb
+++ b/app/jobs/s3_endpoint_delivery_job.rb
@@ -1,19 +1,21 @@
-# Responsibilities:
-# "Speak S3"
-# Check if corresponding zip exists in S3.
+# Posts zips to S3
+# @see PreservationCatalog::S3 for how S3 credentials and bucket are configured
 # Upload zip if needed.
 # Notify ResultsRecorderJob.
 class S3EndpointDeliveryJob < EndpointDeliveryBase
   queue_as :s3_enpoint_delivery
+  delegate :bucket, to: PreservationCatalog::S3
   # note: EndpointDeliveryBase gives us `zip`
-
-  class << self
-    delegate :client, to: PreservationCatalog::S3
-  end
 
   # @param [String] druid
   # @param [Integer] version
   def perform(druid, version)
+    return if object.exists?
+    object.put(zip.file)
     ResultsRecorderJob.perform_later(druid, version, 's3', '12345ABC') # value will be from zip.checksum
+  end
+
+  def object
+    @object ||= bucket.object(zip.s3_key)
   end
 end

--- a/app/lib/preservation_catalog/s3.rb
+++ b/app/lib/preservation_catalog/s3.rb
@@ -1,24 +1,25 @@
 module PreservationCatalog
+  # The Application's configured interface to S3.
   class S3
     class << self
       delegate :client, to: :bucket
-    end
 
-    # @return [Aws::S3::Bucket]
-    def self.bucket
-      resource.bucket(bucket_name)
-    end
+      # @return [Aws::S3::Bucket]
+      def bucket
+        resource.bucket(bucket_name)
+      end
 
-    # Because AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION will be managed via
-    # ENV vars, and the bucket must match those, we check for AWS_BUCKET_NAME first.
-    # @return [String]
-    def self.bucket_name
-      ENV['AWS_BUCKET_NAME'] || Settings.aws.bucket_name
-    end
+      # Because AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION will be managed via
+      # ENV vars, and the bucket must match those, we check for AWS_BUCKET_NAME first.
+      # @return [String]
+      def bucket_name
+        ENV['AWS_BUCKET_NAME'] || Settings.aws.bucket_name
+      end
 
-    # @return [Aws::S3::Resource]
-    def self.resource
-      Aws::S3::Resource.new
+      # @return [Aws::S3::Resource]
+      def resource
+        Aws::S3::Resource.new
+      end
     end
   end
 end

--- a/app/lib/preservation_catalog/s3.rb
+++ b/app/lib/preservation_catalog/s3.rb
@@ -1,0 +1,24 @@
+module PreservationCatalog
+  class S3
+    class << self
+      delegate :client, to: :bucket
+    end
+
+    # @return [Aws::S3::Bucket]
+    def self.bucket
+      resource.bucket(bucket_name)
+    end
+
+    # Because AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION will be managed via
+    # ENV vars, and the bucket must match those, we check for AWS_BUCKET_NAME first.
+    # @return [String]
+    def self.bucket_name
+      ENV['AWS_BUCKET_NAME'] || Settings.aws.bucket_name
+    end
+
+    # @return [Aws::S3::Resource]
+    def self.resource
+      Aws::S3::Resource.new
+    end
+  end
+end

--- a/app/models/druid_version_zip.rb
+++ b/app/models/druid_version_zip.rb
@@ -27,9 +27,9 @@ class DruidVersionZip
   end
 
   # Currently computed live, soon will fetch from checksum storage
-  # @return [String] md5 checksum
+  # @return [String] md5 base64-encoded checksum
   # @todo Fetch (and cache) md5 from checksum storage
   def md5
-    Digest::MD5.file(file_path).hexdigest
+    @md5 ||= Digest::MD5.file(file_path).base64digest
   end
 end

--- a/app/models/druid_version_zip.rb
+++ b/app/models/druid_version_zip.rb
@@ -1,0 +1,35 @@
+# Just a regular model, not an ActiveRecord-backed model
+class DruidVersionZip
+  attr_reader :druid, :version
+
+  # @param [String] druid
+  # @param [Integer] version
+  def initialize(druid, version)
+    @druid = DruidTools::Druid.new(druid.downcase)
+    @version = version
+  end
+
+  # @return [String]
+  # @see [S3 key name performance implications] https://docs.aws.amazon.com/AmazonS3/latest/dev/request-rate-perf-considerations.html
+  # @example return 'ab/123/cd/4567/ab123cd4567/ab123cd4567.v0001.zip'
+  def s3_key
+    druid.tree.join('/') + format(".v%04d.zip", version)
+  end
+
+  # @return [File] opened zip file
+  def file
+    File.open(file_path)
+  end
+
+  # @return [String] Path to the local temporary transfer zip
+  def file_path
+    File.join(Settings.zip_storage, s3_key)
+  end
+
+  # Currently computed live, soon will fetch from checksum storage
+  # @return [String] md5 checksum
+  # @todo Fetch (and cache) md5 from checksum storage
+  def md5
+    Digest::MD5.file(file_path).hexdigest
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,6 @@
+aws:
+  bucket_name: 'sul-sdr-aws-us-west-2-test' # override in prod
+
 # named storage roots are in the storage_root_map (see config/settings for examples).
 # the storage_root_map contains lookups of storage roots per host.
 # see sul-dlss/shared_configs for the storage_root_map of all hosts we deploy to.

--- a/spec/jobs/s3_endpoint_delivery_job_spec.rb
+++ b/spec/jobs/s3_endpoint_delivery_job_spec.rb
@@ -31,9 +31,11 @@ describe S3EndpointDeliveryJob, type: :job do
   end
 
   context 'zip is new to S3' do
+    let(:md5) { '1B2M2Y8AsgTpgAmY7PhCfg==' }
+
     it 'puts to S3' do
       expect(object).to receive(:put).with(
-        a_hash_including(body: File, metadata: a_hash_including(checksum_md5: 'd41d8cd98f00b204e9800998ecf8427e'))
+        a_hash_including(body: File, content_md5: md5, metadata: a_hash_including(checksum_md5: md5))
       )
       described_class.perform_now(druid, version)
     end

--- a/spec/jobs/s3_endpoint_delivery_job_spec.rb
+++ b/spec/jobs/s3_endpoint_delivery_job_spec.rb
@@ -2,14 +2,16 @@ require 'rails_helper'
 
 describe S3EndpointDeliveryJob, type: :job do
   let(:druid) { 'bj102hs9687' }
+  let(:dvz) { DruidVersionZip.new(druid, version) }
   let(:version) { 1 }
 
   it 'descends from EndpointDeliveryBase' do
     expect(described_class.new).to be_an(EndpointDeliveryBase)
   end
 
-  it 'fetches the zip' do
-    expect(EndpointDeliveryBase).to receive(:fetch_zip).with(druid, version)
+  it 'populates a DruidVersionZip' do
+    allow(dvz).to receive(:exists?).and_return(true)
+    expect(DruidVersionZip).to receive(:new).with(druid, version).and_return(dvz)
     described_class.perform_now(druid, version)
   end
 

--- a/spec/jobs/s3_endpoint_delivery_job_spec.rb
+++ b/spec/jobs/s3_endpoint_delivery_job_spec.rb
@@ -2,17 +2,41 @@ require 'rails_helper'
 
 describe S3EndpointDeliveryJob, type: :job do
   let(:druid) { 'bj102hs9687' }
-  let(:dvz) { DruidVersionZip.new(druid, version) }
   let(:version) { 1 }
+  let(:dvz) { DruidVersionZip.new(druid, version) }
+  let(:object) { instance_double(Aws::S3::Object, exists?: false, put: true) }
+  let(:bucket) { instance_double(Aws::S3::Bucket, object: object) }
+
+  before do
+    allow(Settings).to receive(:zip_storage).and_return(Rails.root.join('spec', 'fixtures', 'zip_storage'))
+    allow(PreservationCatalog::S3).to receive(:bucket).and_return(bucket)
+  end
 
   it 'descends from EndpointDeliveryBase' do
     expect(described_class.new).to be_an(EndpointDeliveryBase)
   end
 
   it 'populates a DruidVersionZip' do
-    allow(dvz).to receive(:exists?).and_return(true)
     expect(DruidVersionZip).to receive(:new).with(druid, version).and_return(dvz)
     described_class.perform_now(druid, version)
+  end
+
+  context 'zip already exists on s3' do
+    before { allow(object).to receive(:exists?).and_return(true) }
+
+    it 'does nothing' do
+      expect(object).not_to receive(:put)
+      described_class.perform_now(druid, version)
+    end
+  end
+
+  context 'zip is new to S3' do
+    it 'puts to S3' do
+      expect(object).to receive(:put).with(
+        a_hash_including(body: File, metadata: a_hash_including(checksum_md5: 'd41d8cd98f00b204e9800998ecf8427e'))
+      )
+      described_class.perform_now(druid, version)
+    end
   end
 
   it 'invokes ResultsRecorderJob' do

--- a/spec/lib/preservation_catalog/s3_spec.rb
+++ b/spec/lib/preservation_catalog/s3_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe PreservationCatalog::S3 do
+  describe '.bucket_name' do
+    context 'without ENV variable' do
+      it 'returns value from Settings' do
+        expect(described_class.bucket_name).to eq 'sul-sdr-aws-us-west-2-test'
+      end
+    end
+    context 'with ENV variable AWS_BUCKET_NAME' do
+      before { ENV['AWS_BUCKET_NAME'] = 'bucket_44' }
+      it 'returns the ENV value' do
+        expect(described_class.bucket_name).to eq 'bucket_44'
+      end
+    end
+  end
+
+  describe 'config' do
+    let(:config) { described_class.client.config }
+
+    before do
+      ENV['AWS_SECRET_ACCESS_KEY'] = 'secret'
+      ENV['AWS_ACCESS_KEY_ID'] = 'some_key'
+      ENV['AWS_REGION'] = 'us-east-1'
+    end
+    it 'pulls from ENV vars' do
+      expect(config.region).to eq 'us-east-1'
+      expect(config.credentials).to be_an(Aws::Credentials)
+      expect(config.credentials).to be_set
+      expect(config.credentials.access_key_id).to eq 'some_key'
+    end
+  end
+end

--- a/spec/models/druid_version_zip_spec.rb
+++ b/spec/models/druid_version_zip_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe DruidVersionZip do
+  subject(:dvz) { described_class.new(druid, version) }
+
+  let(:druid) { 'bj102hs9687' }
+  let(:version) { 1 }
+
+  describe '#s3_key' do
+    it 'returns a tree path-based key' do
+      expect(dvz.s3_key).to eq 'bj/102/hs/9687/bj102hs9687.v0001.zip'
+    end
+  end
+
+  describe '#file_path' do
+    it 'returns a full path' do
+      expect(dvz.file_path).to eq '/tmp/bj/102/hs/9687/bj102hs9687.v0001.zip'
+    end
+  end
+
+  describe '#file' do
+    it 'opens file_path' do
+      expect(File).to receive(:open).with(dvz.file_path)
+      dvz.file
+    end
+  end
+
+  describe '#md5' do
+    before do
+      allow(Settings).to receive(:zip_storage).and_return(Rails.root.join('spec', 'fixtures', 'zip_storage'))
+    end
+    it 'returns checksum' do
+      expect(dvz.md5).to eq 'd41d8cd98f00b204e9800998ecf8427e'
+    end
+  end
+end

--- a/spec/models/druid_version_zip_spec.rb
+++ b/spec/models/druid_version_zip_spec.rb
@@ -29,8 +29,8 @@ describe DruidVersionZip do
     before do
       allow(Settings).to receive(:zip_storage).and_return(Rails.root.join('spec', 'fixtures', 'zip_storage'))
     end
-    it 'returns checksum' do
-      expect(dvz.md5).to eq 'd41d8cd98f00b204e9800998ecf8427e'
+    it 'returns base64-encoded checksum' do
+      expect(dvz.md5).to eq '1B2M2Y8AsgTpgAmY7PhCfg=='
     end
   end
 end


### PR DESCRIPTION
- uses the current `aws-sdk-s3` gem
- non-activerecord model for `DruidVersionZip` for logic around zipfiles
- basic S3 configurations/invocations consolidated to a handful of class methods
- placeholder metadata (including md5) posted with S3 object, future work will tie in the checksum from TCR or equivalent

I will follow up with live-S3 integration testing in a separate PR.

Fixes #710