### PR TITLE
CV - ensure it is only for online pres_copies

### DIFF
--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -49,6 +49,7 @@ class PreservedCopy < ApplicationRecord
   }
 
   scope :for_archive_endpoints, -> { by_endpoint_class('archive') }
+  scope :for_online_endpoints, -> { by_endpoint_class('online') }
 
   scope :least_recent_version_audit, lambda { |last_checked_b4_date|
     where('last_version_audit IS NULL or last_version_audit < ?', normalize_date(last_checked_b4_date))

--- a/app/services/checksum_validator.rb
+++ b/app/services/checksum_validator.rb
@@ -18,10 +18,11 @@ class ChecksumValidator
   DELETED = 'deleted'.freeze
   FILES = 'files'.freeze
 
-  def initialize(preserved_copy, endpoint_name)
+  def initialize(preserved_copy)
     @preserved_copy = preserved_copy
     @bare_druid = preserved_copy.preserved_object.druid
-    @endpoint = Endpoint.find_by(endpoint_name: endpoint_name)
+    @endpoint = preserved_copy.endpoint
+    raise ArgumentError, "#{self.class.name} requires PreservedCopy's Endpoint to be online" unless endpoint.endpoint_type.online?
     @results = AuditResults.new(bare_druid, nil, endpoint, 'validate_checksums')
     @full_druid = "druid:#{bare_druid}"
   end

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe Checksum do
       it 'creates an instance and calls #validate_checksums on everything in batches' do
         pcs_from_scope = PreservedCopy.by_endpoint_name(endpoint_name).fixity_check_expired
         cv_list = pcs_from_scope.map do |pc|
-          ChecksumValidator.new(pc, endpoint_name)
+          ChecksumValidator.new(pc)
         end
         cv_list.each do |cv|
-          allow(ChecksumValidator).to receive(:new).with(cv.preserved_copy, endpoint_name).and_return(cv)
+          allow(ChecksumValidator).to receive(:new).with(cv.preserved_copy).and_return(cv)
           expect(cv).to receive(:validate_checksums).exactly(1).times.and_call_original
         end
         described_class.validate_disk(endpoint_name, 2)
@@ -101,10 +101,10 @@ RSpec.describe Checksum do
       druid = 'bz514sm9647'
       pres_copies = PreservedCopy.by_druid(druid)
       cv_list = pres_copies.map do |pc|
-        ChecksumValidator.new(pc, endpoint_name)
+        ChecksumValidator.new(pc)
       end
       cv_list.each do |cv|
-        allow(ChecksumValidator).to receive(:new).with(cv.preserved_copy, endpoint_name).and_return(cv)
+        allow(ChecksumValidator).to receive(:new).with(cv.preserved_copy).and_return(cv)
         expect(cv).to receive(:validate_checksums).exactly(1).times.and_call_original
       end
       described_class.validate_druid(druid)

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ChecksumValidator do
     po = PreservedObject.find_by(druid: druid)
     PreservedCopy.find_by(preserved_object: po, endpoint: endpoint)
   end
-  let(:cv) { described_class.new(pres_copy, endpoint_name) }
+  let(:cv) { described_class.new(pres_copy) }
   let(:results) { instance_double(AuditResults, report_results: nil, check_name: nil) }
 
   context '#initialize' do
@@ -21,6 +21,13 @@ RSpec.describe ChecksumValidator do
       expect(cv.endpoint).to eq endpoint
       expect(cv.full_druid).to eq "druid:#{druid}"
       expect(cv.results).to be_an_instance_of AuditResults
+    end
+    it 'raises ArgumentError if endpoint is not online' do
+      ept = instance_double(EndpointType, online?: false)
+      non_online_ep = instance_double(Endpoint, endpoint_type: ept)
+      allow(pres_copy).to receive(:endpoint).and_return(non_online_ep)
+      exp_err_msg = "ChecksumValidator requires PreservedCopy's Endpoint to be online"
+      expect { described_class.new(pres_copy) }.to raise_error(ArgumentError, exp_err_msg)
     end
   end
 

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../app/services/checksum_validator.rb'
+require 'rails_helper'
 require_relative '../load_fixtures_helper.rb'
 
 RSpec.describe ChecksumValidator do


### PR DESCRIPTION
- Ensure that our existing CV check only affects online PreservedCopy objects.

Additional refactors
- checksum_validator.new takes pres_copy as single argument
- fix checksum_validator_spec so it can be run alone (@atz does this improve random order issues?)

supersedes the M2C and C2M part of PR #823

Connected to #778