### PR TITLE
[WIP] Replace #which_need_archive_copy and #create_archive_preserved_copies

### DIFF
--- a/spec/factories/endpoint.rb
+++ b/spec/factories/endpoint.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     endpoint_node 'localhost'
     storage_location { "spec/fixtures/#{endpoint_name}/sdr2objects" }
     endpoint_type # default online
+    preservation_policies { [PreservationPolicy.default_policy] }
   end
 
   factory :archive_endpoint, parent: :endpoint do


### PR DESCRIPTION
WIP - likely will be closed in favor of a diff PR after db refactor

The new logic operates in a more comprehensible and discernible manner.
- No more arel_table subquery across potentially millions of records
- `create_archive_preserved_copies!` now handles backfilling for ALL version on ALL endpoints
- `Endpoint.ids_to_versions_found` issues a single query and returns a simple data structure (Hash), independently tested, representing all targeted endpoints and the versions already found. That allows PO to iterate through per endpoint, make a single array/set comparison and know what the "missing" PCs are. All missing PCs are populated in a single `create!` statement.

Fixes #899 
Affects #915