### PR TITLE
Remove unneeded explicit flush calls

### DIFF
--- a/lib/tasks/c2m_tasks.rake
+++ b/lib/tasks/c2m_tasks.rake
@@ -21,7 +21,6 @@ namespace :c2m do
       p "You've entered an incorrect timestamp format #{last_checked}."
       p "Please enter correct timestamp format (UTC) (2018-02-01T18:54:48Z)"
     end
-    $stdout.flush
   end
 
   desc "Run C2M version checks on all storage roots"
@@ -43,6 +42,5 @@ namespace :c2m do
       p "You've entered an incorrect timestamp format #{last_checked}."
       p "Please enter correct timestamp format (UTC) (2018-02-01T18:54:48Z)"
     end
-    $stdout.flush
   end
 end

--- a/lib/tasks/cv_tasks.rake
+++ b/lib/tasks/cv_tasks.rake
@@ -14,7 +14,6 @@ namespace :cv do
       Audit::Checksum.validate_disk(storage_root)
     end
     puts "#{Time.now.utc.iso8601} Checksum Validation on #{storage_root} is done."
-    $stdout.flush
   end
 
   desc "Run CV (checksum validation) on all storage roots"
@@ -29,22 +28,18 @@ namespace :cv do
     elsif args[:profile].nil?
       Audit::Checksum.validate_disk_all_endpoints
     end
-    puts "#{Time.now.utc.iso8601} Checksum Validation on all storage roots are done."
-    $stdout.flush
+    puts "#{Time.now.utc.iso8601} Checksum Validation on all storage roots is done."
   end
 
   desc "Run CV (checksum validation) on a single druid"
   task :druid, [:druid] => [:environment] do |_t, args|
     druid = args[:druid].to_sym
-
     cv_results_lists = Audit::Checksum.validate_druid(druid)
     cv_results_lists.each do |aud_res|
       puts aud_res.to_json unless aud_res.contains_result_code?(AuditResults::MOAB_CHECKSUM_VALID)
     end
 
     puts "#{Time.now.utc.iso8601} Checksum Validation on #{druid} is done."
-    $stdout.flush
-
     # exit with non-zero status if any of the pres copies failed checksum validation
     exit 1 if cv_results_lists.detect { |aud_res| !aud_res.contains_result_code?(AuditResults::MOAB_CHECKSUM_VALID) }
   end
@@ -54,7 +49,6 @@ namespace :cv do
     druid_list_file_path = args[:file_path]
     puts "#{Time.now.utc.iso8601} Checksum Validation on the list of druids from #{druid_list_file_path} has started"
     Audit::Checksum.validate_list_of_druids(druid_list_file_path)
-    puts "#{Time.now.utc.iso8601} Checksum Validation on the list of druids from #{druid_list_file_path} has finished."
-    $stdout.flush
+    puts "#{Time.now.utc.iso8601} Checksum Validation on the list of druids from #{druid_list_file_path} is done."
   end
 end

--- a/lib/tasks/m2c_tasks.rake
+++ b/lib/tasks/m2c_tasks.rake
@@ -17,7 +17,6 @@ namespace :m2c do
       Audit::MoabToCatalog.seed_catalog_for_all_storage_roots
     end
     puts "#{Time.now.utc.iso8601} Seeding the catalog for all storage roots is done"
-    $stdout.flush
   end
 
   desc "Delete a single storage root's db data"
@@ -71,7 +70,6 @@ namespace :m2c do
     $stdout.flush # sometimes above is not visible (flushed) until last puts (when run finishes)
     Audit::MoabToCatalog.check_existence_for_druid(args[:druid])
     puts "#{Time.now.utc.iso8601} Moab to Catalog Existence Check for #{args[:druid]} is done"
-    $stdout.flush
   end
 
   desc "Run M2C existence/version checks on a list of druids"
@@ -79,8 +77,7 @@ namespace :m2c do
     druid_list_file_path = args[:file_path]
     puts "#{Time.now.utc.iso8601} Moab to Catalog Existence Check on the list of druids from #{druid_list_file_path} has started"
     Audit::MoabToCatalog.check_existence_for_druid_list(druid_list_file_path)
-    puts "#{Time.now.utc.iso8601} Moab to Catalog Existence Check on the list of druids from #{druid_list_file_path} has finished"
-    $stdout.flush
+    puts "#{Time.now.utc.iso8601} Moab to Catalog Existence Check on the list of druids from #{druid_list_file_path} is done"
   end
 
   desc "Run M2C existence/version checks on a single storage root"
@@ -101,7 +98,6 @@ namespace :m2c do
       Audit::MoabToCatalog.check_existence_for_dir(storage_dir)
     end
     puts "#{Time.now.utc.iso8601} Moab to Catalog Existence Check for #{storage_dir} is done"
-    $stdout.flush
   end
 
   desc "Run M2C existence/version checks on all storage roots"
@@ -117,7 +113,6 @@ namespace :m2c do
     elsif args[:profile].nil?
       Audit::MoabToCatalog.check_existence_for_all_storage_roots
     end
-    puts "#{Time.now.utc.iso8601} Moab to Catalog Existence Check for all storage roots are done"
-    $stdout.flush
+    puts "#{Time.now.utc.iso8601} Moab to Catalog Existence Check for all storage roots is done"
   end
 end


### PR DESCRIPTION
A follow-up after looking at rake tasks from Naomi's PR.

While maybe flushing is required internal to a task, it is not going to help anything at the end of a task, where the job is about to complete anyway.

Also standardized some log language ("done" was more common, instead of "finished") and corrected singular/plural language.