### PR TITLE
Target archive endpoints

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -36,6 +36,20 @@ class Endpoint < ApplicationRecord
     end
   end
 
+  def self.seed_archive_endpoints_from_config(preservation_policies)
+    Settings.archive_endpoints.map do |endpoint_name, endpoint_config|
+      find_or_create_by!(endpoint_name: endpoint_name.to_s) do |endpoint|
+        endpoint.endpoint_type = EndpointType.find_by!(type_name: endpoint_config.endpoint_type_name)
+        endpoint.endpoint_node = endpoint_config.endpoint_node
+        endpoint.storage_location = endpoint_config.storage_location
+        endpoint.access_key = endpoint_config.access_key
+        endpoint.recovery_cost = endpoint_config.recovery_cost
+        endpoint.preservation_policies = preservation_policies
+      end
+    end
+  end
+
+  # TODO: move to EndpointType class?  e.g. .default_for_storage_root
   def self.default_storage_root_endpoint_type
     EndpointType.find_by!(type_name: Settings.endpoints.storage_root_defaults.endpoint_type_name)
   end

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -16,7 +16,6 @@ class Endpoint < ApplicationRecord
   validates :endpoint_type, presence: true
   validates :endpoint_node, presence: true
   validates :storage_location, presence: true
-  validates :recovery_cost, presence: true
 
   scope :archive, lambda {
     # TODO: maybe endpoint_class should be an enum or a constant?
@@ -55,7 +54,6 @@ class Endpoint < ApplicationRecord
         endpoint.endpoint_type = endpoint_type
         endpoint.endpoint_node = Settings.endpoints.storage_root_defaults.endpoint_node
         endpoint.storage_location = File.join(storage_root_location, Settings.moab.storage_trunk)
-        endpoint.recovery_cost = Settings.endpoints.storage_root_defaults.recovery_cost
         endpoint.preservation_policies = preservation_policies
       end
     end
@@ -67,8 +65,6 @@ class Endpoint < ApplicationRecord
         endpoint.endpoint_type = EndpointType.find_by!(type_name: endpoint_config.endpoint_type_name)
         endpoint.endpoint_node = endpoint_config.endpoint_node
         endpoint.storage_location = endpoint_config.storage_location
-        endpoint.access_key = endpoint_config.access_key
-        endpoint.recovery_cost = endpoint_config.recovery_cost
         endpoint.preservation_policies = preservation_policies
       end
     end
@@ -85,8 +81,7 @@ class Endpoint < ApplicationRecord
       endpoint_type_name: endpoint_type.type_name,
       endpoint_type_class: endpoint_type.endpoint_class,
       endpoint_node: endpoint_node,
-      storage_location: storage_location,
-      recovery_cost: recovery_cost
+      storage_location: storage_location
     }
   end
 

--- a/app/models/endpoint_type.rb
+++ b/app/models/endpoint_type.rb
@@ -4,6 +4,7 @@ class EndpointType < ApplicationRecord
   has_many :endpoints, dependent: :restrict_with_exception
 
   validates :type_name, presence: true, uniqueness: true
+  # TODO: maybe endpoint_class should be an enum or a constant?
   validates :endpoint_class, presence: true
 
   # iterates over the endpoint types enumerated in the settings, creating any that don't already exist.

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -7,6 +7,7 @@ class PreservedCopy < ApplicationRecord
   ONLINE_MOAB_NOT_FOUND_STATUS = 'online_moab_not_found'.freeze
   UNEXPECTED_VERSION_ON_STORAGE_STATUS = 'unexpected_version_on_storage'.freeze
   VALIDITY_UNKNOWN_STATUS = 'validity_unknown'.freeze
+  UNREPLICATED_STATUS = 'unreplicated'.freeze
 
   # @note Hash values cannot be modified without migrating any associated persisted data.
   # @see [enum docs] http://api.rubyonrails.org/classes/ActiveRecord/Enum.html
@@ -16,7 +17,8 @@ class PreservedCopy < ApplicationRecord
     INVALID_CHECKSUM_STATUS => 2,
     ONLINE_MOAB_NOT_FOUND_STATUS => 3,
     UNEXPECTED_VERSION_ON_STORAGE_STATUS => 4,
