### PR TITLE
Fix archive pres copy creation (depends on #956, #954)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,6 +110,7 @@ Metrics/LineLength:
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # 1 line 126
     - 'spec/lib/audit/checksum_spec.rb'
     - 'spec/models/endpoint_spec.rb' # line 83 is 123
+    - 'spec/models/archive_endpoint_spec.rb' # tests about have/need scopes are easier to skim with all expectations being one line
     - 'spec/services/audit_results_spec.rb'
     - 'spec/services/checksum_validator_spec.rb'
     - 'spec/services/preserved_object_handler_check_exist_spec.rb' # 17 lines, but who's counting, officer?
@@ -167,6 +168,8 @@ RSpec/MessageSpies:
 
 RSpec/MultipleExpectations:
   Max: 5
+  Exclude:
+    - 'spec/models/archive_endpoint_spec.rb' # testing queries by adding records and scope results based on different input combos
 
 RSpec/NamedSubject:
   Enabled: false

--- a/app/models/archive_endpoint.rb
+++ b/app/models/archive_endpoint.rb
@@ -21,21 +21,16 @@ class ArchiveEndpoint < ApplicationRecord
     joins(preservation_policies: [:preserved_objects]).where(preserved_objects: { druid: druid })
   }
 
-  # TODO: straight port of the scope from the old Endpoint class
-  scope :which_need_archive_copy, lambda { |druid, version|
-    # testing indicates that the Arel::Table#eq will cast the input to the appropriate type for us.  i didn't
-    # didn't see that documented, so i'm casting version.to_i to be safe (since we're not using the usual bind
-    # variable machinery).  just trying to be extra cautious about injection attacks.  we shouldn't have to
-    # worry about druid, since it gets passed via the usual ActiveRecord bind var machinery.
-    apc_table = ArchivePreservedCopy.arel_table
-    aep_table = ArchiveEndpoint.arel_table
-    endpoint_has_pres_copy_subquery =
-      ArchivePreservedCopy.where(
-        apc_table[:archive_endpoint_id].eq(aep_table[:id])
-          .and(apc_table[:version].eq(version.to_i))
-      ).exists
+  scope :which_have_archive_copy, lambda { |druid, version|
+    joins(archive_preserved_copies: [:preserved_object])
+      .where(
+        preserved_objects: { druid: druid },
+        archive_preserved_copies: { version: version }
+      )
+  }
 
-    archive_targets(druid).where.not(endpoint_has_pres_copy_subquery)
+  scope :which_need_archive_copy, lambda { |druid, version|
+    archive_targets(druid).where.not(id: which_have_archive_copy(druid, version))
   }
 
   # iterates over the archive endpoints enumerated in settings, creating an ArchiveEndpoint for each if one doesn't

--- a/app/models/archive_endpoint.rb
+++ b/app/models/archive_endpoint.rb
@@ -16,11 +16,12 @@ class ArchiveEndpoint < ApplicationRecord
   # TODO: after switching to string, validate that input resolves to class which #is_a class of the right type?
   validates :delivery_class, presence: true
 
-  # for the given druid, which archive endpoints should have archive copies?
+  # for the given druid, which archive endpoints should have archive copies, as per the preservation_policy?
   scope :archive_targets, lambda { |druid|
     joins(preservation_policies: [:preserved_objects]).where(preserved_objects: { druid: druid })
   }
 
+  # for a given druid, which archive endpoints have an archive copy of the given version?
   scope :which_have_archive_copy, lambda { |druid, version|
     joins(archive_preserved_copies: [:preserved_object])
       .where(
@@ -29,6 +30,7 @@ class ArchiveEndpoint < ApplicationRecord
       )
   }
 
+  # for a given version of a druid, which archive endpoints need an archive copy, based on the governing pres policy?
   scope :which_need_archive_copy, lambda { |druid, version|
     archive_targets(druid).where.not(id: which_have_archive_copy(druid, version))
   }

--- a/app/models/archive_preserved_copy.rb
+++ b/app/models/archive_preserved_copy.rb
@@ -9,6 +9,7 @@ class ArchivePreservedCopy < ApplicationRecord
   belongs_to :preserved_copy
   belongs_to :archive_endpoint
   has_many :archive_preserved_copy_parts, dependent: :destroy, inverse_of: :archive_preserved_copy
+  has_one :preserved_object, through: :preserved_copy, dependent: :restrict_with_exception
   delegate :preserved_object, to: :preserved_copy
 
   # @note Hash values cannot be modified without migrating any associated persisted data.

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -1,7 +1,5 @@
 ##
 # Metadata about a Moab storage root (a POSIX file system which contains Moab objects).
-# TODO: rename to... OnlineEndpoint?  LocalMoabStorageRoot?
-# TODO: remove the old description (leaving while things are being refactored)
 class Endpoint < ApplicationRecord
   has_many :preserved_copies, dependent: :restrict_with_exception
   has_and_belongs_to_many :preservation_policies

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -26,20 +26,4 @@ class PreservedObject < ApplicationRecord
     # FIXME: STUB
     # Ticket: 920
   end
-
-  # given a version, create any PreservedCopy records for that version which don't yet exist for archive
-  #  endpoints which implement this PreservedObject's PreservationPolicy.
-  # @param archive_vers [Integer] the version for which preserved copies should be created.  must be between
-  #   1 and this PreservedObject's current version (inclusive).
-  # @return [Array<PreservedCopy>] the PreservedCopy records that were created
-  def create_archive_preserved_copies(archive_vers)
-    unless archive_vers > 0 && archive_vers <= current_version
-      raise ArgumentError, "archive_vers (#{archive_vers}) must be between 0 and current_version (#{current_version})"
-    end
-
-    params = Endpoint.which_need_archive_copy(druid, archive_vers).map do |ep|
-      { version: archive_vers, endpoint: ep, status: PreservedCopy::UNREPLICATED_STATUS }
-    end
-    preserved_copies.create!(params)
-  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,12 +9,11 @@
 # https://www.postgresql.org/docs/current/static/transaction-iso.html
 ApplicationRecord.transaction(isolation: :serializable) do
   PreservationPolicy.seed_from_config
-  Endpoint.seed_storage_root_endpoints_from_config(
-    [PreservationPolicy.default_policy]
-  )
+  Endpoint.seed_storage_root_endpoints_from_config([PreservationPolicy.default_policy])
   ArchiveEndpoint.seed_archive_endpoints_from_config([PreservationPolicy.default_policy])
 end
 
 puts "seeded database.  state of seeded object types after seeding:"
 puts "> PreservationPolicy.all: #{PreservationPolicy.all.to_a}"
 puts "> Endpoint.all: #{Endpoint.all.to_a}"
+puts "> ArchiveEndpoint.all: #{ArchiveEndpoint.all.to_a}"

--- a/spec/models/archive_endpoint_spec.rb
+++ b/spec/models/archive_endpoint_spec.rb
@@ -93,8 +93,13 @@ RSpec.describe ArchiveEndpoint, type: :model do
 
   describe '.which_need_archive_copy' do
     let(:version) { 3 }
-
-    before { create(:preserved_object, current_version: version, druid: druid) }
+    let!(:po) { create(:preserved_object, current_version: version, druid: druid) }
+    let(:pc) { create(:preserved_copy, preserved_object: po) }
+    let(:pc_other_druid) do
+      other_po = create(:preserved_object, current_version: version, druid: 'zy098xw7654')
+      create(:preserved_copy, version: version, preserved_object: other_po)
+    end
+    let(:ma1_ep) { ArchiveEndpoint.find_by!(endpoint_name: 'mock_archive1') }
 
     it "returns the archive endpoints which should have a pres copy for the druid/version, but which don't yet" do
       expect(
@@ -104,14 +109,17 @@ RSpec.describe ArchiveEndpoint, type: :model do
         ArchiveEndpoint.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name)
       ).to eq %w[archive-endpoint mock_archive1]
 
