### PR TITLE
only set ok status if all validations (incl CV) have passed

### DIFF
--- a/app/services/moab_validation_handler.rb
+++ b/app/services/moab_validation_handler.rb
@@ -73,7 +73,15 @@ module MoabValidationHandler
       return
     end
 
-    # TODO: this still isn't quite honest in the cases where checksum validation hasn't been performed
-    update_status(PreservedCopy::OK_STATUS)
+    # NOTE: subclasses which override this method should NOT perform checksum validation inside of this method!
+    # CV is expensive, and can run a while, and this method should likely be called from within a DB transaction,
+    # but CV definitely shouldn't happen inside a DB transaction.
+    if results.contains_result_code?(AuditResults::MOAB_CHECKSUM_VALID)
+      update_status(PreservedCopy::OK_STATUS)
+    elsif can_validate_checksums?
+      update_status(PreservedCopy::INVALID_CHECKSUM_STATUS)
+    else
+      update_status(PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+    end
   end
 end

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -36,7 +36,7 @@ class PreservedObjectHandler
     elsif PreservedObject.exists?(druid: druid)
       results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'PreservedObject')
     elsif moab_validation_errors.empty?
-      create_db_objects(PreservedCopy::OK_STATUS)
+      create_db_objects(PreservedCopy::VALIDITY_UNKNOWN_STATUS)
     else
       create_db_objects(PreservedCopy::INVALID_MOAB_STATUS)
     end
@@ -98,7 +98,7 @@ class PreservedObjectHandler
     else
       results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, 'PreservedObject')
       if moab_validation_errors.empty?
-        create_db_objects(PreservedCopy::OK_STATUS)
+        create_db_objects(PreservedCopy::VALIDITY_UNKNOWN_STATUS)
       else
         create_db_objects(PreservedCopy::INVALID_MOAB_STATUS)
       end
@@ -132,7 +132,7 @@ class PreservedObjectHandler
       if endpoint.endpoint_type.endpoint_class == 'online'
         if moab_validation_errors.empty?
           # NOTE: we deal with active record transactions in update_online_version, not here
-          update_online_version(PreservedCopy::OK_STATUS)
+          update_online_version(PreservedCopy::VALIDITY_UNKNOWN_STATUS)
         else
           update_pc_invalid_moab
         end

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -4,10 +4,11 @@ require_relative '../../load_fixtures_helper.rb'
 RSpec.describe CatalogToMoab do
   let(:last_checked_version_b4_date) { (Time.now.utc - 1.day).iso8601 }
   let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
+  let(:druid) { 'bj102hs9687' }
+  let(:c2m) { described_class.new(pres_copy, storage_dir) }
 
   context '#initialize' do
     include_context 'fixture moabs in db'
-    let(:druid) { 'bj102hs9687' }
     let(:pres_copy) do
       po = PreservedObject.find_by(druid: druid)
       ep = Endpoint.find_by(storage_location: storage_dir).id
@@ -15,7 +16,6 @@ RSpec.describe CatalogToMoab do
     end
 
     it 'sets attributes' do
-      c2m = described_class.new(pres_copy, storage_dir)
       expect(c2m.preserved_copy).to eq pres_copy
       expect(c2m.storage_dir).to eq storage_dir
       expect(c2m.druid).to eq druid
@@ -25,7 +25,6 @@ RSpec.describe CatalogToMoab do
 
   context '#check_catalog_version' do
     include_context 'fixture moabs in db'
-    let(:druid) { 'bj102hs9687' }
     let(:pres_copy) do
       po = PreservedObject.find_by(druid: druid)
       ep = Endpoint.find_by(storage_location: storage_dir).id
@@ -34,7 +33,6 @@ RSpec.describe CatalogToMoab do
       pc
     end
     let(:object_dir) { "#{storage_dir}/#{DruidTools::Druid.new(druid).tree.join('/')}" }
-    let(:c2m) { described_class.new(pres_copy, storage_dir) }
 
     it 'instantiates Moab::StorageObject from druid and storage_dir' do
       expect(Moab::StorageObject).to receive(:new).with(druid, a_string_matching(object_dir)).and_call_original

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -316,9 +316,9 @@ RSpec.describe PreservedObjectHandler do
       end
 
       context 'PreservedCopy already has a status other than OK_STATUS' do
-        it_behaves_like 'PreservedCopy already has a status other than OK_STATUS, and incoming_version == pc.version', :check_existence
+        it_behaves_like 'PreservedCopy may have its status checked when incoming_version == pc.version', :check_existence
 