-    VALIDITY_UNKNOWN_STATUS => 6
+    VALIDITY_UNKNOWN_STATUS => 6,
+    UNREPLICATED_STATUS => 7
   }
 
   belongs_to :preserved_object

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -26,4 +26,19 @@ class PreservedObject < ApplicationRecord
       po.save!
     end
   end
+
+  def create_archive_preserved_copies(archive_vers)
+    unless archive_vers > 0 && archive_vers <= current_version
+      raise ArgumentError, "archive_vers (#{archive_vers}) must be between 0 and current_version (#{current_version})"
+    end
+
+    ApplicationRecord.transaction do
+      Endpoint.which_need_archive_copy(druid, archive_vers).map do |ep|
+        # TODO: remember to update size at some later point, after zip is created
+        PreservedCopy.create!(
+          preserved_object: self, version: archive_vers, endpoint: ep, status: PreservedCopy::UNREPLICATED_STATUS
+        )
+      end
+    end
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,6 @@ endpoints:
     # value for endpoint_type_name must correspond to an endpoint_types entry (defined above)
     endpoint_type_name: 'online_nfs'
     endpoint_node: 'localhost'
-    recovery_cost: 1
 
 moab:
   # storage_trunk is the name of the directory under a storage_root which contains

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,8 @@ aws:
 endpoint_types:
   online_nfs:
     endpoint_class: online
+  aws_s3:
+    endpoint_class: archive
 
 endpoints:
   # the defaults used when seeding the endpoints that correspond to local storage roots

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -17,6 +17,4 @@ archive_endpoints:
     endpoint_type_name: 'aws_s3'
     endpoint_node: 'localhost'
     storage_location: 'bucket_name'
-    access_key: 'totallysecret'
-    recovery_cost: 10
 workflow_services_url: 'https://sul-lyberservices-test.stanford.edu/workflow/'

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -12,4 +12,11 @@ storage_root_map:
   preservation_catalog_prod_a:
     fixture_sr1: 'spec/fixtures/storage_root01'
     fixture_sr2: 'spec/fixtures/storage_root02'
+archive_endpoints:
+  mock_archive1:
+    endpoint_type_name: 'aws_s3'
+    endpoint_node: 'localhost'
+    storage_location: 'bucket_name'
+    access_key: 'totallysecret'
+    recovery_cost: 10
 workflow_services_url: 'https://sul-lyberservices-test.stanford.edu/workflow/'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -18,5 +18,3 @@ archive_endpoints:
     endpoint_type_name: 'aws_s3'
     endpoint_node: 'localhost'
     storage_location: 'bucket_name'
-    access_key: 'totallysecret'
-    recovery_cost: 10

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -13,3 +13,10 @@ storage_root_map:
   preservation_catalog_prod_a:
     fixture_sr1: 'spec/fixtures/storage_root01'
     fixture_sr2: 'spec/fixtures/storage_root02'
+archive_endpoints:
+  mock_archive1:
+    endpoint_type_name: 'aws_s3'
+    endpoint_node: 'localhost'
+    storage_location: 'bucket_name'
+    access_key: 'totallysecret'
+    recovery_cost: 10

--- a/db/README.md
+++ b/db/README.md
@@ -25,7 +25,6 @@
   * `endpoint_type_id`: the `EndpointType` implemented by this `Endpoint`.
   * `endpoint_node`: the network location of the endpoint relative to the preservation catalog instance (e.g. localhost for a locally mounted NFS volume, s3.us-east-2.amazonaws.com for an S3 bucket, etc).
   * `storage_location`: the path or bucket name or similar from which to read (e.g. "/services-disk03/sdr2objects", "sdr-bucket-01", etc).
-  * `access_key`: authorization info, if any, for connecting to the endpoint.
   * `preservation_policies`: the preservation policies for which governed objects are preserved (declared to ActiveRecord via `has_and_belongs_to_many :preservation_policies`).
 * An `EndpointType`, as the name implies, describes general shared characteristics common to many `Endpoint` instances.  At present these include a general type name describing what sort of storage the endpoint is to be implemented on (e.g. our own NFS mounts, an AWS bucket, a Ceph instance, etc), as well as the type of objects the endpoint stores (at present, only "online" exploded moabs, or "archive" moabs packed into a single file).
 * A `PreservationPolicy` defines

