### PR TITLE
Zip checksum table

### DIFF
--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -21,6 +21,7 @@ class PreservedCopy < ApplicationRecord
 
   belongs_to :preserved_object
   belongs_to :endpoint
+  has_many :zip_checksums, dependent: :restrict_with_exception
 
   validates :endpoint, presence: true
   validates :preserved_object, presence: true

--- a/app/models/zip_checksum.rb
+++ b/app/models/zip_checksum.rb
@@ -5,6 +5,6 @@ class ZipChecksum < ApplicationRecord
   belongs_to :preserved_copy
 
   validates :preserved_copy, presence: true
-  validates :md5, presence: true
+  validates :md5, presence: true, format: { with: /\A[0-9a-f]{32}\z/ }
   validates :create_info, presence: true
 end

--- a/app/models/zip_checksum.rb
+++ b/app/models/zip_checksum.rb
@@ -1,0 +1,10 @@
+##
+# ZipChecksum contains the MD5 checksum and creation info for every preserved copy (druid, version)
+# that has been archived.
+class ZipChecksum < ApplicationRecord
+  belongs_to :preserved_copy
+
+  validates :preserved_copy, presence: true
+  validates :md5, presence: true
+  validates :create_info, presence: true
+end

--- a/db/migrate/20180517220356_create_zip_checksums.rb
+++ b/db/migrate/20180517220356_create_zip_checksums.rb
@@ -1,0 +1,11 @@
+class CreateZipChecksums < ActiveRecord::Migration[5.1]
+  def change
+    create_table :zip_checksums do |t|
+      t.string :md5, null: false
+      t.string :create_info, null: false
+      t.references :preserved_copy, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180517212635) do
+ActiveRecord::Schema.define(version: 20180517220356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,10 +85,20 @@ ActiveRecord::Schema.define(version: 20180517212635) do
     t.index ["updated_at"], name: "index_preserved_objects_on_updated_at"
   end
 
+  create_table "zip_checksums", force: :cascade do |t|
+    t.string "md5", null: false
+    t.string "create_info", null: false
+    t.bigint "preserved_copy_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["preserved_copy_id"], name: "index_zip_checksums_on_preserved_copy_id"
+  end
+
   add_foreign_key "endpoints", "endpoint_types"
   add_foreign_key "endpoints_preservation_policies", "endpoints"
   add_foreign_key "endpoints_preservation_policies", "preservation_policies"
   add_foreign_key "preserved_copies", "endpoints"
   add_foreign_key "preserved_copies", "preserved_objects"
   add_foreign_key "preserved_objects", "preservation_policies"
+  add_foreign_key "zip_checksums", "preserved_copies"
 end

--- a/spec/factories/zip_checksum.rb
+++ b/spec/factories/zip_checksum.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :zip_checksum do
+    md5 "00236a2ae558018ed13b5222ef1bd977"
+    create_info "ok"
+    preserved_copy
+  end
+end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe PreservedCopy, type: :model do
   it { is_expected.to validate_presence_of(:endpoint) }
   it { is_expected.to validate_presence_of(:preserved_object) }
   it { is_expected.to validate_presence_of(:version) }
+  it { is_expected.to have_many(:zip_checksums) }
 
   describe '#update_audit_timestamps' do
     let(:pc) do

--- a/spec/models/zip_checksum_spec.rb
+++ b/spec/models/zip_checksum_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe ZipChecksum, type: :model do
+  let(:po) { create(:preserved_object) }
+  let(:pres_copy) { create(:preserved_copy, preserved_object: po, endpoint: Endpoint.first) }
+  let(:zip_checksum) do
+    ZipChecksum.create(md5: '387a8ds87ea87', create_info: 'shell command and OS info', preserved_copy: pres_copy)
+  end
+
+  it 'is not valid without valid attributes' do
+    zc = ZipChecksum.new
+    expect(zc).not_to be_valid
+    expect { zc.save! }. to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it 'is not valid unless it has all required attributes' do
+    zc = ZipChecksum.new(preserved_copy_id: pres_copy.id)
+    expect(zc).not_to be_valid
+    expect { zc.save! }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it 'is valid with valid attributes' do
+    expect(zip_checksum).to be_valid
+  end
+  it { is_expected.to validate_presence_of(:md5) }
+  it { is_expected.to validate_presence_of(:create_info) }
+  it { is_expected.to validate_presence_of(:preserved_copy) }
+  it { is_expected.to belong_to(:preserved_copy) }
+end

--- a/spec/models/zip_checksum_spec.rb
+++ b/spec/models/zip_checksum_spec.rb
@@ -3,9 +3,7 @@ require 'rails_helper'
 RSpec.describe ZipChecksum, type: :model do
   let(:po) { create(:preserved_object) }
   let(:pres_copy) { create(:preserved_copy, preserved_object: po, endpoint: Endpoint.first) }
-  let(:zip_checksum) do
-    ZipChecksum.create(md5: '387a8ds87ea87', create_info: 'shell command and OS info', preserved_copy: pres_copy)
-  end
+  let(:zip_checksum) { create(:zip_checksum, preserved_copy: pres_copy) }
 
   it 'is not valid without valid attributes' do
     zc = ZipChecksum.new
@@ -21,6 +19,29 @@ RSpec.describe ZipChecksum, type: :model do
 
   it 'is valid with valid attributes' do
     expect(zip_checksum).to be_valid
+  end
+
+  context "md5 checksum" do
+    it "length is equal to 32" do
+      zip_checksum = create(:zip_checksum, preserved_copy: pres_copy, md5: "00236a2ae558018ed13b5222ef1bd977")
+      expect(zip_checksum).to be_valid
+    end
+    it "length is not equal to 32" do
+      expect {
+        create(:zip_checksum, preserved_copy: pres_copy, md5: "00236a2ae5580")
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "contains only a-f and 0-9 characters" do
+      zip_checksum = create(:zip_checksum, preserved_copy: pres_copy, md5: "abcdeabcdefabcdefabcdefabcdeff21")
+      expect(zip_checksum).to be_valid
+    end
+
+    it "contains characters other than a-f" do
+      expect {
+        create(:zip_checksum, preserved_copy: pres_copy, md5: "ghijklmnopqrstuvwxyz123456789101")
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
   end
   it { is_expected.to validate_presence_of(:md5) }
   it { is_expected.to validate_presence_of(:create_info) }


### PR DESCRIPTION
Create new table that will store the `md5` checksum for each archive zip created. Table contains `md5`, `create_info` - which will have the shell command and OS info under which the zip was created), and the `preserved_copy_id` (preserved_copies has many zip_checksums)


Also introduce zip_checksum factory as the last commit, but the `zip_checksum_spec.rb` uses it before hand.

closes #754 