### PR TITLE
Cv by root by status

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,6 +106,7 @@ Metrics/LineLength:
     - 'lib/tasks/m2c_tasks.rake'
     - 'spec/controllers/catalog_controller_spec.rb'
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # 1 line 126
+    - 'spec/lib/audit/checksum_spec.rb'
     - 'spec/models/endpoint_spec.rb' # line 83 is 123
     - 'spec/services/audit_results_spec.rb'
     - 'spec/services/checksum_validator_spec.rb'

--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ RAILS_ENV=production bundle exec rake cv:druid[bz514sm9647]
 RAILS_ENV=production bundle exec rake cv:druid_list[/file/path/to/your/csv/druid_list.csv]
 ```
 
+### Druids with a particular status on a particular storage root
+
+For example, if you wish to run CV on all the "validity_unknown" druids on storage root 15:
+
+```sh
+bundle exec rails r -e production "Audit::Checksum.validate_status_root(:validity_unknown, :services-disk15)"
+```
+
+[Valid status strings](https://github.com/sul-dlss/preservation_catalog/blob/master/app/models/preserved_copy.rb#L1-L10)
+
 ## Seed the catalog
 
 Seeding the catalog presumes an empty or nearly empty database -- otherwise running the seed task will throw `druid NOT expected to exist in catalog but was found` errors for each found object.
@@ -309,6 +319,13 @@ Audit::Checksum.validate_druid('xx000xx0000')
 ```ruby
 Audit::Checksum.validate_list_of_druids('/path/to/your/csv/druid_list.csv')
 ```
+
+#### Druids with a particular status on a particular storage root
+```ruby
+Audit::Checksum.validate_status_root('validity_unknown', 'services-disk15')
+```
+
+[Valid status strings](https://github.com/sul-dlss/preservation_catalog/blob/master/app/models/preserved_copy.rb#L1-L10)
 
 ## Development
 


### PR DESCRIPTION
Fixes #914 (easy way to run CV for objects with certain status on certain storage root)

Connects to #912 (confirm workflow errors cleared by M2C, C2M) as it will make it really easy to test that for a significant number of druids.