--- a/db/migrate/20180518175719_remove_access_key_from_endpoints.rb
+++ b/db/migrate/20180518175719_remove_access_key_from_endpoints.rb
@@ -1,0 +1,5 @@
+class RemoveAccessKeyFromEndpoints < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :endpoints, :access_key, :string
+  end
+end

--- a/db/migrate/20180518180326_remove_recovery_cost_from_endpoints.rb
+++ b/db/migrate/20180518180326_remove_recovery_cost_from_endpoints.rb
@@ -1,0 +1,5 @@
+class RemoveRecoveryCostFromEndpoints < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :endpoints, :recovery_cost, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180517220356) do
+ActiveRecord::Schema.define(version: 20180518180326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,8 +28,6 @@ ActiveRecord::Schema.define(version: 20180517220356) do
     t.datetime "updated_at", null: false
     t.string "endpoint_node", null: false
     t.string "storage_location", null: false
-    t.integer "recovery_cost", null: false
-    t.string "access_key"
     t.bigint "endpoint_type_id", null: false
     t.integer "delivery_class"
     t.index ["endpoint_name"], name: "index_endpoints_on_endpoint_name", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,7 @@ ApplicationRecord.transaction(isolation: :serializable) do
   Endpoint.seed_storage_root_endpoints_from_config(
     Endpoint.default_storage_root_endpoint_type, [PreservationPolicy.default_policy]
   )
+  Endpoint.seed_archive_endpoints_from_config([PreservationPolicy.default_policy])
 end
 
 puts "seeded database.  state of seeded object types after seeding:"

--- a/spec/factories/endpoint.rb
+++ b/spec/factories/endpoint.rb
@@ -2,14 +2,12 @@ FactoryBot.define do
   factory :endpoint, aliases: [:online_endpoint] do
     sequence(:endpoint_name) { |n| "endpoint#{format('%02d', n)}" }
     endpoint_node 'localhost'
-    recovery_cost 1
     storage_location { "spec/fixtures/#{endpoint_name}/moab_storage_trunk" }
     endpoint_type # default online
   end
 
   factory :archive_endpoint, parent: :endpoint do
     delivery_class 1
-    recovery_cost 10
     association :endpoint_type, endpoint_class: 'archive'
   end
 end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -62,16 +62,13 @@ RSpec.describe Endpoint, type: :model do
   it { is_expected.to validate_presence_of(:recovery_cost) }
 
   describe '.seed_storage_root_endpoints_from_config' do
-    # because of the above `let!`, using just `endpoint_type` as a name here blows up, because the shared name
-    # would cause this `let` to be evaluated eagerly instead of lazily, and the EndpointType we want in this section
-    # doesn't exist till the before block runs.
-    let(:strg_rt_endpoint_type) { Endpoint.default_storage_root_endpoint_type }
+    let(:endpoint_type) { Endpoint.default_storage_root_endpoint_type }
     let(:default_pres_policies) { [PreservationPolicy.default_policy] }
 
     it 'creates a local online endpoint for each storage root' do
       HostSettings.storage_roots.each do |storage_root_name, storage_root_location|
         storage_root_attrs = {
-          endpoint_type: strg_rt_endpoint_type,
+          endpoint_type: endpoint_type,
           endpoint_node: Settings.endpoints.storage_root_defaults.endpoint_node,
           storage_location: File.join(storage_root_location, Settings.moab.storage_trunk),
           recovery_cost: Settings.endpoints.storage_root_defaults.recovery_cost,
@@ -83,7 +80,7 @@ RSpec.describe Endpoint, type: :model do
 
     it 'does not re-create records that already exist' do
       # run it a second time
-      Endpoint.seed_storage_root_endpoints_from_config(strg_rt_endpoint_type, default_pres_policies)
+      Endpoint.seed_storage_root_endpoints_from_config(endpoint_type, default_pres_policies)
       # sort so we can avoid comparing via include, and see that it has only/exactly the four expected elements
       expect(Endpoint.pluck(:endpoint_name).sort).to eq %w[aws-us-east-2 fixture_empty fixture_sr1 fixture_sr2 fixture_sr3]
     end
@@ -97,7 +94,7 @@ RSpec.describe Endpoint, type: :model do
       allow(HostSettings).to receive(:storage_roots).and_return(storage_roots_setting)
 
       # run it a second time
-      Endpoint.seed_storage_root_endpoints_from_config(strg_rt_endpoint_type, default_pres_policies)
+      Endpoint.seed_storage_root_endpoints_from_config(endpoint_type, default_pres_policies)
       expected_ep_names = %w[aws-us-east-2 fixture_empty fixture_sr1 fixture_sr2 fixture_sr3 fixture_srTest]
       expect(Endpoint.pluck(:endpoint_name).sort).to eq expected_ep_names
     end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Endpoint, type: :model do
       endpoint_name: 'aws-us-east-2',
       endpoint_type_id: endpoint_type.id,
       endpoint_node: 's3.us-east-2.amazonaws.com',
-      storage_location: 'sdr-bucket-01',
-      recovery_cost: '5'
+      storage_location: 'sdr-bucket-01'
     )
   end
 
@@ -31,8 +30,7 @@ RSpec.describe Endpoint, type: :model do
         endpoint_name: 'aws-us-east-2',
         endpoint_type_id: endpoint_type.id,
         endpoint_node: 's3.us-east-2.amazonaws.com',
-        storage_location: 'sdr-bucket-01',
-        recovery_cost: '5'
+        storage_location: 'sdr-bucket-01'
       )
     end.to raise_error(ActiveRecord::RecordInvalid)
   end
