### PR TITLE
way to run M2C for single druid

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ RAILS_ENV=production bundle exec rake m2c_exist_all_storage_roots[profile]
 ```
 this will generate a log at, for example, `log/profile_check_existence_for_all_storage_roots2017-12-11T14:25:31-flat.txt`
 
+#### Single Druid
+```sh
+RAILS_ENV=production bundle exec rake m2c_exist_druid['oo000oo0000']
+```
+
 ### Run Catalog to Moab existence check for a single root or for all storage roots
 
 - Given a catalog entry for an online moab, ensure that the online moab exists and that the catalog version matches the online moab version.

--- a/Rakefile
+++ b/Rakefile
@@ -82,6 +82,16 @@ task :populate, [:storage_root, :profile] => [:environment] do |_t, args|
   end
 end
 
+desc "M2C existence/version check on a single druid"
+task :m2c_exist_druid, [:druid] => [:environment] do |_t, args|
+  puts "#{Time.now.utc.iso8601} Running Moab to Catalog Existence Check for #{args[:druid]}"
+  $stdout.flush # sometimes above is not visible (flushed) until last puts (when run finishes)
+  results = MoabToCatalog.check_existence_for_druid(args[:druid])
+  puts results
+  puts "#{Time.now.utc.iso8601} Moab to Catalog Existence Check for #{args[:druid]} is done"
+  $stdout.flush
+end
+
 desc "Fire off M2C existence check on a single storage root"
 task :m2c_exist_single_root, [:storage_root, :profile] => [:environment] do |_t, args|
   unless args[:profile] == 'profile' || args[:profile].nil?

--- a/lib/audit/moab_to_catalog.rb
+++ b/lib/audit/moab_to_catalog.rb
@@ -7,6 +7,19 @@ class MoabToCatalog
     delegate :logger, to: PreservationCatalog::Application
   end
 
+  # this method intended to be called from rake task or via ReST call
+  def self.check_existence_for_druid(druid)
+    logger.info "#{Time.now.utc.iso8601} M2C check_existence_for_druid starting for #{druid}"
+    moab = Stanford::StorageServices.find_storage_object(druid)
+    storage_trunk = Settings.moab.storage_trunk
+    storage_dir = "#{moab.object_pathname.to_s.split(storage_trunk).first}#{storage_trunk}"
+    endpoint = Endpoint.find_by!(storage_location: storage_dir)
+    po_handler = PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, endpoint)
+    po_handler.check_existence
+  ensure
+    logger.info "#{Time.now.utc.iso8601} M2C check_existence_for_druid ended for #{druid}"
+  end
+
   # NOTE: shameless green! code duplication with seed_catalog_for_dir
   def self.check_existence_for_dir(storage_dir)
     logger.info "#{Time.now.utc.iso8601} M2C check_existence starting for '#{storage_dir}'"

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -163,6 +163,38 @@ RSpec.describe MoabToCatalog do
     end
   end
 
+  describe '.check_existence_for_druid' do
+    let(:druid) { 'bz514sm9647' }
+    let(:subject) { described_class.check_existence_for_druid(druid) }
+    let(:results) do
+      [{ db_obj_does_not_exist: "PreservedObject db object does not exist" },
+       { created_new_object: "added object to db as it did not exist" }]
+    end
+
+    it 'finds the relevant moab' do
+      expect(Stanford::StorageServices).to receive(:find_storage_object).with(druid).and_call_original
+      subject
+    end
+    it 'finds the correct Endpoint' do
+      expect(Endpoint).to receive(:find_by!).with(storage_location: storage_dir)
+      subject
+    end
+    it 'calls pohandler.check_existence' do
+      po_handler = instance_double('PreservedObjectHandler')
+      expect(PreservedObjectHandler).to receive(:new).with(
+        druid,
+        3, # current_version
+        instance_of(Integer), # size
+        endpoint
+      ).and_return(po_handler)
+      expect(po_handler).to receive(:check_existence)
+      subject
+    end
+    it 'returns results' do
+      expect(subject).to eq results
+    end
+  end
+
   describe ".seed_catalog_for_dir" do
     let(:subject) { described_class.seed_catalog_for_dir(storage_dir) }
 


### PR DESCRIPTION
In cleaning up some objects (see #814), it became obvious that we will need a rake task to run M2C for a single druid.  I wrote it so that it could be hooked up to a ReST call, if desired (See #630).

Closes #815