### PR TITLE
M2C, C2M: ensure they are only for online pres_copies

### DIFF
--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe PreservedObjectHandler do
   describe 'endpoint validation' do
     it 'errors when endpoint is not an Endpoint object' do
       poh = described_class.new(druid, incoming_version, incoming_size, 1)
-      poh.valid?
+      expect(poh).to be_invalid
       expect(poh.errors.messages).to include(endpoint: ["must be an actual Endpoint"])
     end
     it 'errors when endpoint_type is not online' do
@@ -124,12 +124,11 @@ RSpec.describe PreservedObjectHandler do
                                           endpoint_node: 'node',
                                           storage_location: 'somewhere')
       poh = described_class.new(druid, incoming_version, incoming_size, archival_endpoint)
-      poh.valid?
+      expect(poh).to be_invalid
       expect(poh.errors.messages).to include(endpoint: ["must be an online Endpoint for PreservedObjectHandler"])
     end
     it 'passes when endpoint_type is online' do
-      po_handler.valid?
-      expect(po_handler.errors.size).to eq 0
+      expect(po_handler).to be_valid
     end
   end
 end

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -110,4 +110,26 @@ RSpec.describe PreservedObjectHandler do
       po_handler.create_after_validation
     end
   end
+
+  describe 'endpoint validation' do
+    it 'errors when endpoint is not an Endpoint object' do
+      poh = described_class.new(druid, incoming_version, incoming_size, 1)
+      poh.valid?
+      expect(poh.errors.messages).to include(endpoint: ["must be an actual Endpoint"])
+    end
+    it 'errors when endpoint_type is not online' do
+      endpoint_type = EndpointType.create(type_name: 'foo', endpoint_class: 'archive')
+      archival_endpoint = Endpoint.create(endpoint_name: 'archive1',
+                                          endpoint_type_id: endpoint_type.id,
+                                          endpoint_node: 'node',
+                                          storage_location: 'somewhere')
+      poh = described_class.new(druid, incoming_version, incoming_size, archival_endpoint)
+      poh.valid?
+      expect(poh.errors.messages).to include(endpoint: ["must be an online Endpoint for PreservedObjectHandler"])
+    end
+    it 'passes when endpoint_type is online' do
+      po_handler.valid?
+      expect(po_handler.errors.size).to eq 0
+    end
+  end
 end


### PR DESCRIPTION
Ensure that our existing M2C and C2M checks only affect *online* PreservedCopy objects, using @jmartin-sul 's the elegant solution.

supersedes the M2C and C2M part of PR #823

Connected to #778