### PR TITLE
Let m2c,c2m,cv write to their own logs

### DIFF
--- a/app/lib/audit/catalog_to_moab.rb
+++ b/app/lib/audit/catalog_to_moab.rb
@@ -60,7 +60,7 @@ module Audit
         results.add_result(AuditResults::PC_PO_VERSION_MISMATCH,
                            pc_version: preserved_copy.version,
                            po_version: preserved_copy.preserved_object.current_version)
-        results.report_results
+        results.report_results(Audit::CatalogToMoab.logger)
         return
       end
 
@@ -74,11 +74,11 @@ module Audit
         results.add_result(AuditResults::MOAB_NOT_FOUND,
                            db_created_at: preserved_copy.created_at.iso8601,
                            db_updated_at: preserved_copy.updated_at.iso8601)
-        results.report_results
+        results.report_results(Audit::CatalogToMoab.logger)
         return
       end
 
-      return results.report_results unless can_validate_current_pres_copy_status?
+      return results.report_results(Audit::CatalogToMoab.logger) unless can_validate_current_pres_copy_status?
 
       moab_version = moab.current_version_id
       results.actual_version = moab_version
@@ -87,7 +87,7 @@ module Audit
         if catalog_version == moab_version
           set_status_as_seen_on_disk(true) unless preserved_copy.status == PreservedCopy::OK_STATUS
           results.add_result(AuditResults::VERSION_MATCHES, 'PreservedCopy')
-          results.report_results
+          results.report_results(Audit::CatalogToMoab.logger)
         elsif catalog_version < moab_version
           set_status_as_seen_on_disk(true)
           pohandler = PreservedObjectHandler.new(druid, moab_version, moab.size, preserved_copy.endpoint)
@@ -97,7 +97,7 @@ module Audit
           results.add_result(
             AuditResults::UNEXPECTED_VERSION, db_obj_name: 'PreservedCopy', db_obj_version: preserved_copy.version
           )
-          results.report_results
+          results.report_results(Audit::CatalogToMoab.logger)
         end
 
         preserved_copy.update_audit_timestamps(ran_moab_validation?, true)

--- a/app/lib/audit/moab_to_catalog.rb
+++ b/app/lib/audit/moab_to_catalog.rb
@@ -16,6 +16,7 @@ module Audit
       storage_dir = "#{moab.object_pathname.to_s.split(storage_trunk).first}#{storage_trunk}"
       endpoint = Endpoint.find_by!(storage_location: storage_dir)
       po_handler = PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, endpoint)
+      po_handler.logger = Audit::MoabToCatalog.logger
       results = po_handler.check_existence
       logger.info "#{results} for #{druid}"
       results

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -118,10 +118,10 @@ class AuditResults
   #   results = [result1, result2]
   #   result1 = {response_code => msg}
   #   result2 = {response_code => msg}
-  def report_results
+  def report_results(logger=Rails.logger)
     candidate_workflow_results = []
     result_array.each do |r|
-      log_result(r)
+      log_result(r, logger)
       if r.key?(INVALID_MOAB)
         msg = "#{workflows_msg_prefix} || #{r.values.first}"
         WorkflowReporter.report_error(druid, 'moab-valid', msg)
@@ -159,9 +159,9 @@ class AuditResults
     WorkflowReporter.report_error(druid, 'preservation-audit', msg)
   end
 
-  def log_result(result)
+  def log_result(result, logger)
     severity = self.class.logger_severity_level(result.keys.first)
-    Rails.logger.log(severity, "#{log_msg_prefix} #{result.values.first}")
+    logger.add(severity, "#{log_msg_prefix} #{result.values.first}")
   end
 
   def result_code_msg(code, addl=nil)

--- a/app/services/checksum_validator.rb
+++ b/app/services/checksum_validator.rb
@@ -47,7 +47,7 @@ class ChecksumValidator
     end
     results.remove_db_updated_results unless transaction_ok
 
-    results.report_results
+    results.report_results(Audit::Checksum.logger)
   end
 
   def validate_manifest_inventories

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -21,6 +21,7 @@ class PreservedObjectHandler
   end
 
   attr_reader :druid, :incoming_version, :incoming_size, :endpoint, :results
+  attr_writer :logger
 
   delegate :storage_location, to: :endpoint
 
