### PR TITLE
Fix #728 profiler_spec: no rails, do cleanup, order independence

### DIFF
--- a/lib/profiler.rb
+++ b/lib/profiler.rb
@@ -1,13 +1,16 @@
 # adapted from argo
 # takes a block of code, starts the profiler, runs the code, then
 # stops the profiler and returns the results of the profiling.
-# example usage:
+# @example usage
 #  profiler = Profiler.new
 #  profiler.prof { MoabToCatalog.seed_catalog_for_dir(storage_dir) }
 #  profiler.print_results_flat(out_file_id)
 class Profiler
-
   attr_accessor :results
+
+  def output_path(out_file_id)
+    "log/profile_#{out_file_id}#{Time.now.utc.localtime.strftime('%FT%T')}-flat.txt" # start w/ UTC per rubocop
+  end
 
   def prof
     RubyProf.start
@@ -16,8 +19,8 @@ class Profiler
   end
 
   def print_results_flat(out_file_id)
-    File.open "log/profile_#{out_file_id}#{Time.current.localtime.strftime('%FT%T')}-flat.txt", 'w' do |file|
-      RubyProf::FlatPrinterWithLineNumbers.new(@results).print(file)
+    File.open output_path(out_file_id), 'w' do |file|
+      RubyProf::FlatPrinterWithLineNumbers.new(results).print(file)
     end
   end
 end


### PR DESCRIPTION
`Time.current` relies on Rails, but this `lib` class doesn't have any guarantee of Rails being loaded. Here I convert the call to use only the functionality available from the un-enhanced Ruby class.

This resolves a test order-dependency and test-independence failure (the spec could not previously run in isolation).

Would you prefer not to have 200 log files leftover by running specs on your local machine?  Me, too. I also made the test clean up after itself.

Fix #728