### PR TITLE
Add Audit Check Usage via Console to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Rails application to track, audit and replicate archival artifacts associated wi
     * [Catalog to Moab](#c2m) (C2M) existence/version check
     * [Checksum Validation](#cv) (CV)
     * [Seed the catalog](#seeding)
+    * [Audit Checks via Console](#console)
 * [Development](#development)
 * [Deploying](#deploying)
 
@@ -200,7 +201,6 @@ RAILS_ENV=production bundle exec rake seed_catalog[profile]
 ```
 this will generate a log at, for example, `log/profile_seed_catalog_for_all_storage_roots2017-11-13T13:57:01-flat.txt`
 
-
 #### Reset the catalog for re-seeding
 
 WARNING! this will erase the catalog, and thus require re-seeding from scratch.  It is mostly intended for development purposes, and it is unlikely that you'll need to run this against production once the catalog is in regular use.
@@ -242,6 +242,72 @@ RAILS_ENV=production bundle exec rake drop[fixture_sr1]
 
 ```sh
 RAILS_ENV=production bundle exec rake populate[fixture_sr1]
+```
+
+## <a name="console"/>Audit Checks via Console
+To run audit checks via the console open up the rails console:
+```sh
+bundle exec rails console production
+```
+
+Next, require the audit module. This will load all of the required files needed to run the audit checks.
+```ruby
+require 'audit'
+```
+
+Here are the list of the Audit Checks.
+
+### Moab To Catalog Audit Checks:
+
+#### Single Druid
+```ruby
+Audit::MoabToCatalog.check_existence_for_druid('xx000xx0000')
+```
+#### List of Druids
+```ruby
+Audit::MoabToCatalog.check_existence_for_druid_list('/path/to/your/csv/druid_list.csv')
+```
+#### Single Storage Root
+```ruby
+Audit::MoabToCatalog.check_existence_for_dir('path/to/root/spec/fixtures/storage_root01/moab_storage_trunk')
+```
+#### All Storage Roots
+```ruby
+Audit::MoabToCatalog.check_existence_for_all_storage_roots
+```
+
+### Catalog To Moab Audit Checks:
+-  The (date/timestamp) argument is a threshold:  it will run the check on all catalog entries which last had a version check BEFORE the argument. It should be in the format '2018-01-22 22:54:48 UTC'.
+
+- Note: Must enter date/timestamp argument as a string.
+#### Single Storage Root
+
+```ruby
+Audit::CatalogToMoab.check_version_on_dir('2018-01-22 22:54:48 UTC', 'path/to/root/spec/fixtures/storage_root01/moab_storage_trunk')
+```
+#### All Storage Roots
+```ruby
+Audit::CatalogToMoab.check_version_all_dirs('2018-01-22 22:54:48 UTC')
+```
+
+### Checksum Audit Checks:
+
+#### Single Storage Root
+```ruby
+Audit::Checksum.validate_disk('fixture_sr3')
+```
+#### All Storage Roots
+```ruby
+Audit::Checksum.validate_disk_all_endpoints
+```
+#### Single Druid
+```ruby
+Audit::Checksum.validate_druid('xx000xx0000')
+```
+
+#### List of Druids
+```ruby
+Audit::Checksum.validate_list_of_druids('/path/to/your/csv/druid_list.csv')
 ```
 
 ## <a name="development"/>Development


### PR DESCRIPTION
This might be overkill, but I wanted to be as explicit as possible. 
~~This PR builds off of Joe's PR #727 , because of the `require 'audit'` part. I'll put this PR in WIP for now.~~ 
- rebased off master, which includes the `Audit::` Namespace (#727)
- Please let me know if i'm missing anything.

connects #833 