### PR TITLE
Use dor-workflow-service for rest calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 # general Ruby/Rails gems
 gem 'aws-sdk-s3', '~> 1.9.1'
 gem 'config' # Settings to manage configs on different instances
-gem 'faraday' # ReST calls
+gem 'dor-workflow-service' # audit errors are reported to the workflow service
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'jbuilder', '~> 2.5' # Build JSON APIs with ease.
 gem 'okcomputer' # ReST endpoint with upness status
@@ -21,7 +21,6 @@ gem 'puma', '~> 3.7' # app server
 gem 'rails', '~> 5.1.3'
 gem 'resque', '~> 1.27'
 gem 'resque-lock' # deduplication of worker queue jobs
-gem 'retries' # robust handling of network glitches
 gem 'ruby-prof' # to profile methods
 gem 'whenever' # manage cron for audit checks
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       dry-validation (>= 0.10.4)
     confstruct (1.0.2)
       hashie (~> 3.3)
+    connection_pool (2.2.2)
     coveralls (0.8.21)
       json (>= 1.8, < 3)
       simplecov (~> 0.14.1)
@@ -115,6 +116,13 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.1.5)
+    dor-workflow-service (2.3.0)
+      activesupport (>= 3.2.1, < 6)
+      confstruct (>= 0.2.7, < 2)
+      faraday (~> 0.9, >= 0.9.2)
+      net-http-persistent (>= 2.9.4, < 4.a)
+      nokogiri (~> 1.6)
+      retries
     druid-tools (1.0.0)
     dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
@@ -149,7 +157,7 @@ GEM
     factory_bot_rails (4.8.2)
       factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
-    faraday (0.14.0)
+    faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.23)
     globalid (0.4.1)
