### PR TITLE
DruidVersionZip logic for chunks

### DIFF
--- a/app/models/druid_version_zip.rb
+++ b/app/models/druid_version_zip.rb
@@ -96,7 +96,7 @@ class DruidVersionZip
   # @see #work_dir
   # @return [String] shell command to create this zip
   def zip_command
-    "zip -vr0X -s 10g #{file_path} #{druid.id}/#{v_version}"
+    "zip -vr0X -sv -s #{zip_split_size} #{file_path} #{druid.id}/#{v_version}"
   end
 
   # We presume the system guts do not change underneath a given class instance.
@@ -116,6 +116,11 @@ class DruidVersionZip
     end
     return match[1] if match && match[1].present?
     raise 'No version info matched from `zip -v` ouptut'
+  end
+
+  # @return [String] the option included with "zip -s"
+  def zip_split_size
+    '10g'
   end
 
   def zip_version_regexp

--- a/spec/models/druid_version_zip_spec.rb
+++ b/spec/models/druid_version_zip_spec.rb
@@ -54,7 +54,7 @@ describe DruidVersionZip do
       before { allow(dvz).to receive(:zip_command).and_return(zip_command) }
 
       context 'when inpath is incorrect' do
-        let(:zip_command) { "zip -vr0X -s 10g #{zip_path} /wrong/path" }
+        let(:zip_command) { "zip -vr0X -sv -s 10g #{zip_path} /wrong/path" }
 
         it 'raises error' do
           expect { dvz.create_zip! }.to raise_error(RuntimeError, %r{zipmaker failure.*/wrong/path})
@@ -70,7 +70,7 @@ describe DruidVersionZip do
       end
 
       context 'if the utility "moved"' do
-        let(:zip_command) { "zap -vr0X -s 10g #{zip_path} #{druid}/v0003" }
+        let(:zip_command) { "zap -vr0X -sv -s 10g #{zip_path} #{druid}/v0003" }
 
         it 'raises error' do
           expect { dvz.create_zip! }.to raise_error(Errno::ENOENT, /No such file/)
@@ -116,7 +116,7 @@ describe DruidVersionZip do
     let(:zip_path) { '/tmp/bj/102/hs/9687/bj102hs9687.v0001.zip' }
 
     it 'returns zip string to execute for this druid/version' do
-      expect(dvz.zip_command).to eq "zip -vr0X -s 10g #{zip_path} bj102hs9687/v0001"
+      expect(dvz.zip_command).to eq "zip -vr0X -sv -s 10g #{zip_path} bj102hs9687/v0001"
     end
   end
 


### PR DESCRIPTION
Add DVZ methods #parts and #expected_parts.  Because we will only be able to store the **count** of parts in the S3 metadata, we need a way of reconstructing what filename is expected to correspond to part X of N, or the whole set of N filenames, as here.

This logic will be utilized after workers are converted subsequent to the PC model split.