### PR TITLE
Why isn't resque picking up the redis url?

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,7 +18,7 @@ set :deploy_to, "/opt/app/pres/#{fetch(:application)}"
 # set :pty, true
 
 # Default value for :linked_files is []
-append :linked_files, "config/database.yml" # , "config/secrets.yml"
+append :linked_files, "config/database.yml", "config/resque.yml"
 
 # Default value for linked_dirs is []
 append :linked_dirs, "log", "config/settings" # , "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"


### PR DESCRIPTION
  Because there was no symlink set to resque.yml in `shared_configs`.

  Fixes #928 