@@ -43,7 +41,6 @@ RSpec.describe Endpoint, type: :model do
     dup_endpoint.endpoint_name = 'aws-us-east-2'
     dup_endpoint.endpoint_node = 's3.us-east-2.amazonaws.com'
     dup_endpoint.storage_location = 'sdr-bucket-01'
-    dup_endpoint.recovery_cost = '5'
     dup_endpoint.endpoint_type_id = endpoint_type.id
     expect { dup_endpoint.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
   end
@@ -59,7 +56,6 @@ RSpec.describe Endpoint, type: :model do
   it { is_expected.to validate_presence_of(:endpoint_type) }
   it { is_expected.to validate_presence_of(:endpoint_node) }
   it { is_expected.to validate_presence_of(:storage_location) }
-  it { is_expected.to validate_presence_of(:recovery_cost) }
 
   describe '.seed_storage_root_endpoints_from_config' do
     let(:endpoint_type) { Endpoint.default_storage_root_endpoint_type }
@@ -71,7 +67,6 @@ RSpec.describe Endpoint, type: :model do
           endpoint_type: endpoint_type,
           endpoint_node: Settings.endpoints.storage_root_defaults.endpoint_node,
           storage_location: File.join(storage_root_location, Settings.moab.storage_trunk),
-          recovery_cost: Settings.endpoints.storage_root_defaults.recovery_cost,
           preservation_policies: default_pres_policies
         }
         expect(Endpoint.find_by(endpoint_name: storage_root_name)).to have_attributes(storage_root_attrs)
@@ -124,8 +119,6 @@ RSpec.describe Endpoint, type: :model do
           endpoint_type: endpoint_type,
           endpoint_node: endpoint_config.endpoint_node,
           storage_location: endpoint_config.storage_location,
-          access_key: endpoint_config.access_key,
-          recovery_cost: endpoint_config.recovery_cost,
           preservation_policies: default_pres_policies
         }
         expect(Endpoint.find_by(endpoint_name: endpoint_name)).to have_attributes(archive_endpoint_attrs)
@@ -146,9 +139,7 @@ RSpec.describe Endpoint, type: :model do
           Config::Options.new(
             endpoint_type_name: 'aws_s3',
             endpoint_node: 'endpoint_node',
-            storage_location: 'storage_location',
-            access_key: 'access_key',
-            recovery_cost: 20
+            storage_location: 'storage_location'
           )
       )
       allow(Settings).to receive(:archive_endpoints).and_return(archive_endpoints_setting)
