### PR TITLE
Update more timestamps in checksum validator

### DIFF
--- a/app/services/checksum_validator.rb
+++ b/app/services/checksum_validator.rb
@@ -36,6 +36,7 @@ class ChecksumValidator
         results.add_result(AuditResults::MOAB_CHECKSUM_VALID)
         found_expected_version = moab.current_version_id == preserved_copy.version
         set_status_as_seen_on_disk(found_expected_version)
+        preserved_copy.update_audit_timestamps(true, true)
         unless found_expected_version
           results.add_result(AuditResults::UNEXPECTED_VERSION, actual_version: moab.current_version_id, db_obj_name: 'PreservedCopy', db_obj_version: preserved_copy.version)
         end

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -239,6 +239,15 @@ RSpec.describe ChecksumValidator do
         expect(pres_copy.reload.status).to eq PreservedCopy::OK_STATUS
       end
 
+      it 'updates audit timestamps' do
+        expect(pres_copy.last_moab_validation).to be nil
+        expect(pres_copy.last_version_audit).to be nil
+        approximate_validation_time = Time.current
+        cv.validate_checksums
+        expect(pres_copy.last_moab_validation).to be > approximate_validation_time
+        expect(pres_copy.last_version_audit).to be > approximate_validation_time
+      end
+
       context 'fails other moab validation' do
         context 'version on disk does not match expected version from catalog' do
           before do


### PR DESCRIPTION
Fixes #688 

I'm open to adding to tests, if they seem insufficient, say, for a change in timestamp value, or testing that timestamps don't get updated in the else condition.