-        it_behaves_like 'PreservedCopy already has a status other than OK_STATUS, and incoming_version < pc.version', :check_existence
+        it_behaves_like 'PreservedCopy may have its status checked when incoming_version < pc.version', :check_existence
 
         context 'incoming_version > db version' do
           let(:incoming_version) { pc.version + 1 }

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe PreservedObjectHandler do
                 pc.status = PreservedCopy::INVALID_MOAB_STATUS
                 pc.save!
                 po_handler.check_existence
-                expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+                expect(pc.reload.status).to eq PreservedCopy::VALIDITY_UNKNOWN_STATUS
               end
             end
             context 'unchanged' do
@@ -330,19 +330,19 @@ RSpec.describe PreservedObjectHandler do
             po_handler.check_existence
             expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
           end
-          it 'had INVALID_MOAB_STATUS, was remediated, should now have OK_STATUS' do
+          it 'had INVALID_MOAB_STATUS, was remediated, should now have VALIDITY_UNKNOWN_STATUS' do
             pc.status = PreservedCopy::INVALID_MOAB_STATUS
             pc.save!
             allow(po_handler).to receive(:moab_validation_errors).and_return([])
             po_handler.check_existence
-            expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+            expect(pc.reload.status).to eq PreservedCopy::VALIDITY_UNKNOWN_STATUS
           end
           it 'had UNEXPECTED_VERSION_ON_STORAGE_STATUS, seems to have an acceptable version now' do
             pc.status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
             pc.save!
             allow(po_handler).to receive(:moab_validation_errors).and_return([])
             po_handler.check_existence
-            expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+            expect(pc.reload.status).to eq PreservedCopy::VALIDITY_UNKNOWN_STATUS
           end
         end
       end
@@ -471,7 +471,7 @@ RSpec.describe PreservedObjectHandler do
               version: incoming_version,
               size: incoming_size,
               endpoint: ep,
-              status: PreservedCopy::OK_STATUS, # NOTE: ensuring this particular status
+              status: PreservedCopy::VALIDITY_UNKNOWN_STATUS, # NOTE: ensuring this particular status
               last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
               last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
             }

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -106,9 +106,9 @@ RSpec.describe PreservedObjectHandler do
       end
 
       context 'PreservedCopy already has a status other than OK_STATUS' do
-        it_behaves_like 'PreservedCopy already has a status other than OK_STATUS, and incoming_version == pc.version', :confirm_version
+        it_behaves_like 'PreservedCopy may have its status checked when incoming_version == pc.version', :confirm_version
 
-        it_behaves_like 'PreservedCopy already has a status other than OK_STATUS, and incoming_version < pc.version', :confirm_version
+        it_behaves_like 'PreservedCopy may have its status checked when incoming_version < pc.version', :confirm_version
 
         context 'incoming_version > db version' do
           let(:incoming_version) { pc.version + 1 }

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe PreservedObjectHandler do
         version: incoming_version,
         size: incoming_size,
         endpoint: ep,
-        status: PreservedCopy::OK_STATUS, # NOTE ensuring this particular status
+        status: PreservedCopy::VALIDITY_UNKNOWN_STATUS, # NOTE ensuring this particular status
         last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
         last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
       }

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -309,9 +309,8 @@ RSpec.describe PreservedObjectHandler do
               expect(pc.reload.size).to eq orig
             end
             it 'status' do
-              orig = pc.status
               po_handler.update_version_after_validation
-              expect(pc.reload.status).to eq orig
+              expect(pc.reload).to be_validity_unknown
               skip 'is there a scenario when status should change here?  See #431'
             end
           end
@@ -327,17 +326,17 @@ RSpec.describe PreservedObjectHandler do
           end
         end
 
-        it 'calls #update_online_version with validated = true and status = "ok"' do
-          expect(po_handler).to receive(:update_online_version).with(PreservedCopy::OK_STATUS).and_call_original
+        it 'calls #update_online_version with validated = true and status = "validity_unknown"' do
+          expect(po_handler).to receive(:update_online_version).with(PreservedCopy::VALIDITY_UNKNOWN_STATUS).and_call_original
           po_handler.update_version_after_validation
           skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
         end
 
-        it 'updates PreservedCopy status to "ok" if it was "moab_invalid"' do
+        it 'updates PreservedCopy status to "validity_unknown" if it was "moab_invalid"' do
           pc.status = PreservedCopy::INVALID_MOAB_STATUS
           pc.save!
           po_handler.update_version_after_validation
