### PR TITLE
Fix zipmaker bugs and gaps

### DIFF
--- a/app/jobs/zipmaker_job.rb
+++ b/app/jobs/zipmaker_job.rb
@@ -1,20 +1,18 @@
-require 'open3'
 # Responsibilities:
 # if needed, zip files to zip storage and calculate checksum
 # invoke PlexerJob
 class ZipmakerJob < DruidVersionJobBase
   queue_as :zipmaker
-  delegate :metadata, :zip_command, to: :zip
+  delegate :metadata, :create_zip!, :file_path, to: :zip
 
   # @param [String] druid
   # @param [Integer] version
   def perform(druid, version)
-    create_zip! unless File.exist?(zip.file_path)
+    if File.exist?(file_path)
+      FileUtils.touch(file_path)
+    else
+      create_zip!
+    end
     PlexerJob.perform_later(druid, version, metadata)
-  end
-
-  def create_zip!
-    combined, status = Open3.capture2e(zip_command)
-    raise "zipmaker failure #{combined}" unless status.success?
   end
 end

--- a/app/models/druid_version_zip.rb
+++ b/app/models/druid_version_zip.rb
@@ -12,8 +12,10 @@ class DruidVersionZip
     @version = version
   end
 
+  # Creates a zip of Druid-Version content.
   # Changes directory so that the storage root (and druid tree) are not part of
-  # the archival directory structure, just the object.
+  # the archival directory structure, just the object, e.g. starting at 'ab123cd4567/...' directory,
+  # not 'ab/123/cd/4567/ab123cd4567/...'
   def create_zip!
     ensure_zip_directory!
     Dir.chdir(work_dir.to_s) do

--- a/spec/jobs/zipmaker_job_spec.rb
+++ b/spec/jobs/zipmaker_job_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe ZipmakerJob, type: :job do
   let(:druid) { 'bj102hs9687' }
   let(:version) { 1 }
-  let(:moab_version_path) { Moab::StorageServices.object_version_path(druid, version) }
   let(:zip_path) { "spec/fixtures/zip_storage/bj/102/hs/9687/#{druid}#{format('.v%04d.zip', version)}" }
   let(:job) do
     described_class.new(druid, version).tap { |j| j.zip = DruidVersionZip.new(druid, version) }
@@ -24,62 +23,23 @@ describe ZipmakerJob, type: :job do
   end
 
   context 'zip already exists in zip storage' do
-    it 'does not create a zip' do
+    it 'does not create a zip, but touches it' do
       expect(File).to exist(zip_path)
-      expect(job).not_to receive(:create_zip!)
-      described_class.perform_now(druid, version)
+      expect(FileUtils).to receive(:touch).with(job.zip.file_path)
+      expect(job.zip).not_to receive(:create_zip!)
+      job.perform(druid, version)
     end
   end
 
   context 'zip is not yet in zip storage' do
     let(:version) { 3 }
 
-    after { File.delete(zip_path) }
+    before { allow(job.zip).to receive(:metadata).and_return(fake: 1) }
 
-    it 'zips up the druid version into zip storage' do
-      described_class.perform_now(druid, version)
-      expect(File).to exist(zip_path)
-    end
-  end
-
-  describe '.create_zip!' do
-    let(:version) { 3 }
-
-    context 'succeeds in zipping the binary' do
-      after { File.delete(zip_path) }
-
-      it 'does not raise an error' do
-        expect { job.create_zip! }.not_to raise_error
-        expect(File).to exist(zip_path)
-      end
-    end
-
-    context 'fails to zip the binary' do
-      before { allow(job).to receive(:zip_command).and_return(zip_command) }
-
-      context 'when inpath is incorrect' do
-        let(:zip_command) { "zip -vr0X -s 10g #{zip_path} /wrong/path" }
-
-        it 'raises error' do
-          expect { job.create_zip! }.to raise_error(RuntimeError, %r{zipmaker failure.*/wrong/path})
-        end
-      end
-
-      context 'when options are unsupported' do
-        let(:zip_command) { "zip --fantasy #{zip_path} #{moab_version_path}" }
-
-        it 'raises error' do
-          expect { job.create_zip! }.to raise_error(RuntimeError, /Invalid command arguments.*fantasy/)
-        end
-      end
-
-      context 'if the utility "moved"' do
-        let(:zip_command) { "zap -vr0X -s 10g #{zip_path} #{moab_version_path}" }
-
-        it 'raises error' do
-          expect { job.create_zip! }.to raise_error(Errno::ENOENT, /No such file/)
-        end
-      end
+    it 'creates the zip' do
+      expect(File).not_to exist(zip_path)
+      expect(job.zip).to receive(:create_zip!)
+      job.perform(druid, version)
     end
   end
 end

