### PR TITLE
Profiler oneliner

### DIFF
--- a/app/lib/audit/catalog_to_moab.rb
+++ b/app/lib/audit/catalog_to_moab.rb
@@ -22,9 +22,7 @@ module Audit
     end
 
     def self.check_version_on_dir_profiled(last_checked_b4_date, storage_dir)
-      profiler = Profiler.new
-      profiler.prof { check_version_on_dir(last_checked_b4_date, storage_dir) }
-      profiler.print_results_flat('C2M_check_version_on_dir')
+      Profiler.print_profile('C2M_check_version_on_dir') { check_version_on_dir(last_checked_b4_date, storage_dir) }
     end
 
     def self.check_version_all_dirs(last_checked_b4_date)
@@ -37,9 +35,7 @@ module Audit
     end
 
     def self.check_version_all_dirs_profiled(last_checked_b4_date)
-      profiler = Profiler.new
-      profiler.prof { check_version_all_dirs(last_checked_b4_date) }
-      profiler.print_results_flat('C2M_check_version_all_dirs')
+      Profiler.print_profile('C2M_check_version_all_dirs') { check_version_all_dirs(last_checked_b4_date) }
     end
 
     # ----  INSTANCE code below this line ---------------------------

--- a/app/lib/audit/checksum.rb
+++ b/app/lib/audit/checksum.rb
@@ -20,9 +20,7 @@ module Audit
     end
 
     def self.validate_disk_profiled(endpoint_name)
-      profiler = Profiler.new
-      profiler.prof { validate_disk(endpoint_name) }
-      profiler.print_results_flat('cv_validate_disk')
+      Profiler.print_profile('cv_validate_disk') { validate_disk(endpoint_name) }
     end
 
     def self.validate_disk_all_endpoints
@@ -35,9 +33,7 @@ module Audit
     end
 
     def self.validate_disk_all_endpoints_profiled
-      profiler = Profiler.new
-      profiler.prof { validate_disk_all_endpoints }
-      profiler.print_results_flat('cv_validate_disk_all_endpoints')
+      Profiler.print_profile('cv_validate_disk_all_endpoints') { validate_disk_all_endpoints }
     end
 
     def self.validate_druid(druid)

--- a/app/lib/audit/moab_to_catalog.rb
+++ b/app/lib/audit/moab_to_catalog.rb
@@ -43,9 +43,7 @@ module Audit
     end
 
     def self.check_existence_for_dir_profiled(storage_dir)
-      profiler = Profiler.new
-      profiler.prof { check_existence_for_dir(storage_dir) }
-      profiler.print_results_flat('M2C_check_existence_for_dir')
+      Profiler.print_profile('M2C_check_existence_for_dir') { check_existence_for_dir(storage_dir) }
     end
 
     # NOTE: shameless green! code duplication with check_existence_for_dir
@@ -74,9 +72,7 @@ module Audit
     end
 
     def self.seed_catalog_for_all_storage_roots_profiled
-      profiler = Profiler.new
-      profiler.prof { seed_catalog_for_all_storage_roots }
-      profiler.print_results_flat('seed_catalog_for_all_storage_roots')
+      Profiler.print_profile('seed_catalog_for_all_storage_roots') { seed_catalog_for_all_storage_roots }
     end
 
     # Shameless green. Code duplication with seed_catalog_for_all_storage_roots
@@ -90,9 +86,7 @@ module Audit
     end
 
     def self.check_existence_for_all_storage_roots_profiled
-      profiler = Profiler.new
-      profiler.prof { check_existence_for_all_storage_roots }
-      profiler.print_results_flat('M2C_check_existence_for_all_storage_roots')
+      Profiler.print_profile('M2C_check_existence_for_all_storage_roots') { check_existence_for_all_storage_roots }
     end
 
     def self.drop_endpoint(endpoint_name)
@@ -111,9 +105,7 @@ module Audit
     end
 
     def self.populate_endpoint_profiled(endpoint_name)
-      profiler = Profiler.new
-      profiler.prof { populate_endpoint(endpoint_name) }
-      profiler.print_results_flat('populate_endpoint')
+      Profiler.print_profile('populate_endpoint') { populate_endpoint(endpoint_name) }
     end
   end
 end

--- a/lib/profiler.rb
+++ b/lib/profiler.rb
@@ -8,6 +8,17 @@
 class Profiler
   attr_accessor :results
 
+  # @param [String] out_file_id, if result printing is desired
+  # @param [Block] code to be profiled
+  # @return [Profiler] the instance with results
+  def self.print_profile(out_file_id = nil)
+    raise 'No block given to profile' unless block_given?
+    new.tap do |instance|
+      instance.prof(&Proc.new) # like a yield, this wraps the block given to re-pass it
+      instance.print_results_flat(out_file_id) if out_file_id
+    end
+  end
+
   def output_path(out_file_id)
     "log/profile_#{out_file_id}#{Time.now.utc.localtime.strftime('%FT%T')}-flat.txt" # start w/ UTC per rubocop
   end

--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -5,6 +5,31 @@ RSpec.describe Profiler do
   let(:profiler) { described_class.new }
   let(:faketime) { Time.at(628_232_400).utc } # 1989-11-27 21:00:00 -0800 == 1989-11-28 05:00:00 UTC
 
+  describe '.print_profile' do
+    before { allow(described_class).to receive(:new).and_return(profiler) }
+
+    it 'starts, yields, stops, and returns instance' do
+      expect(RubyProf).to receive(:start)
+      expect(RubyProf).to receive(:stop).and_return(instance_double(RubyProf::Profile))
+      test_value = false
+      return_val = described_class.print_profile { test_value = true }
+      expect(test_value).to be true
+      expect(return_val).to eq profiler
+    end
+
+    it 'prints if given an out_file_id' do
+      allow(profiler).to receive(:prof)
+      expect(profiler).to receive(:print_results_flat).with('foobar')
+      described_class.print_profile('foobar') { 'noop' }
+    end
+
+    it 'does not print without an out_file_id' do
+      allow(profiler).to receive(:prof)
+      expect(profiler).not_to receive(:print_results_flat)
+      described_class.print_profile { 'noop' }
+    end
+  end
+
   describe '#output_path' do
     before { allow(Time).to receive(:now).and_return(faketime) }
 


### PR DESCRIPTION
Fixes half of #869

Add method for simple one-liner invocation of profiler.  This reduces the need to have bespoke one-off methods that shadow regular methods for the purpose of profiling them. Whatever calls them (e.g. rake task) can now just invoke `Profiler.print_profile` itself.

Converts `Profiler` invocations in `Audit` module.  This is a setup for externalizing each `xxx_profiled` method to the place where it is called (seems like each is called in only one place).  (The second half of #869).  

After all, it shouldn't be the business logic for a class _how_ a given method is going to be profiled (or which are profilable).