@@ -30,6 +31,7 @@ class PreservedObjectHandler
     @incoming_size = string_to_int(incoming_size)
     @endpoint = endpoint
     @results = AuditResults.new(druid, incoming_version, endpoint)
+    @logger = PreservationCatalog::Application.logger
   end
 
   def create_after_validation

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -198,6 +198,7 @@ RSpec.describe Audit::MoabToCatalog do
         instance_of(Integer), # size
         endpoint
       ).and_return(po_handler)
+      expect(po_handler).to receive(:logger=)
       expect(po_handler).to receive(:check_existence)
       subject
     end

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -52,24 +52,24 @@ RSpec.describe AuditResults do
       end
       it 'with log_msg_prefix' do
         expected = "FooCheck(#{druid}, fixture_sr1)"
-        expect(Rails.logger).to receive(:log).with(Logger::ERROR, a_string_matching(Regexp.escape(expected)))
+        expect(Rails.logger).to receive(:add).with(Logger::ERROR, a_string_matching(Regexp.escape(expected)))
         audit_results.report_results
       end
       it 'with check name' do
-        expect(Rails.logger).to receive(:log).with(Logger::ERROR, a_string_matching(check_name))
+        expect(Rails.logger).to receive(:add).with(Logger::ERROR, a_string_matching(check_name))
         audit_results.report_results
       end
       it 'with druid' do
-        expect(Rails.logger).to receive(:log).with(Logger::ERROR, a_string_matching(druid))
+        expect(Rails.logger).to receive(:add).with(Logger::ERROR, a_string_matching(druid))
         audit_results.report_results
       end
       it 'with endpoint name' do
-        expect(Rails.logger).to receive(:log).with(Logger::ERROR, a_string_matching(endpoint.endpoint_name))
+        expect(Rails.logger).to receive(:add).with(Logger::ERROR, a_string_matching(endpoint.endpoint_name))
         audit_results.report_results
       end
       it 'with severity assigned by .logger_severity_level' do
         expect(described_class).to receive(:logger_severity_level).with(result_code).and_return(Logger::FATAL)
-        expect(Rails.logger).to receive(:log).with(Logger::FATAL, a_string_matching(version_not_matched_str))
+        expect(Rails.logger).to receive(:add).with(Logger::FATAL, a_string_matching(version_not_matched_str))
         audit_results.report_results
       end
       it 'for every result' do
@@ -77,10 +77,10 @@ RSpec.describe AuditResults do
         status_details = { old_status: PreservedCopy::INVALID_MOAB_STATUS, new_status: PreservedCopy::OK_STATUS }
         audit_results.add_result(result_code2, status_details)
         severity_level = described_class.logger_severity_level(result_code)
-        expect(Rails.logger).to receive(:log).with(severity_level, a_string_matching(version_not_matched_str))
+        expect(Rails.logger).to receive(:add).with(severity_level, a_string_matching(version_not_matched_str))
         severity_level = described_class.logger_severity_level(result_code2)
         status_changed_str = "PreservedCopy status changed from #{PreservedCopy::INVALID_MOAB_STATUS}"
-        expect(Rails.logger).to receive(:log).with(severity_level, a_string_matching(status_changed_str))
+        expect(Rails.logger).to receive(:add).with(severity_level, a_string_matching(status_changed_str))
         audit_results.report_results
       end
       it 'actual_version number is in log message when set after initialization' do
@@ -88,7 +88,7 @@ RSpec.describe AuditResults do
         result_code = AuditResults::VERSION_MATCHES
         my_results.actual_version = 666 # NOTE: must be set before "add_result" call
         my_results.add_result(result_code, 'foo')
-        expect(Rails.logger).to receive(:log).with(anything, a_string_matching('666'))
+        expect(Rails.logger).to receive(:add).with(anything, a_string_matching('666'))
         my_results.report_results
       end
     end


### PR DESCRIPTION
- For c2m/cv, direct check output to the c2m/cv logger via an argument to `report_results`
- For m2c, add a logger to poh constructor, and override it to point to the m2c logger
- `report_results` ultimately logs by a call to the `add` method of `Logger`, because the `log` method will not broadcast messages to both STDOUT and another logger.
- spec touchups to show poh receiving a logger override, and the calls to `add`

Fixes #858 