@@ -206,8 +197,7 @@ RSpec.describe Endpoint, type: :model do
         endpoint_type_name: 'aws',
         endpoint_type_class: 'archive',
         endpoint_node: 's3.us-east-2.amazonaws.com',
-        storage_location: 'sdr-bucket-01',
-        recovery_cost: 5
+        storage_location: 'sdr-bucket-01'
       )
     end
   end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Endpoint, type: :model do
       # run it a second time
       Endpoint.seed_storage_root_endpoints_from_config(endpoint_type, default_pres_policies)
       # sort so we can avoid comparing via include, and see that it has only/exactly the four expected elements
-      expect(Endpoint.pluck(:endpoint_name).sort).to eq %w[aws-us-east-2 fixture_empty fixture_sr1 fixture_sr2 fixture_sr3]
+      expect(Endpoint.pluck(:endpoint_name).sort).to eq %w[aws-us-east-2 fixture_empty fixture_sr1 fixture_sr2 fixture_sr3 mock_archive1]
     end
 
     it 'adds new records if there are additions to Settings since the last run' do
@@ -95,7 +95,7 @@ RSpec.describe Endpoint, type: :model do
 
       # run it a second time
       Endpoint.seed_storage_root_endpoints_from_config(endpoint_type, default_pres_policies)
-      expected_ep_names = %w[aws-us-east-2 fixture_empty fixture_sr1 fixture_sr2 fixture_sr3 fixture_srTest]
+      expected_ep_names = %w[aws-us-east-2 fixture_empty fixture_sr1 fixture_sr2 fixture_sr3 fixture_srTest mock_archive1]
       expect(Endpoint.pluck(:endpoint_name).sort).to eq expected_ep_names
     end
   end
@@ -111,6 +111,52 @@ RSpec.describe Endpoint, type: :model do
       # lookup to fail fast.  since db is already seeded, we just make it look up something that we know isn't there.
       allow(Settings.endpoints.storage_root_defaults).to receive(:endpoint_type_name).and_return('nonexistent')
       expect { Endpoint.default_storage_root_endpoint_type }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe '.seed_archive_endpoints_from_config' do
+    let(:endpoint_type) { EndpointType.find_by!(type_name: 'aws_s3') }
+    let(:default_pres_policies) { [PreservationPolicy.default_policy] }
+
+    it 'creates an endpoints entry for each archive endpoint' do
+      Settings.archive_endpoints.each do |endpoint_name, endpoint_config|
+        archive_endpoint_attrs = {
+          endpoint_type: endpoint_type,
+          endpoint_node: endpoint_config.endpoint_node,
+          storage_location: endpoint_config.storage_location,
+          access_key: endpoint_config.access_key,
+          recovery_cost: endpoint_config.recovery_cost,
+          preservation_policies: default_pres_policies
+        }
+        expect(Endpoint.find_by(endpoint_name: endpoint_name)).to have_attributes(archive_endpoint_attrs)
+      end
+    end
+
+    it 'does not re-create records that already exist' do
+      # run it a second time
+      Endpoint.seed_archive_endpoints_from_config(default_pres_policies)
+      # sort so we can avoid comparing via include, and see that it has only/exactly the four expected elements
+      expect(Endpoint.pluck(:endpoint_name).sort).to eq %w[aws-us-east-2 fixture_empty fixture_sr1 fixture_sr2 fixture_sr3 mock_archive1]
+    end
+
+    it 'adds new records if there are additions to Settings since the last run' do
+      # skip "doesn't work yet, ripped off from storage roots version, fixing"
+      archive_endpoints_setting = Config::Options.new(
+        fixture_archiveTest:
+          Config::Options.new(
+            endpoint_type_name: 'aws_s3',
+            endpoint_node: 'endpoint_node',
+            storage_location: 'storage_location',
+            access_key: 'access_key',
+            recovery_cost: 20
+          )
+      )
+      allow(Settings).to receive(:archive_endpoints).and_return(archive_endpoints_setting)
+
+      # run it a second time
+      Endpoint.seed_archive_endpoints_from_config(default_pres_policies)
+      expected_ep_names = %w[aws-us-east-2 fixture_archiveTest fixture_empty fixture_sr1 fixture_sr2 fixture_sr3 mock_archive1]
+      expect(Endpoint.pluck(:endpoint_name).sort).to eq expected_ep_names
     end
   end
 

