### PR TITLE
[WIP] POH: optional flag to public update and create methods to indicate caller verified checksums

### DIFF
--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -40,6 +40,7 @@ class PreservedObjectHandler
       results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'PreservedObject')
     elsif moab_validation_errors.empty?
       creation_status = (caller_verified_checksums ? PreservedCopy::OK_STATUS : PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+      # TODO: what, if any, timestamps does this imply update for?
       create_db_objects(creation_status)
     else
       create_db_objects(PreservedCopy::INVALID_MOAB_STATUS)
@@ -56,6 +57,7 @@ class PreservedObjectHandler
       results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'PreservedObject')
     else
       creation_status = (caller_verified_checksums ? PreservedCopy::OK_STATUS : PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+      # TODO: what, if any, timestamps does this imply update for?
       create_db_objects(creation_status)
     end
 
@@ -129,6 +131,7 @@ class PreservedObjectHandler
       if moab_validation_errors.empty?
         # NOTE: we deal with active record transactions in update_online_version, not here
         new_status = (caller_verified_checksums ? PreservedCopy::OK_STATUS : PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+        # TODO: what, if any, timestamps does this imply update for?
         update_online_version(new_status)
       else
         update_pc_invalid_moab
@@ -146,6 +149,7 @@ class PreservedObjectHandler
       Rails.logger.debug "update_version #{druid} called"
       # NOTE: we deal with active record transactions in update_online_version, not here
       new_status = (caller_verified_checksums ? PreservedCopy::OK_STATUS : nil)
+      # TODO: what, if any, timestamps does this imply update for?
       update_online_version(new_status, true)
     end
 

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -204,7 +204,7 @@ class PreservedObjectHandler
         results.add_result(code, db_obj_name: 'PreservedCopy', db_obj_version: pres_copy.version)
 
         pres_copy.upd_audstamps_version_size(ran_moab_validation?, incoming_version, incoming_size)
-        update_status(status) if status && ran_moab_validation?
+        update_status(status) if status
         pres_copy.save!
         pres_object.current_version = incoming_version
         pres_object.save!

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe PreservedObjectHandler do
       po_handler.create
     end
 
+    it 'creates the PreservedCopy with "ok" status if caller ran CV' do
+      pc_args[:status] = PreservedCopy::OK_STATUS
+      expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
+      po_handler.create(true)
+    end
+
     it_behaves_like 'attributes validated', :create
 
     it 'object already exists' do
@@ -129,6 +135,18 @@ RSpec.describe PreservedObjectHandler do
       po_handler.create_after_validation
     end
 
+    it 'creates PreservedCopy in "ok" status in db when there are no validation errors and caller ran CV' do
+      pc_args.merge!(
+        status: PreservedCopy::OK_STATUS,
+        last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
+        last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
+      )
+
+      expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
+      po_handler = described_class.new(valid_druid, incoming_version, incoming_size, ep)
+      po_handler.create_after_validation(true)
+    end
+
     it 'calls moab-versioning Stanford::StorageObjectValidator.validation_errors' do
       mock_sov = instance_double(Stanford::StorageObjectValidator)
       expect(mock_sov).to receive(:validation_errors).and_return([])
@@ -152,7 +170,7 @@ RSpec.describe PreservedObjectHandler do
         end
       end
 
-      it 'creates PreservedObject and PreservedCopy with "invalid_moab" status in database' do
+      it 'creates PreservedObject, and PreservedCopy with "invalid_moab" status in database' do
         po_args[:druid] = invalid_druid
         pc_args.merge!(
           status: PreservedCopy::INVALID_MOAB_STATUS,
@@ -163,6 +181,17 @@ RSpec.describe PreservedObjectHandler do
         expect(PreservedObject).to receive(:create!).with(po_args).and_call_original
         expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
         po_handler.create_after_validation
+      end
+
+      it 'creates PreservedCopy with "invalid_moab" status in database even if caller ran CV' do
+        pc_args.merge!(
+          status: PreservedCopy::INVALID_MOAB_STATUS,
+          last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
+          last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
+        )
+
+        expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
+        po_handler.create_after_validation(true)
       end
 
       it 'includes invalid moab result' do

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -326,6 +326,24 @@ RSpec.describe PreservedObjectHandler do
               expect(pc.reload.size).to eq incoming_size
               expect(pc.size).not_to eq orig
             end
+            context 'caller has run checksum validation, original status was not ok' do
+              shared_examples 'POH#update_version_after_validation(true) sets status to "ok"' do |orig_status|
+                before { pc.update(status: orig_status) }
+                it 'status' do
+                  expect do
+                    po_handler.update_version_after_validation(true)
+                  end.to change { pc.reload.status }.from(orig_status).to('ok')
+                end
+              end
+
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "ok"', 'validity_unknown'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "ok"', 'online_moab_not_found'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "ok"', 'unexpected_version_on_storage'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "ok"', 'invalid_moab'
+
+              # TODO: should caller CV clear this?  does it CV the whole moab, or just the new version?
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "ok"', 'invalid_checksum'
+            end
           end
           context 'unchanged' do
             it 'size if incoming size is nil' do
@@ -334,10 +352,14 @@ RSpec.describe PreservedObjectHandler do
               po_handler.update_version_after_validation
               expect(pc.reload.size).to eq orig
             end
-            it 'status' do
-              po_handler.update_version_after_validation
-              expect(pc.reload).to be_validity_unknown
-              skip 'is there a scenario when status should change here?  See #431'
+            it 'status started validity_unknown and caller has not verified checksums' do
+              pc.update(status: 'validity_unknown')
+              expect { po_handler.update_version_after_validation }.not_to change { pc.reload.status }.from('validity_unknown')
+            end
+            it 'status started ok and caller has verified checksums' do
+              expect do
+                po_handler.update_version_after_validation(true)
+              end.not_to change { pc.reload.status }.from('ok')
             end
           end
         end
@@ -398,10 +420,24 @@ RSpec.describe PreservedObjectHandler do
               expect(pc.reload.last_moab_validation).to be > orig
             end
             it 'status' do
-              orig = pc.status
-              po_handler.update_version_after_validation
-              expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
-              expect(pc.status).not_to eq orig
+              expect do
+                po_handler.update_version_after_validation
+              end.to change { pc.reload.status }.from('ok').to('invalid_moab')
+            end
+            context 'caller has run checksum validation, original status was not ok' do
+              shared_examples 'POH#update_version_after_validation(true) sets status to "invalid_moab"' do |orig_status|
+                before { pc.update(status: orig_status) }
+                it 'status' do
+                  expect do
+                    po_handler.update_version_after_validation(true)
+                  end.to change { pc.reload.status }.from(orig_status).to('invalid_moab')
+                end
+              end
+
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "invalid_moab"', 'validity_unknown'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "invalid_moab"', 'online_moab_not_found'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "invalid_moab"', 'unexpected_version_on_storage'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "invalid_moab"', 'invalid_checksum'
             end
           end
           context 'unchanged' do
@@ -419,6 +455,19 @@ RSpec.describe PreservedObjectHandler do
               orig = pc.last_version_audit
               po_handler.update_version_after_validation
               expect(pc.reload.last_version_audit).to eq orig
+            end
+            context 'original status was invalid_moab' do
+              before { pc.update(status: 'invalid_moab') }
+              it 'status remains invalid_moab if caller has not verified checksums' do
+                expect do
+                  po_handler.update_version_after_validation
+                end.not_to change { pc.reload.status }.from('invalid_moab')
+              end
+              it 'status remains invalid_moab evne if caller has verified checksums' do
+                expect do
+                  po_handler.update_version_after_validation(true)
+                end.not_to change { pc.reload.status }.from('invalid_moab')
+              end
             end
           end
         end

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe PreservedObjectHandler do
 
     context 'in Catalog' do
       before do
-        po = PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
-        @pc = PreservedCopy.create!(
+        po = create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_prez_policy)
+        create(
+          :preserved_copy,
           preserved_object: po,
           version: po.current_version,
           size: 1,
@@ -63,10 +64,7 @@ RSpec.describe PreservedObjectHandler do
               expect(pc.reload.size).to eq orig
             end
             it 'status' do
-              orig = pc.status
-              po_handler.update_version
-              expect(pc.reload.status).to eq orig
-              skip 'is there a scenario when status should change here?  See #431'
+              expect { po_handler.update_version }.not_to change { pc.reload.status }.from('ok')
             end
             it 'last_moab_validation' do
               orig = pc.last_moab_validation
@@ -104,8 +102,7 @@ RSpec.describe PreservedObjectHandler do
 
       context 'PreservedCopy and PreservedObject versions do not match' do
         before do
-          @pc.version = @pc.version + 1
-          @pc.save!
+          pc.update(version: pc.version + 1)
         end
 
         it_behaves_like 'PreservedObject current_version does not match online PC version', :update_version, 3, 3, 2

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -339,7 +339,7 @@ RSpec.shared_examples 'PreservedObject current_version does not match online PC 
   let(:version_mismatch_msg) { "PreservedCopy online Moab version #{pc_v} does not match PreservedObject current_version #{po_v}" }
 
   it 'does not update PreservedCopy' do
-    orig = pc.updated_at
+    orig = pc.reload.updated_at
     po_handler.send(method_sym)
     expect(pc.reload.updated_at).to eq orig
   end


### PR DESCRIPTION
called out some things i wasn't sure about in TODO comments.  did a little refactoring that felt like it made existing tests a little easier to read, and that i thought made the new tests easier to read (by showing more clearly what differed from parent contexts).  also got rid of an instance var in the specs.

another open question besides the TODOs about what timestamps to update:  do we queue druids for CV in the methods that got modified here?  should we just always add that functionality?  or should we let regularly scheduled CV deal with that as it gets to the least recently checked objects continuously?  @julianmorley [said](https://github.com/sul-dlss/preservation_catalog/issues/817#issuecomment-396678967):
> Ideally, I'd like to see this set 'OK' on initial ingest (trust the Robots to not give us bad data) but then immediately add the new druid to the CV queue for validation (trust... but verify).

connects to #817
(doesn't close it, because we need to wire these changes up to controllers, and have robots pass the right values in their calls to the controllers)