### PR TITLE
Fix #844: Zip util outputs "errors" on STDOUT

### DIFF
--- a/app/jobs/zipmaker_job.rb
+++ b/app/jobs/zipmaker_job.rb
@@ -14,7 +14,7 @@ class ZipmakerJob < DruidVersionJobBase
   end
 
   def create_zip!
-    _output, error, status = Open3.capture3(zip_command)
-    raise "zipmaker failure #{error}" unless status.success?
+    combined, status = Open3.capture2e(zip_command)
+    raise "zipmaker failure #{combined}" unless status.success?
   end
 end

--- a/spec/jobs/zipmaker_job_spec.rb
+++ b/spec/jobs/zipmaker_job_spec.rb
@@ -61,15 +61,15 @@ describe ZipmakerJob, type: :job do
         let(:zip_command) { "zip -vr0X -s 10g #{zip_path} /wrong/path" }
 
         it 'raises error' do
-          expect { job.create_zip! }.to raise_error(RuntimeError, /zipmaker failure/)
+          expect { job.create_zip! }.to raise_error(RuntimeError, %r{zipmaker failure.*/wrong/path})
         end
       end
 
       context 'when options are unsupported' do
-        let(:zip_command) { "zip -a #{zip_path} #{moab_version_path}" }
+        let(:zip_command) { "zip --fantasy #{zip_path} #{moab_version_path}" }
 
         it 'raises error' do
-          expect { job.create_zip! }.to raise_error(RuntimeError, /zipmaker failure/)
+          expect { job.create_zip! }.to raise_error(RuntimeError, /Invalid command arguments.*fantasy/)
         end
       end
 


### PR DESCRIPTION
Makes error reporting work.  As a bonus, one less unused variable.