--- a/spec/models/druid_version_zip_spec.rb
+++ b/spec/models/druid_version_zip_spec.rb
@@ -34,8 +34,19 @@ describe DruidVersionZip do
       after { File.delete(zip_path) }
 
       it 'produces the expected zip file' do
+        expect(File).not_to exist(zip_path)
         expect { dvz.create_zip! }.not_to raise_error
         expect(File).to exist(zip_path)
+      end
+
+      # we `list` a given filepath out of the zip, `unzip` exits w/ 0 only when found
+      it 'produced zip has expected structure' do
+        techmd = "bj102hs9687/v0003/data/metadata/technicalMetadata.xml"
+        dvz.create_zip!
+        _, status = Open3.capture2e("unzip -lq #{zip_path} #{techmd}")
+        expect(status).to be_success
+        _, status = Open3.capture2e("unzip -lq #{zip_path} bj/102/hs/9687/#{techmd}")
+        expect(status).not_to be_success
       end
     end
 

--- a/spec/models/druid_version_zip_spec.rb
+++ b/spec/models/druid_version_zip_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 describe DruidVersionZip do
-  subject(:dvz) { described_class.new(druid, version) }
-
+  let(:dvz) { described_class.new(druid, version) }
   let(:druid) { 'bj102hs9687' }
   let(:version) { 1 }
 
@@ -22,6 +21,50 @@ describe DruidVersionZip do
     it 'opens file_path' do
       expect(File).to receive(:open).with(dvz.file_path)
       dvz.file
+    end
+  end
+
+  describe '.create_zip!' do
+    let(:zip_path) { dvz.file_path }
+    let(:version) { 3 } # v1 and v2 pre-existing
+
+    after { FileUtils.rm_rf('/tmp/bj') } # cleanup
+
+    context 'succeeds in zipping the binary' do
+      after { File.delete(zip_path) }
+
+      it 'produces the expected zip file' do
+        expect { dvz.create_zip! }.not_to raise_error
+        expect(File).to exist(zip_path)
+      end
+    end
+
+    context 'fails to zip the binary' do
+      before { allow(dvz).to receive(:zip_command).and_return(zip_command) }
+
+      context 'when inpath is incorrect' do
+        let(:zip_command) { "zip -vr0X -s 10g #{zip_path} /wrong/path" }
+
+        it 'raises error' do
+          expect { dvz.create_zip! }.to raise_error(RuntimeError, %r{zipmaker failure.*/wrong/path})
+        end
+      end
+
+      context 'when options are unsupported' do
+        let(:zip_command) { "zip --fantasy #{zip_path} #{druid}/v0003" }
+
+        it 'raises error' do
+          expect { dvz.create_zip! }.to raise_error(RuntimeError, /Invalid command arguments.*fantasy/)
+        end
+      end
+
+      context 'if the utility "moved"' do
+        let(:zip_command) { "zap -vr0X -s 10g #{zip_path} #{druid}/v0003" }
+
+        it 'raises error' do
+          expect { dvz.create_zip! }.to raise_error(Errno::ENOENT, /No such file/)
+        end
+      end
     end
   end
 
@@ -59,11 +102,10 @@ describe DruidVersionZip do
   end
 
   describe '#zip_command' do
-    let(:moab_version_path) { Moab::StorageServices.object_version_path(druid, version) }
     let(:zip_path) { '/tmp/bj/102/hs/9687/bj102hs9687.v0001.zip' }
 
     it 'returns zip string to execute for this druid/version' do
-      expect(dvz.zip_command).to eq "zip -vr0X -s 10g #{zip_path} #{moab_version_path}"
+      expect(dvz.zip_command).to eq "zip -vr0X -s 10g #{zip_path} bj102hs9687/v0001"
     end
   end
 


### PR DESCRIPTION
- Move last auxiliary method from zipmaker to DruidVersionZip
- Handles chdir for zip creation
- Handles `mkdir -p` for zip destination directory
- Performs `touch` on existing zip file to prevent premature cleanup

Fix #849
Fix #845