### PR TITLE
Constrain resque dashboard set up to workers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
+require 'resque/server'
+
 Rails.application.routes.draw do
   resources :catalog, param: :druid, only: %i[create update]
   resources :moab_storage, only: %i[index show]
+
+  mount Resque::Server.new, at: '/resque', constraints: { host: /stage-02|prod-03/ }
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
This is a naive approach that works, at the cost of hard-coding parts of machine names into a regex. 

If the team is uncomfortable with it, one other way is to set up an "advanced constraint", such as the example at http://guides.rubyonrails.org/routing.html#advanced-constraints. The TLDR is to "provide an object that responds to `matches?` that Rails should use" in the constraint. This might be a small class that pulls from `Settings`, or...

Or there might be another approach that I'm unaware of.