--- a/spec/models/endpoint_type_spec.rb
+++ b/spec/models/endpoint_type_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe EndpointType, type: :model do
       # run it a second time
       EndpointType.seed_from_config
       # sort so we can avoid comparing via include, and see that it has only/exactly the expected elements
-      expect(EndpointType.pluck(:type_name).sort).to eq %w[online_nfs]
+      expect(EndpointType.pluck(:type_name).sort).to eq %w[aws_s3 online_nfs]
     end
 
     it 'adds new records if there are additions to Settings since the last run' do

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe PreservedCopy, type: :model do
       PreservedCopy::INVALID_CHECKSUM_STATUS => 2,
       PreservedCopy::ONLINE_MOAB_NOT_FOUND_STATUS => 3,
       PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS => 4,
-      PreservedCopy::VALIDITY_UNKNOWN_STATUS => 6
+      PreservedCopy::VALIDITY_UNKNOWN_STATUS => 6,
+      PreservedCopy::UNREPLICATED_STATUS => 7
     )
   end
 

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -106,4 +106,74 @@ RSpec.describe PreservedObject, type: :model do
       end
     end
   end
+
+  describe '#create_archive_preserved_copies' do
+    let(:druid) { 'ab123cd4567' }
+    let(:current_version) { 3 }
+    let!(:po) { create(:preserved_object, druid: druid, current_version: current_version) }
+    let(:archive_ep) { Endpoint.find_by(endpoint_name: 'mock_archive1') }
+    let(:new_archive_ep) { create(:archive_endpoint, endpoint_name: 'mock_archive2') }
+    let(:archive_pcs_for_druid) do
+      PreservedCopy
+        .joins(endpoint: [:endpoint_type])
+        .where(preserved_object: po, endpoint_types: { endpoint_class: 'archive' })
+    end
+
+    it "creates pres copies that don't yet exist for the given version, but should" do
+      expect { po.create_archive_preserved_copies(current_version) }.to change {
+        Endpoint.which_need_archive_copy(druid, current_version).to_a
+      }.from([archive_ep]).to([])
+
+      expect(archive_pcs_for_druid.count).to eq 1
+
+      expect { po.create_archive_preserved_copies(current_version - 1) }.to change {
+        Endpoint.which_need_archive_copy(druid, current_version - 1).to_a
+      }.from([archive_ep]).to([])
+      expect(archive_pcs_for_druid.count).to eq 2
+
+      expect(archive_pcs_for_druid.where(version: 1).count).to eq 0
+    end
+
+    it "creates pres copies that don't yet exist for the given endpoint, but should" do
+      expect { po.create_archive_preserved_copies(current_version) }.to change {
+        Endpoint.which_need_archive_copy(druid, current_version).to_a
+      }.from([archive_ep]).to([])
+      expect(archive_pcs_for_druid.where(version: current_version).count).to eq 1
+
+      new_archive_ep.preservation_policies = [PreservationPolicy.default_policy]
+      expect { po.create_archive_preserved_copies(current_version) }.to change {
+        Endpoint.which_need_archive_copy(druid, current_version).to_a
+      }.from([new_archive_ep]).to([])
+      expect(archive_pcs_for_druid.where(version: current_version).count).to eq 2
+    end
+
+    it 'checks that version is in range' do
+      [-1, 0, 4, 5].each do |version|
+        exp_err_msg = "archive_vers (#{version}) must be between 0 and current_version (#{current_version})"
+        expect { po.create_archive_preserved_copies(version) }.to raise_error ArgumentError, exp_err_msg
+      end
+
+      (1..3).each do |version|
+        expect { po.create_archive_preserved_copies(version) }.not_to raise_error
+      end
+    end
+
+    it 'creates the pres copies in a transaction and allows exceptions to bubble up' do
+      new_archive_ep.preservation_policies = [PreservationPolicy.default_policy]
+      allow(PreservedCopy).to receive(:create!).with(
+        preserved_object: po,
+        version: current_version,
+        endpoint: new_archive_ep,
+        status: PreservedCopy::UNREPLICATED_STATUS
+      ).and_raise(ActiveRecord::ConnectionTimeoutError)
+
+      # would do `expect { }.not_to(change { })`, but the raised error doesn't play nicely with that construct
+      exp_ep_list = %w[mock_archive1 mock_archive2]
+      expect(Endpoint.which_need_archive_copy(druid, current_version).pluck(:endpoint_name).sort).to eq exp_ep_list
+      expect do
+        po.create_archive_preserved_copies(current_version)
+      end.to raise_error(ActiveRecord::ConnectionTimeoutError)
+      expect(Endpoint.which_need_archive_copy(druid, current_version).pluck(:endpoint_name).sort).to eq exp_ep_list
+    end
+  end
 end

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -220,7 +220,6 @@ RSpec.describe PreservedObjectHandler do
               endpoint.endpoint_type = Endpoint.default_storage_root_endpoint_type
               endpoint.endpoint_node = Settings.endpoints.storage_root_defaults.endpoint_node
               endpoint.storage_location = invalid_storage_dir