@@ -189,6 +197,8 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mustermann (1.0.2)
+    net-http-persistent (3.0.0)
+      connection_pool (~> 2.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
@@ -344,9 +354,9 @@ DEPENDENCIES
   config
   coveralls
   dlss-capistrano
+  dor-workflow-service
   druid-tools
   factory_bot_rails (~> 4.0)
-  faraday
   hirb
   honeybadger
   jbuilder (~> 2.5)
@@ -362,7 +372,6 @@ DEPENDENCIES
   rails-controller-testing
   resque (~> 1.27)
   resque-lock
-  retries
   rspec-rails (~> 3.6)
   rubocop (~> 0.50.0)
   rubocop-rspec

--- a/app/services/workflow_errors_reporter.rb
+++ b/app/services/workflow_errors_reporter.rb
@@ -3,44 +3,11 @@ require 'retries'
 # send errors to preservationAuditWF workflow for an object via ReST calls.
 class WorkflowErrorsReporter
 
+  # this method will always return true because of the dor-workflow-service gem
+  # see issue sul-dlss/dor-workflow-service#50 for more context
   def self.update_workflow(druid, process_name, error_message)
-    response = http_workflow_request(druid, process_name, error_message)
-    if response
-      if response.status == 204
-        Rails.logger.debug("#{druid} - sent error to workflow service for preservationAuditWF #{process_name}")
-      else
-        # Note: status == 400 will be handled by the rescue clause
-        Rails.logger.error("#{druid} - unable to update workflow for preservationAuditWF #{process_name}: #{response.body}. Error message: #{error_message}")
-      end
-    end
-  rescue StandardError => e
-    Rails.logger.error("#{druid} - unable to update workflow for preservationAuditWF #{process_name} #{e.inspect}. Error message: #{error_message}")
-  end
-
-  private_class_method def self.http_workflow_request(druid, process_name, error_message)
-    return unless conn
-    handler = proc do |exception, attempt_number, total_delay|
-      Rails.logger.debug("Handler saw a #{exception.class}; retry attempt #{attempt_number}; #{total_delay} seconds have passed.")
-    end
-    with_retries(max_tries: 3, handler: handler, rescue: Faraday::Error) do
-      conn.put do |request|
-        request_params(request, druid, process_name, error_message)
-      end
-    end
-  end
-
-  private_class_method def self.request_params(request, druid, process_name, error_message)
-    request.headers['content-type'] = "application/xml"
-    request.url  "/workflow/dor/objects/druid:#{druid}/workflows/preservationAuditWF/#{process_name}"
-    request.body = "<process name='#{process_name}' status='error' errorMessage='#{CGI.escapeHTML(error_message)}'/>"
-  end
-
-  private_class_method def self.conn
     if Settings.workflow_services_url.present?
-      @connection ||= Faraday.new(url: Settings.workflow_services_url) do |c|
-        c.use Faraday::Response::RaiseError
-        c.use Faraday::Adapter::NetHttp
-      end
+      Dor::WorkflowService.update_workflow_error_status('dor', "druid:#{druid}", 'preservationAuditWF', process_name, error_message)
     else
       Rails.logger.warn('no workflow hookup - assume you are in test or dev environment')
     end

--- a/config/initializers/dor_workflow_service.rb
+++ b/config/initializers/dor_workflow_service.rb
@@ -1,0 +1,6 @@
+require 'dor-workflow-service'
+wf_log = Logger.new('log/workflow_service.log', 'weekly')
+Dor::WorkflowService.configure(
+  Settings.workflow_services_url,
+  logger: wf_log
+)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -40,7 +40,7 @@ provlog:
 storage_root_map: # empty here, override in #{RAILS_ENV}.yml
   default: {}
 
-workflow_services_url: ''
+workflow_services_url: 'https://workflows.example.org/workflow/'
 c2m_sql_limit: 1000
 
 checksum_algos: ['md5'] # 'sha1' 'sha256'

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,5 +1,9 @@
 require 'rails_helper'
 RSpec.describe CatalogController, type: :controller do
+  before do
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
+  end
+
   let(:size) { 2342 }
   let(:ver) { 3 }
   let(:prefixed_druid) { 'druid:bj102hs9687' }

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -2,6 +2,10 @@ require_relative '../../../lib/audit/catalog_to_moab.rb'
 require_relative '../../load_fixtures_helper.rb'
 
 RSpec.describe CatalogToMoab do
+  before do
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
+  end
+
   let(:last_checked_version_b4_date) { (Time.now.utc - 1.day).iso8601 }
   let(:storage_dir) { 'spec/fixtures/storage_root01/moab_storage_trunk' }
   let(:druid) { 'bj102hs9687' }

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -3,10 +3,13 @@ require_relative "../../../lib/audit/checksum.rb"
 require_relative '../../load_fixtures_helper.rb'
 
 RSpec.describe Checksum do
+  before do
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
+    allow(described_class.logger).to receive(:info) # silence STDOUT chatter
+  end
+
   let(:endpoint_name) { 'fixture_sr1' }
   let(:limit) { Settings.c2m_sql_limit }
-
-  before { allow(described_class.logger).to receive(:info) } # silence STDOUT chatter
 
   context '.validate_disk' do
     include_context 'fixture moabs in db'

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe MoabToCatalog do
   before do
     PreservationPolicy.seed_from_config
     allow(described_class.logger).to receive(:info) # silence STDOUT chatter
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
   end
 
   describe ".check_existence_for_all_storage_roots" do

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe AuditResults do
+  before do
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
+  end
+
   let(:druid) { 'ab123cd4567' }
   let(:actual_version) { 6 }
   let(:endpoint) { Endpoint.find_by(storage_location: 'spec/fixtures/storage_root01/moab_storage_trunk') }

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 require_relative '../load_fixtures_helper.rb'
 
 RSpec.describe ChecksumValidator do
+  before do
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
+  end
+
   include_context 'fixture moabs in db'
   let(:druid) { 'zz102hs9687' }
   let(:endpoint_name) { "fixture_sr3" }

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 require 'services/shared_examples_preserved_object_handler'
 
 RSpec.describe PreservedObjectHandler do
+  before do
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
+  end
+
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 require 'services/shared_examples_preserved_object_handler'
 
 RSpec.describe PreservedObjectHandler do
+  before do
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
+  end
+
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 require 'services/shared_examples_preserved_object_handler'
 
 RSpec.describe PreservedObjectHandler do
+  before do
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
+  end
+
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 require 'services/shared_examples_preserved_object_handler'
 
 RSpec.describe PreservedObjectHandler do
+  before do
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
+  end
+
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 require 'services/shared_examples_preserved_object_handler'
 
 RSpec.describe PreservedObjectHandler do
+  before do
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
+  end
+
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }

--- a/spec/services/workflow_errors_reporter_spec.rb
+++ b/spec/services/workflow_errors_reporter_spec.rb
@@ -1,61 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe WorkflowErrorsReporter do
-  let(:full_url) do
-    'https://sul-lyberservices-test.stanford.edu/workflow/dor/objects/druid:jj925bx9565/workflows/preservationAuditWF/moab-valid'
-  end
-  let(:headers) { { 'Content-Type' => 'application/xml' } }
-  let(:result) { "Invalid moab, validation error...ential version directories." }
-  let(:body) { "<process name='moab-valid' status='error' errorMessage='#{result}'/>" }
-  let(:druid) { 'jj925bx9565' }
-  let(:process_name) { 'moab-valid' }
-
   context '.update_workflow' do
-    it '204 response' do
-      allow(Settings).to receive(:workflow_services_url).and_return('https://sul-lyberservices-test.stanford.edu/workflow/')
+    it 'returns true' do
+      # because we always get true the from the dor-workflow-service gem
+      # see issue sul-dlss/dor-workflow-service#50 for more context
+      full_url = 'https://workflows.example.org/workflow/dor/objects/druid:jj925bx9565/workflows/preservationAuditWF/moab-valid'
+      result = 'Invalid moab, validation error...ential version directories.'
+      body = "<?xml version=\"1.0\"?>\n<process name=\"moab-valid\" status=\"error\" errorMessage=\"#{result}\"/>\n"
+      headers = { 'User-Agent' => 'Faraday v0.15.2' }
+      druid = 'jj925bx9565'
+      process_name = 'moab-valid'
+
       stub_request(:put, full_url)
-        .with(body: body, headers: headers)
-        .to_return(status: 204, body: "", headers: {})
-      expect(Rails.logger).to receive(:debug).with("#{druid} - sent error to workflow service for preservationAuditWF moab-valid")
-      described_class.update_workflow(druid, process_name, result)
-    end
+        .with(
+          body: body,
+          headers: headers
+        ).to_return(status: 200, body: "", headers: {})
 
-    it '400 response' do
-      allow(Settings).to receive(:workflow_services_url).and_return('https://sul-lyberservices-test.stanford.edu/workflow/')
-      stub_request(:put, full_url)
-        .with(body: body, headers: headers)
-        .to_return(status: 400, body: "", headers: {})
-      expect(Rails.logger).to receive(:error).with("#{druid} - unable to update workflow for preservationAuditWF moab-valid #<Faraday::ClientError response={:status=>400, :headers=>{}, :body=>\"\"}>. Error message: Invalid moab, validation error...ential version directories.")
-      described_class.update_workflow(druid, process_name, result)
-    end
-
-    it 'has invalid workflow_services_url' do
-      stub_request(:put, full_url)
-        .with(body: body, headers: headers)
-        .to_return(status: 400, body: "", headers: {})
-      expect(Rails.logger).to receive(:warn).with('no workflow hookup - assume you are in test or dev environment')
-      described_class.update_workflow(druid, process_name, result)
-    end
-  end
-
-  context '.request_params' do
-    let(:headers_hash) { {} }
-    let(:mock_request) { instance_double(Faraday::Request, headers: headers_hash) }
-
-    it 'make sure request gets correct params' do
-      error_msg = "Invalid moab, validation error...ential version directories."
-      expect(mock_request).to receive(:url).with("/workflow/dor/objects/druid:#{druid}/workflows/preservationAuditWF/#{process_name}")
-      expect(mock_request).to receive(:body=).with("<process name='#{process_name}' status='error' errorMessage='#{error_msg}'/>")
-      described_class.send(:request_params, mock_request, druid, process_name, error_msg)
-      expect(headers_hash).to eq("content-type" => "application/xml")
-    end
-
-    it 'escapes special characters in error message' do
-      error_msg = "Invalid moab, validation errors: [\"Version directory name not in 'v00xx' format: original-v1\"]"
-      expected_error_msg = CGI.escapeHTML(error_msg)
-      allow(mock_request).to receive(:url)
-      expect(mock_request).to receive(:body=).with("<process name='#{process_name}' status='error' errorMessage='#{expected_error_msg}'/>")
-      described_class.send(:request_params, mock_request, druid, process_name, error_msg)
+      expect(described_class.update_workflow(druid, process_name, result)).to be true
     end
   end
 end


### PR DESCRIPTION
  Fixes #809 

  - installs and configures `dor-workflow-service`
  - replaces a lot of homegrown faraday code with a call to `dor-workflow-service`, with a spec (for a method that unexceptionally returns `true`)
  - adds to `Settings` (would be nice to get the actual workflow service URL out of there)
  - makes other specs aware of the `dor-workflow-service` call