### PR TITLE
line in between constants and first method, make string use in update…

### DIFF
--- a/app/services/workflow_reporter.rb
+++ b/app/services/workflow_reporter.rb
@@ -5,6 +5,8 @@ class WorkflowReporter
   DOR = 'dor'.freeze
   PRESERVATIONAUDITWF = 'preservationAuditWF'.freeze
   NO_WORKFLOW_HOOKUP = 'no workflow hookup - assume you are in test or dev environment'.freeze
+  COMPLETED = 'completed'.freeze
+
   # this method will always return true because of the dor-workflow-service gem
   # see issue sul-dlss/dor-workflow-service#50 for more context
   def self.report_error(druid, process_name, error_message)
@@ -17,7 +19,7 @@ class WorkflowReporter
 
   def self.report_completed(druid, process_name)
     if Settings.workflow_services_url.present?
-      Dor::WorkflowService.update_workflow_status(DOR, "druid:#{druid}", PRESERVATIONAUDITWF, process_name, 'completed')
+      Dor::WorkflowService.update_workflow_status(DOR, "druid:#{druid}", PRESERVATIONAUDITWF, process_name, COMPLETED)
     else
       Rails.logger.warn(NO_WORKFLOW_HOOKUP)
     end


### PR DESCRIPTION
…_workflow_status call consistent w/ other strings in the class

using `COMPLETED` for `'completed'` seemed most consistent with the rest of the class, to my eyes.  happy to get rid of that if others think it's overkill.  would've made it a separate commit to make it easier to lop off, but two commits that small felt silly to me.

spawned by #875