-      create(
-        :archive_preserved_copy,
-        version: version,
-        archive_endpoint: ArchiveEndpoint.find_by!(endpoint_name: 'mock_archive1')
-      )
+      create(:archive_preserved_copy, preserved_copy: pc, version: version, archive_endpoint: ma1_ep)
       expect(
         ArchiveEndpoint.which_need_archive_copy(druid, version).pluck(:endpoint_name)
       ).to eq %w[archive-endpoint]
+      expect(
+        ArchiveEndpoint.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name)
+      ).to eq %w[archive-endpoint mock_archive1]
+
+      create(
+        :archive_preserved_copy, preserved_copy: pc_other_druid, version: version - 1, archive_endpoint: ma1_ep
+      )
       expect(
         ArchiveEndpoint.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name)
       ).to eq %w[archive-endpoint mock_archive1]

--- a/spec/models/archive_endpoint_spec.rb
+++ b/spec/models/archive_endpoint_spec.rb
@@ -91,38 +91,63 @@ RSpec.describe ArchiveEndpoint, type: :model do
     end
   end
 
-  describe '.which_need_archive_copy' do
+  context 'ArchivePreservedCopy presence on ArchiveEndpoint' do
     let(:version) { 3 }
     let!(:po) { create(:preserved_object, current_version: version, druid: druid) }
     let(:pc) { create(:preserved_copy, preserved_object: po) }
