### PR TITLE
Add resque config and add routes for dashboard

### DIFF
--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -5,4 +5,4 @@ Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 set :bundle_without, 'deploy test'
 set :deploy_to, '/opt/app/pres/preservation_catalog'
-append :linked_files, "config/newrelic.yml"
+append :linked_files, "config/newrelic.yml", "config/resque.yml"

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,3 @@
+config_file = Rails.root.join('config', 'resque.yml')
+resque_config = YAML.safe_load(ERB.new(IO.read(config_file)).result)
+Resque.redis = resque_config[Rails.env.to_s]

--- a/config/resque.yml
+++ b/config/resque.yml
@@ -1,0 +1,1 @@
+development: localhost:6379

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
+require 'resque/server'
+
 Rails.application.routes.draw do
   resources :catalog, param: :druid, only: %i[create update]
   resources :moab_storage, only: %i[index show]
+
+  mount Resque::Server.new, at: '/resque',
+                            constraints: ->(req) { Settings.resque_dashboard_hostnames.include?(req.host) }
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,3 +45,7 @@ c2m_sql_limit: 1000
 checksum_algos: ['md5'] # 'sha1' 'sha256'
 
 zip_storage: '/tmp' # override in #{RAILS_ENV}.yml
+
+resque_dashboard_hostnames: # tells the router where to mount the resque dashboard
+  - 'worker-hostname-01.example.com'
+  - 'worker-hostname-02.example.com'

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -13,3 +13,5 @@ storage_root_map:
     fixture_sr1: 'spec/fixtures/storage_root01'
     fixture_sr2: 'spec/fixtures/storage_root02'
 workflow_services_url: 'https://sul-lyberservices-test.stanford.edu/workflow/'
+resque_dashboard_hostnames:
+  - 'localhost'


### PR DESCRIPTION
Previous discussion at https://github.com/sul-dlss/preservation_catalog/pull/761

This adds resque config files to wire the app up to redis/resque, and restricts the resque dashboard to what we specify via a setting. 

If the settings approach is agreeable, I'll have PRs in to shared configs that set up the resque dashboards in stage/prod