### PR TITLE
Pohandler spec refactor

### DIFF
--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -400,19 +400,15 @@ RSpec.describe PreservedObjectHandler do
       end
 
       it 'calls PreservedCopy.save! (but not PreservedObject.save!) if the existing record is NOT altered' do
-        po_handler = described_class.new(druid, 1, 1, ep)
-        po = instance_double(PreservedObject)
-        pc = instance_double(PreservedCopy)
+        druid = 'zy987xw6543'
+        po = create :preserved_object, druid: druid
         allow(PreservedObject).to receive(:find_by!).with(druid: druid).and_return(po)
-        allow(po).to receive(:current_version).and_return(1)
-        allow(po).to receive(:save!)
+        pc = create :preserved_copy, preserved_object: po
         allow(PreservedCopy).to receive(:find_by!).with(preserved_object: po, endpoint: ep).and_return(pc)
-        allow(pc).to receive(:matches_po_current_version?).and_return(true)
-        allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
-        allow(pc).to receive(:version).and_return(1)
-        allow(pc).to receive(:update_audit_timestamps)
-        allow(pc).to receive(:changed?).and_return(false)
+
+        allow(po).to receive(:save!)
         allow(pc).to receive(:save!)
+        po_handler = described_class.new(druid, 1, 1, ep)
         po_handler.check_existence
         expect(po).not_to have_received(:save!)
         expect(pc).to have_received(:save!)

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -13,23 +13,26 @@ RSpec.describe PreservedObjectHandler do
   let(:ep) { Endpoint.find_by(storage_location: storage_dir) }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ep) }
   let(:exp_msg) { "added object to db as it did not exist" }
+  let(:po_args) do
+    {
+      druid: druid,
+      current_version: incoming_version,
+      preservation_policy_id: PreservationPolicy.default_policy.id
+    }
+  end
+  let(:pc_args) do
+    {
+      preserved_object: an_instance_of(PreservedObject), # TODO: ensure we got the preserved object that we expected
+      version: incoming_version,
+      size: incoming_size,
+      endpoint: ep,
+      status: PreservedCopy::VALIDITY_UNKNOWN_STATUS # NOTE: ensuring this particular status is the default
+      # NOTE: lack of validation timestamps here
+    }
+  end
 
   describe '#create' do
     it 'creates PreservedObject and PreservedCopy in database' do
-      po_args = {
-        druid: druid,
-        current_version: incoming_version,
-        preservation_policy_id: PreservationPolicy.default_policy.id
-      }
-      pc_args = {
-        preserved_object: an_instance_of(PreservedObject), # TODO: ensure we got the preserved object that we expected
-        version: incoming_version,
-        size: incoming_size,
-        endpoint: ep,
-        status: PreservedCopy::VALIDITY_UNKNOWN_STATUS # NOTE: ensuring this particular status
-        # NOTE: lack of validation timestamps here
-      }
-
       expect(PreservedObject).to receive(:create!).with(po_args).and_call_original
       expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
       po_handler.create
@@ -114,20 +117,11 @@ RSpec.describe PreservedObjectHandler do
     end
 
     it 'creates PreservedObject and PreservedCopy in database when there are no validation errors' do
-      po_args = {
-        druid: valid_druid,
-        current_version: incoming_version,
-        preservation_policy_id: PreservationPolicy.default_policy.id
-      }
-      pc_args = {
-        preserved_object: an_instance_of(PreservedObject), # TODO: ensure we got the preserved object that we expected
-        version: incoming_version,
-        size: incoming_size,
-        endpoint: ep,
-        status: PreservedCopy::VALIDITY_UNKNOWN_STATUS, # NOTE ensuring this particular status
+      po_args[:druid] = valid_druid
+      pc_args.merge!(
         last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
         last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
-      }
+      )
 
       expect(PreservedObject).to receive(:create!).with(po_args).and_call_original
       expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
@@ -159,20 +153,12 @@ RSpec.describe PreservedObjectHandler do
       end
 
       it 'creates PreservedObject and PreservedCopy with "invalid_moab" status in database' do
-        po_args = {
-          druid: invalid_druid,
-          current_version: incoming_version,
-          preservation_policy_id: PreservationPolicy.default_policy.id
-        }
-        pc_args = {
-          preserved_object: an_instance_of(PreservedObject), # TODO: ensure we got the preserved object that we expected
-          version: incoming_version,
-          size: incoming_size,
-          endpoint: ep,
-          status: PreservedCopy::INVALID_MOAB_STATUS, # NOTE ensuring this particular status
+        po_args[:druid] = invalid_druid
+        pc_args.merge!(
+          status: PreservedCopy::INVALID_MOAB_STATUS,
           last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
           last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
-        }
+        )
 
         expect(PreservedObject).to receive(:create!).with(po_args).and_call_original
         expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -123,19 +123,12 @@ RSpec.describe PreservedObjectHandler do
           context 'ActiveRecordError' do
             let(:results) do
               allow(Rails.logger).to receive(:log)
