### PR TITLE
Make resque's rake tasks available

### DIFF
--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -1,0 +1,1 @@
+require 'resque/tasks'


### PR DESCRIPTION
Note: because of #842, attempting to run `rake resque:work` will crash from an unrelated dependency (okcomputer) problem, but this is required both for the point where we've fixed that, or for the workaround of targeting just the `resque.rake` file directly (not loading `Rakefile`).