### PR TITLE
Replace normalize_druid_name with more accurate validation

### DIFF
--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -4,28 +4,16 @@
 # represent a specific stored instance on a specific node, but aggregates
 # those instances.
 class PreservedObject < ApplicationRecord
+  PREFIX_RE = /druid:/i
   belongs_to :preservation_policy
   has_many :preserved_copies, dependent: :restrict_with_exception
-  validates :druid, presence: true, uniqueness: true, format: { with: DruidTools::Druid.pattern }
+  validates :druid,
+            presence: true,
+            uniqueness: true,
+            length: { is: 11 },
+            format: { with: /(?!#{PREFIX_RE})#{DruidTools::Druid.pattern}/ } # ?! group is a *negative* match
   validates :current_version, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :preservation_policy, null: false
-
-  def self.normalize_druid_name
-    targets = PreservedObject.where("druid LIKE 'druid:%'")
-    druids_no_prefix = targets.pluck(:druid).map { |d| d.split(':', 2).last }
-    targets_by_druid = targets.map { |rec| [rec.druid, rec] }.to_h
-    PreservedObject.where(druid: druids_no_prefix).pluck(:druid).each do |x|
-      po = targets_by_druid.delete("druid:#{x}")
-      ApplicationRecord.transaction do
-        po.preserved_copies.destroy_all
-        po.destroy
-      end
-    end
-    targets_by_druid.each_value do |po|
-      po.druid = po.druid.split(':', 2).last
-      po.save!
-    end
-  end
 
   # given a version, create any PreservedCopy records for that version which don't yet exist for archive
   #  endpoints which implement this PreservedObject's PreservationPolicy.

--- a/db/migrate/20180511210539_noramlize_druid_name.rb
+++ b/db/migrate/20180511210539_noramlize_druid_name.rb
@@ -1,5 +1,6 @@
 class NoramlizeDruidName < ActiveRecord::Migration[5.1]
   def change
-    PreservedObject.normalize_druid_name
+    # No longer possible to create invalid data as fixed by this removed method.
+    # PreservedObject.normalize_druid_name
   end
 end

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -20,89 +20,32 @@ RSpec.describe PreservedObject, type: :model do
 
   context 'validation' do
     it 'is valid with required attributes' do
-      po = PreservedObject.create(required_attributes)
-      expect(po).to be_valid
+      expect(described_class.new(required_attributes)).to be_valid
     end
-    it 'is not valid without attributes' do
-      expect(PreservedObject.new).not_to be_valid
+    it 'is not valid without all required attributes' do
+      expect(described_class.new).not_to be_valid
+      expect(described_class.new(current_version: 1)).not_to be_valid
     end
-    it 'is not valid without a druid' do
-      expect(PreservedObject.new(current_version: 1)).not_to be_valid
+    it 'with bad druid is invalid' do
+      expect(described_class.new(required_attributes.merge(druid: 'FOObarzubaz'))).not_to be_valid
+      expect(described_class.new(required_attributes.merge(druid: 'b123cd4567'))).not_to be_valid
+      expect(described_class.new(required_attributes.merge(druid: 'ab123cd45678'))).not_to be_valid
     end
-    it 'is not valid without a current_version' do
-      expect(PreservedObject.new(druid: 'ab123cd45678')).not_to be_valid
+    it 'with druid prefix is invalid' do
+      expect(described_class.new(required_attributes.merge(druid: 'druid:ab123cd4567'))).not_to be_valid
+      expect(described_class.new(required_attributes.merge(druid: 'DRUID:ab123cd4567'))).not_to be_valid
     end
-    it 'enforces unique constraint on druid (model level)' do
-      PreservedObject.create(required_attributes)
-      exp_err_msg = 'Validation failed: Druid has already been taken'
-      expect do
-        PreservedObject.create!(required_attributes)
-      end.to raise_error(ActiveRecord::RecordInvalid, exp_err_msg)
-    end
-    it 'enforces unique constraint on druid (db level)' do
-      PreservedObject.create(required_attributes)
-      dup_po = PreservedObject.new
-      dup_po.druid = 'ab123cd4567'
-      dup_po.current_version = 2
-      dup_po.preservation_policy = preservation_policy
-      expect { dup_po.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
-    end
-  end
 
-  describe '.normalize_druid_name' do
-    context 'druid with prefix created ex. (druid:xx000xx0000)' do
-      before do
-        po_with_prefix1 = create(:preserved_object, druid: 'druid:bb123cd4567')
-        create(:preserved_copy, preserved_object: po_with_prefix1, endpoint: Endpoint.first)
-        po_with_prefix2 = create(:preserved_object, druid: 'druid:ef891gh5300')
-        create(:preserved_copy, preserved_object: po_with_prefix2, endpoint: Endpoint.first)
+    describe 'enforces unique constraint on druid' do
+      before { described_class.create!(required_attributes) }
+
+      it 'at model level' do
+        msg = 'Validation failed: Druid has already been taken'
+        expect { described_class.create!(required_attributes) }.to raise_error(ActiveRecord::RecordInvalid, msg)
       end
-
-      context 'matching record already exists' do
-        before do
-          po = create(:preserved_object, druid: 'bb123cd4567')
-          create(:preserved_copy, preserved_object: po, endpoint: Endpoint.first)
-        end
-
-        it 'delete record w/ druid prefix' do
-          expect(PreservedObject.where(druid: 'druid:bb123cd4567')).to exist
-          expect(PreservedObject.where(druid: 'bb123cd4567')).to exist
-          PreservedObject.normalize_druid_name
-          expect(PreservedObject.where(druid: 'bb123cd4567')).to exist
-          expect(PreservedObject.where(druid: 'druid:bb123cd4567')).not_to exist
-        end
-      end
-      context 'matching record does not exist' do
-        it 'updates bb123cd4567' do
-          expect(PreservedObject.where(druid: 'druid:bb123cd4567')).to exist
-          expect(PreservedObject.where(druid: 'bb123cd4567')).not_to exist
-          PreservedObject.normalize_druid_name
-          expect(PreservedObject.where(druid: 'druid:bb123cd4567')).not_to exist
-          expect(PreservedObject.where(druid: 'bb123cd4567')).to exist
-        end
-        it 'updates ef891gh5300' do
-          expect(PreservedObject.where(druid: 'druid:ef891gh5300')).to exist
-          expect(PreservedObject.where(druid: 'ef891gh5300')).not_to exist
-          PreservedObject.normalize_druid_name
-          expect(PreservedObject.where(druid: 'ef891gh5300')).to exist
-          expect(PreservedObject.where(druid: 'druid:ef891gh5300')).not_to exist
-        end
-      end
-      context 'rolls back transaction' do
-        before do
-          po = create(:preserved_object, druid: 'bb123cd4567')
-          create(:preserved_copy, preserved_object: po, endpoint: Endpoint.first)
-        end
-
-        it 'pres obj is not deleted if pres copy cannot be deleted' do
-          po_to_delete = PreservedObject.where(druid: 'druid:bb123cd4567')
-          allow(PreservedObject).to receive(:where).with("druid LIKE 'druid:%'").and_return(po_to_delete)
-          allow(po_to_delete.first).to receive(:destroy).and_raise(ActiveRecord::ConnectionTimeoutError)
-          expect { PreservedObject.normalize_druid_name }.to raise_error
-          allow(PreservedObject).to receive(:where).and_call_original
-          expect(PreservedObject.where(druid: 'druid:bb123cd4567')).to exist
-          expect(PreservedObject.where(druid: 'bb123cd4567')).to exist
-        end
+      it 'at db level' do
+        dup_po = described_class.new(druid: 'ab123cd4567', current_version: 2, preservation_policy: preservation_policy)
+        expect { dup_po.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
       end
     end
   end


### PR DESCRIPTION
This method existed to correct previously inserted data (druids w/ prefixes), but it has served its purpose and is no longer needed.  The more comprehensive validation ensures that no more druid prefixes can be inserted (i.e. the method will never be needed again).

This also helps because one of the tests for the removed method was silently invalid: was catching generic `raise_error`, but the actual exception was coming from the mock, not the model!

Fixes #893