-    let(:pc_other_druid) do
-      other_po = create(:preserved_object, current_version: version, druid: 'zy098xw7654')
+    let(:other_druid) { 'zy098xw7654' }
+    let!(:pc_other_druid) do
+      other_po = create(:preserved_object, current_version: version, druid: other_druid)
       create(:preserved_copy, version: version, preserved_object: other_po)
     end
     let(:ma1_ep) { ArchiveEndpoint.find_by!(endpoint_name: 'mock_archive1') }
 
-    it "returns the archive endpoints which should have a pres copy for the druid/version, but which don't yet" do
-      expect(
-        ArchiveEndpoint.which_need_archive_copy(druid, version).pluck(:endpoint_name)
-      ).to eq %w[archive-endpoint mock_archive1]
-      expect(
-        ArchiveEndpoint.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name)
-      ).to eq %w[archive-endpoint mock_archive1]
+    describe '.which_have_archive_copy' do
+      it 'returns the archive endpoints which have a pres copy for the druid version' do
+        expect(ArchiveEndpoint.which_have_archive_copy(druid, version).pluck(:endpoint_name)).to eq []
+        expect(ArchiveEndpoint.which_have_archive_copy(druid, version - 1).pluck(:endpoint_name)).to eq []
+        expect(ArchiveEndpoint.which_have_archive_copy(other_druid, version).pluck(:endpoint_name)).to eq []
+        expect(ArchiveEndpoint.which_have_archive_copy(other_druid, version - 1).pluck(:endpoint_name)).to eq []
 
-      create(:archive_preserved_copy, preserved_copy: pc, version: version, archive_endpoint: ma1_ep)
-      expect(
-        ArchiveEndpoint.which_need_archive_copy(druid, version).pluck(:endpoint_name)
-      ).to eq %w[archive-endpoint]
-      expect(
-        ArchiveEndpoint.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name)
-      ).to eq %w[archive-endpoint mock_archive1]
+        create(:archive_preserved_copy, preserved_copy: pc, version: version, archive_endpoint: ma1_ep)
+        expect(ArchiveEndpoint.which_have_archive_copy(druid, version).pluck(:endpoint_name)).to eq %w[mock_archive1]
+        expect(ArchiveEndpoint.which_have_archive_copy(druid, version - 1).pluck(:endpoint_name)).to eq []
+        expect(ArchiveEndpoint.which_have_archive_copy(other_druid, version).pluck(:endpoint_name)).to eq []
+        expect(ArchiveEndpoint.which_have_archive_copy(other_druid, version - 1).pluck(:endpoint_name)).to eq []
 
