### PR TITLE
Allow individuals settings to be overridden via (bash) ENV

### DIFF
--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,4 +1,7 @@
 Config.setup do |config|
   # Name of the constant exposing loaded settings
   config.const_name = 'Settings'
+  config.env_prefix = 'SETTINGS'
+  config.env_separator = '__'
+  config.use_env = true
 end


### PR DESCRIPTION
This follows what we did w/ Hyku and greatly enhances flexibility.
See: https://github.com/railsconfig/config#fine-tuning

Example usage, overriding `Settings.zip_storage` for a single process without changing the YAML file or code:
```
SETTINGS__ZIP_STORAGE=foobar be rails c
[1] pry(main)> Settings.zip_storage
=> "foobar"
```
This is just using the core functionality of the Rails `config` gem, but setting it up for bash instead of Heroku.