-              po = instance_double('PreservedObject')
-              allow(po).to receive(:current_version).and_return(1)
+              po = instance_double('PreservedObject', current_version: 1)
               allow(PreservedObject).to receive(:find_by!).with(druid: druid).and_return(po)
-              pc = instance_double('PreservedCopy')
+              pc = create :preserved_copy
               allow(PreservedCopy).to receive(:find_by!).with(preserved_object: po, endpoint: ep).and_return(pc)
-              allow(pc).to receive(:version).and_return(1)
-              allow(pc).to receive(:upd_audstamps_version_size)
-              allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
-              allow(pc).to receive(:status=)
-              allow(pc).to receive(:update_audit_timestamps)
-              allow(pc).to receive(:changed?).and_return(true)
+
               allow(pc).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
-              allow(pc).to receive(:matches_po_current_version?).and_return(true)
               po_handler.update_version
             end
 
@@ -156,22 +149,12 @@ RSpec.describe PreservedObjectHandler do
           context 'ActiveRecordError' do
             let(:results) do
               allow(Rails.logger).to receive(:log)
-              po = instance_double('PreservedObject')
-              allow(po).to receive(:current_version).and_return(5)
-              allow(po).to receive(:current_version=).with(incoming_version)
-              allow(po).to receive(:changed?).and_return(true)
-              allow(po).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+              po = create :preserved_object, current_version: 5
               allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-              pc = instance_double('PreservedCopy')
+              pc = create :preserved_copy
               allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
-              allow(pc).to receive(:version).and_return(5)
-              allow(pc).to receive(:upd_audstamps_version_size).with(boolean, incoming_version, incoming_size)
-              allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
-              allow(pc).to receive(:status=)
-              allow(pc).to receive(:update_audit_timestamps)
-              allow(pc).to receive(:changed?).and_return(true)
-              allow(pc).to receive(:save!)
-              allow(pc).to receive(:matches_po_current_version?).and_return(true)
+
+              allow(po).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
               po_handler.update_version
             end
 
@@ -191,43 +174,26 @@ RSpec.describe PreservedObjectHandler do
       end
 
       it 'calls PreservedObject.save! and PreservedCopy.save! if the records are altered' do
-        po = instance_double(PreservedObject)
+        po = create :preserved_object
         allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-        allow(po).to receive(:current_version).and_return(1)
-        allow(po).to receive(:current_version=).with(incoming_version)
-        allow(po).to receive(:changed?).and_return(true)
-        allow(po).to receive(:save!)
-        pc = instance_double(PreservedCopy)
+        pc = create :preserved_copy
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
-        allow(pc).to receive(:version).and_return(1)
-        allow(pc).to receive(:upd_audstamps_version_size).with(boolean, incoming_version, incoming_size)
-        allow(pc).to receive(:endpoint).with(ep)
-        allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
-        allow(pc).to receive(:status=)
-        allow(pc).to receive(:update_audit_timestamps)
-        allow(pc).to receive(:changed?).and_return(true)
+
+        allow(po).to receive(:save!)
         allow(pc).to receive(:save!)
-        allow(pc).to receive(:matches_po_current_version?).and_return(true)
         po_handler.update_version
         expect(po).to have_received(:save!)
         expect(pc).to have_received(:save!)
       end
 
       it 'does not call PreservedObject.save when PreservedCopy only has timestamp updates' do
-        po = instance_double(PreservedObject)
+        po = create :preserved_object
         allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-        allow(po).to receive(:current_version).and_return(1)
-        allow(po).to receive(:touch)
-        allow(po).to receive(:save!)
-        pc = instance_double(PreservedCopy)
+        pc = create :preserved_copy
         allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
-        allow(pc).to receive(:version).and_return(1)
-        allow(pc).to receive(:endpoint).with(ep)
-        allow(pc).to receive(:update_audit_timestamps)
-        allow(pc).to receive(:update_status)
-        allow(pc).to receive(:changed?).and_return(true)
+
+        allow(po).to receive(:save!)
         allow(pc).to receive(:save!)
-        allow(pc).to receive(:matches_po_current_version?).and_return(true)
         po_handler = described_class.new(druid, 1, 1, ep)
         po_handler.update_version
         expect(po).not_to have_received(:save!)
@@ -422,21 +388,14 @@ RSpec.describe PreservedObjectHandler do
         end
 
         it 'does not call PreservedObject.save! when PreservedCopy only has timestamp updates' do
-          po = instance_double(PreservedObject)
+          po = create :preserved_object
           allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-          allow(po).to receive(:save!)
