### PR TITLE
Re-write #create_archive_preserved_copies

### DIFF
--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -37,12 +37,9 @@ class PreservedObject < ApplicationRecord
       raise ArgumentError, "archive_vers (#{archive_vers}) must be between 0 and current_version (#{current_version})"
     end
 
-    ApplicationRecord.transaction do
-      Endpoint.which_need_archive_copy(druid, archive_vers).map do |ep|
-        PreservedCopy.create!(
-          preserved_object: self, version: archive_vers, endpoint: ep, status: PreservedCopy::UNREPLICATED_STATUS
-        )
-      end
+    params = Endpoint.which_need_archive_copy(druid, archive_vers).map do |ep|
+      { version: archive_vers, endpoint: ep, status: PreservedCopy::UNREPLICATED_STATUS }
     end
+    preserved_copies.create!(params)
   end
 end

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -161,23 +161,5 @@ RSpec.describe PreservedObject, type: :model do
         expect { po.create_archive_preserved_copies(version) }.not_to raise_error
       end
     end
-
-    it 'creates the pres copies in a transaction and allows exceptions to bubble up' do
-      new_archive_ep.preservation_policies = [PreservationPolicy.default_policy]
-      allow(PreservedCopy).to receive(:create!).with(
-        preserved_object: po,
-        version: current_version,
-        endpoint: new_archive_ep,
-        status: PreservedCopy::UNREPLICATED_STATUS
-      ).and_raise(ActiveRecord::ConnectionTimeoutError)
-
-      # would do `expect { }.not_to(change { })`, but the raised error doesn't play nicely with that construct
-      exp_ep_list = %w[mock_archive1 mock_archive2]
-      expect(Endpoint.which_need_archive_copy(druid, current_version).pluck(:endpoint_name).sort).to eq exp_ep_list
-      expect do
-        po.create_archive_preserved_copies(current_version)
-      end.to raise_error(ActiveRecord::ConnectionTimeoutError)
-      expect(Endpoint.which_need_archive_copy(druid, current_version).pluck(:endpoint_name).sort).to eq exp_ep_list
-    end
   end
 end


### PR DESCRIPTION
Create the preserved_copies through PreservedObject. No need to do `preserved_object: self`. 
Also the active record `create!` has transaction-ality, so you don't need to add another transaction here.