### PR TITLE
Introduce resque-pool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'puma', '~> 3.7' # app server
 gem 'rails', '~> 5.1.3'
 gem 'resque', '~> 1.27'
 gem 'resque-lock' # deduplication of worker queue jobs
+gem 'resque-pool'
 gem 'ruby-prof' # to profile methods
 gem 'whenever' # manage cron for audit checks
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,9 @@ GEM
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
     resque-lock (1.1.0)
+    resque-pool (0.6.0)
+      rake
+      resque (~> 1.22)
     retries (0.0.5)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
@@ -373,6 +376,7 @@ DEPENDENCIES
   rails-controller-testing
   resque (~> 1.27)
   resque-lock
+  resque-pool
   rspec-rails (~> 3.6)
   rubocop (~> 0.50.0)
   rubocop-rspec

--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,0 +1,9 @@
+# EXAMPLE
+# In production, this file should be controlled per machine via shared_configs to accomplish task segregation.
+#
+# These are queue names (like would be passed as QUEUES=... rake resque:work)
+# and the count of workers that should be spun up to service them.
+checksum_validation: 3
+endpoint_events: 4
+"s3_us_east_1_delivery,s3_us_west_2_delivery": 6
+"zipmaker,zips_made": 4

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -1,2 +1,10 @@
 require 'resque/tasks'
 task 'resque:setup' => :environment
+
+require 'resque/pool/tasks'
+task "resque:pool:setup" do
+  ActiveRecord::Base.connection.disconnect! # close any sockets or files in pool manager
+  Resque::Pool.after_prefork do |_job|
+    ActiveRecord::Base.establish_connection # and re-open them in the resque worker parent
+  end
+end


### PR DESCRIPTION
This allows configuration of the number of workers to service each queue (by name).

Run with the (example) `resque-pool.yml` config:
```
$ bundle exec rake resque:pool
resque-pool-worker[preservation_catalog][6079]: Starting worker DN0a286.SUNet:6079:checksum_validation
resque-pool-worker[preservation_catalog][6080]: Starting worker DN0a286.SUNet:6080:checksum_validation
resque-pool-worker[preservation_catalog][6081]: Starting worker DN0a286.SUNet:6081:checksum_validation
resque-pool-worker[preservation_catalog][6082]: Starting worker DN0a286.SUNet:6082:endpoint_events
resque-pool-worker[preservation_catalog][6083]: Starting worker DN0a286.SUNet:6083:endpoint_events
resque-pool-worker[preservation_catalog][6084]: Starting worker DN0a286.SUNet:6084:endpoint_events
resque-pool-worker[preservation_catalog][6085]: Starting worker DN0a286.SUNet:6085:endpoint_events
resque-pool-worker[preservation_catalog][6086]: Starting worker DN0a286.SUNet:6086:s3_us_east_1_delivery,s3_us_west_2_delivery
resque-pool-worker[preservation_catalog][6087]: Starting worker DN0a286.SUNet:6087:s3_us_east_1_delivery,s3_us_west_2_delivery
resque-pool-worker[preservation_catalog][6088]: Starting worker DN0a286.SUNet:6088:s3_us_east_1_delivery,s3_us_west_2_delivery
resque-pool-worker[preservation_catalog][6089]: Starting worker DN0a286.SUNet:6089:s3_us_east_1_delivery,s3_us_west_2_delivery
resque-pool-worker[preservation_catalog][6090]: Starting worker DN0a286.SUNet:6090:s3_us_east_1_delivery,s3_us_west_2_delivery
resque-pool-worker[preservation_catalog][6091]: Starting worker DN0a286.SUNet:6091:s3_us_east_1_delivery,s3_us_west_2_delivery
resque-pool-worker[preservation_catalog][6092]: Starting worker DN0a286.SUNet:6092:zipmaker,zips_made
resque-pool-worker[preservation_catalog][6093]: Starting worker DN0a286.SUNet:6093:zipmaker,zips_made
resque-pool-worker[preservation_catalog][6094]: Starting worker DN0a286.SUNet:6094:zipmaker,zips_made
resque-pool-manager[preservation_catalog][6066]: started manager
resque-pool-worker[preservation_catalog][6095]: Starting worker DN0a286.SUNet:6095:zipmaker,zips_made
resque-pool-manager[preservation_catalog][6066]: Pool contains worker PIDs: [6079, 6080, 6081, 6082, 6083, 6084, 6085, 6086, 6087, 6088, 6089, 6090, 6091, 6092, 6093, 6094, 6095]

^C
resque-pool-manager[preservation_catalog][6066]: Tried to reap worker [6071], but it had already died. (status: )
resque-pool-manager[preservation_catalog][6066]: Tried to reap worker [6068], but it had already died. (status: )
resque-pool-manager[preservation_catalog][6066]: INT: immediate shutdown (graceful worker shutdown)
resque-pool-manager[preservation_catalog][6066]: Sending QUIT to all workers
resque-pool-manager[preservation_catalog][6066]: manager finished
```