-          pc = instance_double(PreservedCopy)
+          pc = create :preserved_copy
           allow(PreservedCopy).to receive(:find_by).with(preserved_object: po, endpoint: ep).and_return(pc)
-          allow(pc).to receive(:version).and_return(1)
-          allow(pc).to receive(:version=).with(incoming_version)
-          allow(pc).to receive(:size=).with(incoming_size)
-          allow(pc).to receive(:endpoint).with(ep)
-          allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
-          allow(pc).to receive(:update_status)
-          allow(pc).to receive(:update_audit_timestamps)
-          allow(pc).to receive(:changed?).and_return(true)
-          allow(pc).to receive(:save!)
           allow(po_handler).to receive(:moab_validation_errors).and_return(['foo'])
+
+          allow(po).to receive(:save!)
+          allow(pc).to receive(:save!)
           po_handler.update_version_after_validation
           expect(po).not_to have_received(:save!)
           expect(pc).to have_received(:save!)
@@ -474,19 +433,12 @@ RSpec.describe PreservedObjectHandler do
             context 'ActiveRecordError' do
               let(:results) do
                 allow(Rails.logger).to receive(:log)
-                po = instance_double('PreservedObject')
-                allow(po).to receive(:current_version).and_return(1)
+                po = instance_double(PreservedObject, current_version: 1)
                 allow(PreservedObject).to receive(:find_by!).with(druid: druid).and_return(po)
-                pc = instance_double('PreservedCopy')
+                pc = create :preserved_copy
                 allow(PreservedCopy).to receive(:find_by!).with(preserved_object: po, endpoint: ep).and_return(pc)
-                allow(pc).to receive(:version).and_return(1)
-                allow(pc).to receive(:version=)
-                allow(pc).to receive(:status).and_return(PreservedCopy::OK_STATUS)
-                allow(pc).to receive(:update_status)
-                allow(pc).to receive(:update_audit_timestamps)
-                allow(pc).to receive(:changed?).and_return(true)
+
                 allow(pc).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
-                allow(pc).to receive(:size=)
                 po_handler.update_version_after_validation
               end
 

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe PreservedObjectHandler do
 
     context 'in Catalog' do
       before do
-        po = PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
-        @pc = PreservedCopy.create!(
+        po = create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_prez_policy)
+        create(
+          :preserved_copy,
           preserved_object: po,
           version: po.current_version,
           size: 1,
@@ -63,10 +64,7 @@ RSpec.describe PreservedObjectHandler do
               expect(pc.reload.size).to eq orig
             end
             it 'status' do
-              orig = pc.status
-              po_handler.update_version
-              expect(pc.reload.status).to eq orig
-              skip 'is there a scenario when status should change here?  See #431'
+              expect { po_handler.update_version }.not_to change { pc.reload.status }.from('ok')
             end
             it 'last_moab_validation' do
               orig = pc.last_moab_validation
@@ -104,8 +102,7 @@ RSpec.describe PreservedObjectHandler do
 
       context 'PreservedCopy and PreservedObject versions do not match' do
         before do
-          @pc.version = @pc.version + 1
-          @pc.save!
+          pc.update(version: pc.version + 1)
         end
 
         it_behaves_like 'PreservedObject current_version does not match online PC version', :update_version, 3, 3, 2

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -75,11 +75,7 @@ RSpec.shared_examples 'PreservedCopy does not exist' do |method_sym|
   let(:exp_msg) { "#<ActiveRecord::RecordNotFound: foo> db object does not exist" }
   let(:results) do
     allow(Rails.logger).to receive(:log)
-    po = instance_double(PreservedObject)
-    allow(po).to receive(:current_version).and_return(2)
-    allow(po).to receive(:current_version=)
-    allow(po).to receive(:changed?).and_return(true)
-    allow(po).to receive(:save!)
+    po = create :preserved_object, current_version: 2
     allow(PreservedObject).to receive(:find_by!).and_return(po)
     allow(PreservedCopy).to receive(:find_by!).and_raise(ActiveRecord::RecordNotFound, 'foo')
     po_handler.send(method_sym)

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -339,7 +339,7 @@ RSpec.shared_examples 'PreservedObject current_version does not match online PC 
   let(:version_mismatch_msg) { "PreservedCopy online Moab version #{pc_v} does not match PreservedObject current_version #{po_v}" }
 
   it 'does not update PreservedCopy' do
-    orig = pc.updated_at
+    orig = pc.reload.updated_at
     po_handler.send(method_sym)
     expect(pc.reload.updated_at).to eq orig
   end


### PR DESCRIPTION
These refactorings, which should be easy to review, were done to clear the way to adding an argument to some of the pohandler methods.  @jmartin-sul did some of them.

We need to add the argument for #817 - robots creating/updating preserved copies with status ok (instead of invalid_checksum).  I have a branch in progress for that but it still needs more love