-              endpoint.recovery_cost = Settings.endpoints.storage_root_defaults.recovery_cost
             end
             # these need to be in before loop so it happens before each context below
             invalid_po = PreservedObject.create!(
@@ -546,7 +545,6 @@ RSpec.describe PreservedObjectHandler do
               endpoint.endpoint_type = Endpoint.default_storage_root_endpoint_type
               endpoint.endpoint_node = Settings.endpoints.storage_root_defaults.endpoint_node
               endpoint.storage_location = storage_dir
-              endpoint.recovery_cost = Settings.endpoints.storage_root_defaults.recovery_cost
             end
           end
 

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -32,8 +32,7 @@ RSpec.describe PreservedObjectHandler do
           endpoint_name: 'diff_endpoint',
           endpoint_type: Endpoint.default_storage_root_endpoint_type,
           endpoint_node: 'localhost',
-          storage_location: 'blah',
-          recovery_cost: 1
+          storage_location: 'blah'
         )
         PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
         po_handler = described_class.new(druid, 3, incoming_size, diff_ep)

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -151,7 +151,6 @@ RSpec.describe PreservedObjectHandler do
           endpoint.endpoint_type = Endpoint.default_storage_root_endpoint_type
           endpoint.endpoint_node = Settings.endpoints.storage_root_defaults.endpoint_node
           endpoint.storage_location = storage_dir
-          endpoint.recovery_cost = Settings.endpoints.storage_root_defaults.recovery_cost
         end
       end
 

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -351,7 +351,6 @@ RSpec.describe PreservedObjectHandler do
             endpoint.endpoint_type = Endpoint.default_storage_root_endpoint_type
             endpoint.endpoint_node = Settings.endpoints.storage_root_defaults.endpoint_node
             endpoint.storage_location = storage_dir
-            endpoint.recovery_cost = Settings.endpoints.storage_root_defaults.recovery_cost
           end
           po = PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
           t = Time.current


### PR DESCRIPTION
still needs:
* [x] tests for archive endpoint seeding
* [x] tests for scopes
* [x] tests for pres copy creation
  * [x] make sure PCs get made for default seeded endpoint
  * [x] make sure only PCs for given version are made
  * [x] add endpoint and call creation and confirm a new PC gets made
  * [x] version check
  * [x] transactionality

i'd also like to:
* [ ] index endpoint_types.type_name and .endpoint_class ; preserved_copies.version ; preserved_objects.current_version
* [ ] take care of the small TODOs:
  * [ ] move the default endpoint type methods into the `EndpointType` class and specs
  * [ ] enum for `endpoint_class` ~maybe constants or something for endpoint type~.

closes #713