### PR TITLE
Additional logging for when we change status 

### DIFF
--- a/app/services/checksum_validator.rb
+++ b/app/services/checksum_validator.rb
@@ -36,6 +36,9 @@ class ChecksumValidator
         results.add_result(AuditResults::MOAB_CHECKSUM_VALID)
         found_expected_version = moab.current_version_id == preserved_copy.version
         set_status_as_seen_on_disk(found_expected_version)
+        unless found_expected_version
+          results.add_result(AuditResults::UNEXPECTED_VERSION, actual_version: moab.current_version_id, db_obj_name: 'PreservedCopy', db_obj_version: preserved_copy.version)
+        end
       else
         update_status(PreservedCopy::INVALID_CHECKSUM_STATUS)
       end

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -257,6 +257,7 @@ RSpec.describe ChecksumValidator do
               pres_copy.status = initial_status
               pres_copy.save!
               expect { cv.validate_checksums }.to change { pres_copy.status }.to PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
+              expect(cv.results.contains_result_code?(AuditResults::UNEXPECTED_VERSION)).to be true
               expect(pres_copy.reload.status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
             end
           end
@@ -265,6 +266,7 @@ RSpec.describe ChecksumValidator do
             pres_copy.status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
             pres_copy.save!
             expect { cv.validate_checksums }.not_to(change { pres_copy.status })
+            expect(cv.results.contains_result_code?(AuditResults::UNEXPECTED_VERSION)).to be true
             expect(pres_copy.reload.status).to eq PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
           end
         end


### PR DESCRIPTION
When status is set to `PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE`, we want to log more information than just the status information. We want to also long the corresponding `AuditResults::UNEXPECTED_VERSION` message.


closes #752 