-      create(
-        :archive_preserved_copy, preserved_copy: pc_other_druid, version: version - 1, archive_endpoint: ma1_ep
-      )
-      expect(
-        ArchiveEndpoint.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name)
-      ).to eq %w[archive-endpoint mock_archive1]
+        create(:archive_preserved_copy, preserved_copy: pc_other_druid, version: version - 1, archive_endpoint: ma1_ep)
+        expect(ArchiveEndpoint.which_have_archive_copy(druid, version).pluck(:endpoint_name)).to eq %w[mock_archive1]
+        expect(ArchiveEndpoint.which_have_archive_copy(druid, version - 1).pluck(:endpoint_name)).to eq []
+        expect(ArchiveEndpoint.which_have_archive_copy(other_druid, version).pluck(:endpoint_name)).to eq []
+        expect(ArchiveEndpoint.which_have_archive_copy(other_druid, version - 1).pluck(:endpoint_name)).to eq %w[mock_archive1]
+
+        create(:archive_preserved_copy, preserved_copy: pc_other_druid, version: version - 1, archive_endpoint: archive_endpoint)
+        expect(ArchiveEndpoint.which_have_archive_copy(druid, version).pluck(:endpoint_name)).to eq %w[mock_archive1]
+        expect(ArchiveEndpoint.which_have_archive_copy(druid, version - 1).pluck(:endpoint_name)).to eq []
+        expect(ArchiveEndpoint.which_have_archive_copy(other_druid, version).pluck(:endpoint_name)).to eq []
+        expect(ArchiveEndpoint.which_have_archive_copy(other_druid, version - 1).pluck(:endpoint_name).sort).to eq %w[archive-endpoint mock_archive1]
+      end
+    end
+
+    describe '.which_need_archive_copy' do
+      it "returns the archive endpoints which should have a pres copy for the druid/version, but which don't yet" do
+        expect(ArchiveEndpoint.which_need_archive_copy(druid, version).pluck(:endpoint_name).sort).to eq %w[archive-endpoint mock_archive1]
+        expect(ArchiveEndpoint.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name).sort).to eq %w[archive-endpoint mock_archive1]
+        expect(ArchiveEndpoint.which_need_archive_copy(other_druid, version).pluck(:endpoint_name).sort).to eq %w[archive-endpoint mock_archive1]
+        expect(ArchiveEndpoint.which_need_archive_copy(other_druid, version - 1).pluck(:endpoint_name).sort).to eq %w[archive-endpoint mock_archive1]
+
+        create(:archive_preserved_copy, preserved_copy: pc, version: version, archive_endpoint: ma1_ep)
+        expect(ArchiveEndpoint.which_need_archive_copy(druid, version).pluck(:endpoint_name)).to eq %w[archive-endpoint]
+        expect(ArchiveEndpoint.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name).sort).to eq %w[archive-endpoint mock_archive1]
+        expect(ArchiveEndpoint.which_need_archive_copy(other_druid, version).pluck(:endpoint_name).sort).to eq %w[archive-endpoint mock_archive1]
+        expect(ArchiveEndpoint.which_need_archive_copy(other_druid, version - 1).pluck(:endpoint_name).sort).to eq %w[archive-endpoint mock_archive1]
+
+        create(:archive_preserved_copy, preserved_copy: pc_other_druid, version: version - 1, archive_endpoint: ma1_ep)
+        expect(ArchiveEndpoint.which_need_archive_copy(druid, version).pluck(:endpoint_name)).to eq %w[archive-endpoint]
+        expect(ArchiveEndpoint.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name).sort).to eq %w[archive-endpoint mock_archive1]
+        expect(ArchiveEndpoint.which_need_archive_copy(other_druid, version).pluck(:endpoint_name).sort).to eq %w[archive-endpoint mock_archive1]
+        expect(ArchiveEndpoint.which_need_archive_copy(other_druid, version - 1).pluck(:endpoint_name)).to eq %w[archive-endpoint]
+      end
     end
   end
 end

