### PR TITLE
Fix order dependence and mistaken nesting in workflow_errors_reporter_spec

### DIFF
--- a/spec/services/workflow_errors_reporter_spec.rb
+++ b/spec/services/workflow_errors_reporter_spec.rb
@@ -8,62 +8,54 @@ RSpec.describe WorkflowErrorsReporter do
   let(:result) { "Invalid moab, validation error...ential version directories." }
   let(:body) { "<process name='moab-valid' status='error' errorMessage='#{result}'/>" }
   let(:druid) { 'jj925bx9565' }
+  let(:process_name) { 'moab-valid' }
 
   context '.update_workflow' do
     it '204 response' do
-      Settings.workflow_services_url = 'https://sul-lyberservices-test.stanford.edu/workflow/'
+      allow(Settings).to receive(:workflow_services_url).and_return('https://sul-lyberservices-test.stanford.edu/workflow/')
       stub_request(:put, full_url)
-        .with(body: body,
-              headers: headers)
+        .with(body: body, headers: headers)
         .to_return(status: 204, body: "", headers: {})
       expect(Rails.logger).to receive(:debug).with("#{druid} - sent error to workflow service for preservationAuditWF moab-valid")
-      described_class.update_workflow(druid, 'moab-valid', result)
+      described_class.update_workflow(druid, process_name, result)
     end
 
     it '400 response' do
-      Settings.workflow_services_url = 'https://sul-lyberservices-test.stanford.edu/workflow/'
+      allow(Settings).to receive(:workflow_services_url).and_return('https://sul-lyberservices-test.stanford.edu/workflow/')
       stub_request(:put, full_url)
-        .with(body: body,
-              headers: headers)
+        .with(body: body, headers: headers)
         .to_return(status: 400, body: "", headers: {})
       expect(Rails.logger).to receive(:error).with("#{druid} - unable to update workflow for preservationAuditWF moab-valid #<Faraday::ClientError response={:status=>400, :headers=>{}, :body=>\"\"}>. Error message: Invalid moab, validation error...ential version directories.")
-      described_class.update_workflow(druid, 'moab-valid', result)
+      described_class.update_workflow(druid, process_name, result)
     end
 
     it 'has invalid workflow_services_url' do
       stub_request(:put, full_url)
         .with(body: body, headers: headers)
         .to_return(status: 400, body: "", headers: {})
-      Settings.workflow_services_url = ''
       expect(Rails.logger).to receive(:warn).with('no workflow hookup - assume you are in test or dev environment')
-      described_class.update_workflow(druid, 'moab-valid', result)
+      described_class.update_workflow(druid, process_name, result)
     end
+  end
+
+  context '.request_params' do
+    let(:headers_hash) { {} }
+    let(:mock_request) { instance_double(Faraday::Request, headers: headers_hash) }
 
     it 'make sure request gets correct params' do
-      process_name = 'moab-valid'
       error_msg = "Invalid moab, validation error...ential version directories."
-      mock_request = instance_double(Faraday::Request)
-      headers_hash = {}
-      expect(mock_request).to receive(:headers).and_return(headers_hash)
       expect(mock_request).to receive(:url).with("/workflow/dor/objects/druid:#{druid}/workflows/preservationAuditWF/#{process_name}")
       expect(mock_request).to receive(:body=).with("<process name='#{process_name}' status='error' errorMessage='#{error_msg}'/>")
       described_class.send(:request_params, mock_request, druid, process_name, error_msg)
       expect(headers_hash).to eq("content-type" => "application/xml")
     end
-  end
 
-  context '.request_params' do
     it 'escapes special characters in error message' do
-      process_name = 'moab-valid'
       error_msg = "Invalid moab, validation errors: [\"Version directory name not in 'v00xx' format: original-v1\"]"
-      mock_request = instance_double(Faraday::Request)
-      headers_hash = {}
       expected_error_msg = CGI.escapeHTML(error_msg)
-      allow(mock_request).to receive(:headers).and_return(headers_hash)
       allow(mock_request).to receive(:url)
       expect(mock_request).to receive(:body=).with("<process name='#{process_name}' status='error' errorMessage='#{expected_error_msg}'/>")
       described_class.send(:request_params, mock_request, druid, process_name, error_msg)
     end
   end
-
 end


### PR DESCRIPTION
Doing assignments to `Settings` in tests is an anti-pattern because it requires undoing them later or invisibly side-effecting the rest of the suite.

Side note: one of the tests calling only `request_params` was under the `.update_workflow` description.