-          expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+          expect(pc.reload.status).to eq PreservedCopy::VALIDITY_UNKNOWN_STATUS
         end
       end
 

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -379,10 +379,10 @@ RSpec.shared_examples 'cannot validate something with INVALID_CHECKSUM_STATUS' d
   end
 end
 
-RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, and incoming_version == pc.version' do |method_sym|
+RSpec.shared_examples 'PreservedCopy may have its status checked when incoming_version == pc.version' do |method_sym|
   let(:incoming_version) { pc.version }
 
-  it 'had OK_STATUS, and is still OK' do
+  it 'had OK_STATUS, keeps OK_STATUS' do
     pc.status = PreservedCopy::OK_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
@@ -410,7 +410,7 @@ RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, 
     po_handler.send(method_sym)
     expect(pc.reload.status).to eq PreservedCopy::VALIDITY_UNKNOWN_STATUS
   end
-  it 'had VALIDITY_UNKNOWN_STATUS, but is now VALIDITY_UNKNOWN_STATUS' do
+  it 'had VALIDITY_UNKNOWN_STATUS, keeps VALIDITY_UNKNOWN_STATUS' do
     pc.status = PreservedCopy::VALIDITY_UNKNOWN_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
@@ -446,7 +446,7 @@ RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, 
   end
 end
 
-RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, and incoming_version < pc.version' do |method_sym|
+RSpec.shared_examples 'PreservedCopy may have its status checked when incoming_version < pc.version' do |method_sym|
   let(:incoming_version) { pc.version - 1 }
 
   it 'had OK_STATUS, but is now UNEXPECTED_VERSION_ON_STORAGE_STATUS' do

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -389,12 +389,12 @@ RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, 
     po_handler.send(method_sym)
     expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
   end
-  it 'had UNEXPECTED_VERSION_ON_STORAGE_STATUS, but is now OK' do
+  it 'had UNEXPECTED_VERSION_ON_STORAGE_STATUS, but is now VALIDITY_UNKNOWN_STATUS' do
     pc.status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
     po_handler.send(method_sym)
-    expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+    expect(pc.reload.status).to eq PreservedCopy::VALIDITY_UNKNOWN_STATUS
   end
   it 'had UNEXPECTED_VERSION_ON_STORAGE_STATUS, but is now INVALID_MOAB_STATUS' do
     pc.status = PreservedCopy::UNEXPECTED_VERSION_ON_STORAGE_STATUS
@@ -403,19 +403,19 @@ RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, 
     po_handler.send(method_sym)
     expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
   end
-  it 'had INVALID_MOAB_STATUS, but is now OK' do
+  it 'had INVALID_MOAB_STATUS, but is now VALIDITY_UNKNOWN_STATUS' do
     pc.status = PreservedCopy::INVALID_MOAB_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
     po_handler.send(method_sym)
-    expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+    expect(pc.reload.status).to eq PreservedCopy::VALIDITY_UNKNOWN_STATUS
   end
-  it 'had VALIDITY_UNKNOWN_STATUS, but is now OK' do
+  it 'had VALIDITY_UNKNOWN_STATUS, but is now VALIDITY_UNKNOWN_STATUS' do
     pc.status = PreservedCopy::VALIDITY_UNKNOWN_STATUS
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
     po_handler.send(method_sym)
-    expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+    expect(pc.reload.status).to eq PreservedCopy::VALIDITY_UNKNOWN_STATUS
   end
   it 'had VALIDITY_UNKNOWN_STATUS, but is now INVALID_MOAB_STATUS' do
     pc.status = PreservedCopy::VALIDITY_UNKNOWN_STATUS
@@ -429,7 +429,7 @@ RSpec.shared_examples 'PreservedCopy already has a status other than OK_STATUS, 
     pc.save!
     allow(po_handler).to receive(:moab_validation_errors).and_return([])
     po_handler.send(method_sym)
-    expect(pc.reload.status).to eq PreservedCopy::OK_STATUS
+    expect(pc.reload.status).to eq PreservedCopy::VALIDITY_UNKNOWN_STATUS
   end
 
   context 'had INVALID_CHECKSUM_STATUS' do


### PR DESCRIPTION
otherwise, status can be set to any errors that may have been found (e.g. `'invalid_moab'`, `'unexpected_version_on_storage'`), or `'validity_unknown'` if e.g. no errors were found but checksum validation wasn't run.

closes #690