--- a/spec/models/archive_endpoint_spec.rb
+++ b/spec/models/archive_endpoint_spec.rb
@@ -124,12 +124,5 @@ RSpec.describe ArchiveEndpoint, type: :model do
         ArchiveEndpoint.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name)
       ).to eq %w[archive-endpoint mock_archive1]
     end
-
-    # since we build AREL subquery, the cast is a guarantee against SQL injection
-    it 'Casts version to integer' do
-      bogus_version = instance_double(Integer)
-      expect(bogus_version).to receive(:to_i).and_return(1)
-      ArchiveEndpoint.which_need_archive_copy(druid, bogus_version).first
-    end
   end
 end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -319,24 +319,20 @@ RSpec.describe PreservedCopy, type: :model do
     let(:pc_version) { 3 }
     let(:archive_ep) { ArchiveEndpoint.find_by!(endpoint_name: 'mock_archive1') }
     let(:new_archive_ep) { create(:archive_endpoint, endpoint_name: 'mock_archive2') }
-    # TODO: i think sarav's PR (or joe's?) adds a .by_druid scope to ArchivePreservedCopy
-    let(:archive_pcs_for_druid) do
-      ArchivePreservedCopy.joins(:preserved_object).where(preserved_objects: { druid: druid })
-    end
 
     it "creates pres copies that don't yet exist for the given version, but should" do
       expect { pc.create_archive_preserved_copies!(pc_version) }.to change {
         ArchiveEndpoint.which_need_archive_copy(druid, pc_version).to_a
       }.from([archive_ep]).to([])
 
-      expect(archive_pcs_for_druid.count).to eq 1
+      expect(ArchivePreservedCopy.by_druid(druid).count).to eq 1
 
       expect { pc.create_archive_preserved_copies!(pc_version - 1) }.to change {
         ArchiveEndpoint.which_need_archive_copy(druid, pc_version - 1).to_a
       }.from([archive_ep]).to([])
-      expect(archive_pcs_for_druid.count).to eq 2
+      expect(ArchivePreservedCopy.by_druid(druid).count).to eq 2
 
-      expect(archive_pcs_for_druid.where(version: 1).count).to eq 0
+      expect(ArchivePreservedCopy.by_druid(druid).where(version: 1).count).to eq 0
     end
 
     it 'creates the pres copies so that they start with unreplicated status' do
@@ -347,13 +343,13 @@ RSpec.describe PreservedCopy, type: :model do
       expect { pc.create_archive_preserved_copies!(pc_version) }.to change {
         ArchiveEndpoint.which_need_archive_copy(druid, pc_version).to_a
       }.from([archive_ep]).to([])
-      expect(archive_pcs_for_druid.where(version: pc_version).count).to eq 1
+      expect(ArchivePreservedCopy.by_druid(druid).where(version: pc_version).count).to eq 1
 
       new_archive_ep.preservation_policies = [PreservationPolicy.default_policy]
       expect { pc.create_archive_preserved_copies!(pc_version) }.to change {
         ArchiveEndpoint.which_need_archive_copy(druid, pc_version).to_a
       }.from([new_archive_ep]).to([])
-      expect(archive_pcs_for_druid.where(version: pc_version).count).to eq 2
+      expect(ArchivePreservedCopy.by_druid(druid).where(version: pc_version).count).to eq 2
     end
 
     it 'checks that version is in range' do


### PR DESCRIPTION
ported and fixed the query, and added a test which would've demonstrated issue #899.

still need to:
- [x] finish porting `create_archive_preserved_copies!` to `PreservedCopy`
- [x] port/write tests for `PreservedCopy.create_archive_preserved_copies!`
- [x] write tests for `ArchiveEndpoint.which_have_archive_copy`
- [x] ~~remove `Endpoint.which_need_archive_copy` (will likely happen after rebasing on the below mentioned PRs anyway)~~ yup, 954 took care of it
- [x] rebase on master after #956 is merged
- [x] rebase on master after #954 is merged

i think the tentative plan is to get #956 merged, then #954, then this.

fixes #899