### PR TITLE
Pohandler methods take checksums_validated param

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,13 @@ Layout/SpaceInsideBrackets:
     - 'app/services/preserved_object_handler.rb' # line 126 is clearer with the spaces
 
 # --- Lint ---
+
+Lint/AmbiguousBlockAssociation:
+  # doesn't play nicely with rspec change syntax, e.g. "expect { foo }.to change { bar.field }"
+  Exclude:
+    - spec/services/preserved_object_handler_update_version_spec.rb
+    - spec/services/shared_examples_preserved_object_handler.rb
+
 Lint/HandleExceptions:
   Exclude:
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # So method does not stop executing and can test the correct case
@@ -53,7 +60,6 @@ Lint/HandleExceptions:
 Lint/RescueWithoutErrorClass:
   Exclude:
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # So method does not stop executing and can test the correct case
-
 
 # --- Metrics ---
 

--- a/app/lib/audit/catalog_to_moab.rb
+++ b/app/lib/audit/catalog_to_moab.rb
@@ -78,6 +78,21 @@ module Audit
 
       return results.report_results(Audit::CatalogToMoab.logger) unless can_validate_current_pres_copy_status?
 
+      compare_version_and_take_action
+    end
+
+    alias storage_location storage_dir
+
+    private
+
+    def online_moab_found?
+      return true if moab
+      false
+    end
+
+    # compare the catalog version to the actual Moab;  update the catalog version if the Moab is newer
+    #   report results (and return them)
+    def compare_version_and_take_action
       moab_version = moab.current_version_id
       results.actual_version = moab_version
       catalog_version = preserved_copy.version
@@ -102,15 +117,6 @@ module Audit
         preserved_copy.save!
       end
       results.remove_db_updated_results unless transaction_ok
-    end
-
-    alias storage_location storage_dir
-
-    private
-
-    def online_moab_found?
-      return true if moab
-      false
     end
   end
 end

--- a/app/lib/audit/catalog_to_moab.rb
+++ b/app/lib/audit/catalog_to_moab.rb
@@ -60,8 +60,7 @@ module Audit
         results.add_result(AuditResults::PC_PO_VERSION_MISMATCH,
                            pc_version: preserved_copy.version,
                            po_version: preserved_copy.preserved_object.current_version)
-        results.report_results(Audit::CatalogToMoab.logger)
-        return
+        return results.report_results(Audit::CatalogToMoab.logger)
       end
 
       unless online_moab_found?
@@ -74,8 +73,7 @@ module Audit
         results.add_result(AuditResults::MOAB_NOT_FOUND,
                            db_created_at: preserved_copy.created_at.iso8601,
                            db_updated_at: preserved_copy.updated_at.iso8601)
-        results.report_results(Audit::CatalogToMoab.logger)
-        return
+        return results.report_results(Audit::CatalogToMoab.logger)
       end
 
       return results.report_results(Audit::CatalogToMoab.logger) unless can_validate_current_pres_copy_status?

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -200,7 +200,7 @@ class PreservedObjectHandler
         results.add_result(code, db_obj_name: 'PreservedCopy', db_obj_version: pres_copy.version)
 
         pres_copy.upd_audstamps_version_size(ran_moab_validation?, incoming_version, incoming_size)
-        update_status(status) if status && ran_moab_validation?
+        update_status(status) if status
         pres_copy.save!
         pres_object.current_version = incoming_version
         pres_object.save!

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -249,7 +249,6 @@ class PreservedObjectHandler
       po_version = pres_copy.preserved_object.current_version
       res_code = AuditResults::PC_PO_VERSION_MISMATCH
       results.add_result(res_code, { pc_version: pc_version, po_version: po_version })
-      results.report_results(Audit::CatalogToMoab.logger)
       raise ActiveRecord::Rollback, "PreservedCopy version #{pc_version} != PreservedObject current_version #{po_version}"
     end
   end

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -40,6 +40,7 @@ class PreservedObjectHandler
       results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'PreservedObject')
     elsif moab_validation_errors.empty?
       creation_status = (checksums_validated ? PreservedCopy::OK_STATUS : PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+      # TODO: what, if any, timestamps does this imply update for?
       create_db_objects(creation_status)
     else
       create_db_objects(PreservedCopy::INVALID_MOAB_STATUS)
@@ -56,6 +57,7 @@ class PreservedObjectHandler
       results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'PreservedObject')
     else
       creation_status = (checksums_validated ? PreservedCopy::OK_STATUS : PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+      # TODO: what, if any, timestamps does this imply update for?
       create_db_objects(creation_status)
     end
 
@@ -129,6 +131,7 @@ class PreservedObjectHandler
       if moab_validation_errors.empty?
         # NOTE: we deal with active record transactions in update_online_version, not here
         new_status = (checksums_validated ? PreservedCopy::OK_STATUS : PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+        # TODO: what, if any, timestamps does this imply update for?
         update_online_version(new_status)
       else
         update_pc_invalid_moab
@@ -146,6 +149,7 @@ class PreservedObjectHandler
       Rails.logger.debug "update_version #{druid} called"
       # NOTE: we deal with active record transactions in update_online_version, not here
       new_status = (checksums_validated ? PreservedCopy::OK_STATUS : nil)
+      # TODO: what, if any, timestamps does this imply update for?
       update_online_version(new_status, true)
     end
 

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -32,14 +32,15 @@ class PreservedObjectHandler
     @logger = PreservationCatalog::Application.logger
   end
 
-  def create_after_validation
+  def create_after_validation(checksums_validated = false)
     results.check_name = 'create_after_validation'
     if invalid?
       results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
     elsif PreservedObject.exists?(druid: druid)
       results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'PreservedObject')
     elsif moab_validation_errors.empty?
-      create_db_objects(PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+      creation_status = (checksums_validated ? PreservedCopy::OK_STATUS : PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+      create_db_objects(creation_status)
     else
       create_db_objects(PreservedCopy::INVALID_MOAB_STATUS)
     end
@@ -47,14 +48,15 @@ class PreservedObjectHandler
     results.report_results
   end
 
-  def create
+  def create(checksums_validated = false)
     results.check_name = 'create'
     if invalid?
       results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
     elsif PreservedObject.exists?(druid: druid)
       results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'PreservedObject')
     else
-      create_db_objects(PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+      creation_status = (checksums_validated ? PreservedCopy::OK_STATUS : PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+      create_db_objects(creation_status)
     end
 
     results.report_results
@@ -118,7 +120,7 @@ class PreservedObjectHandler
     results.report_results
   end
 
-  def update_version_after_validation
+  def update_version_after_validation(checksums_validated = false)
     results.check_name = 'update_version_after_validation'
     if invalid?
       results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
@@ -126,7 +128,8 @@ class PreservedObjectHandler
       Rails.logger.debug "update_version_after_validation #{druid} called"
       if moab_validation_errors.empty?
         # NOTE: we deal with active record transactions in update_online_version, not here
-        update_online_version(PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+        new_status = (checksums_validated ? PreservedCopy::OK_STATUS : PreservedCopy::VALIDITY_UNKNOWN_STATUS)
+        update_online_version(new_status)
       else
         update_pc_invalid_moab
       end
@@ -135,14 +138,15 @@ class PreservedObjectHandler
     results.report_results
   end
 
-  def update_version
+  def update_version(checksums_validated = false)
     results.check_name = 'update_version'
     if invalid?
       results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
     else
       Rails.logger.debug "update_version #{druid} called"
       # NOTE: we deal with active record transactions in update_online_version, not here
-      update_online_version(nil, true)
+      new_status = (checksums_validated ? PreservedCopy::OK_STATUS : nil)
+      update_online_version(new_status, true)
     end
 
     results.report_results

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -141,6 +141,8 @@ class PreservedObjectHandler
           # for case when no db updates b/c pres_obj version != pres_copy version
           update_pc_invalid_moab unless pres_copy.invalid_moab?
         else
+          # TODO: we don't know checksum validity of incoming version, and we also have invalid moab
+          #   so ideally we could report on moab validation errors (done) *and* queue up a checksum validity check
           update_online_version(PreservedCopy::VALIDITY_UNKNOWN_STATUS, false, false)
           # for case when no db updates b/c pres_obj version != pres_copy version
           update_pc_validity_unknown unless pres_copy.validity_unknown?

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -32,6 +32,7 @@ class PreservedObjectHandler
     @logger = PreservationCatalog::Application.logger
   end
 
+  # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
   def create_after_validation(checksums_validated = false)
     results.check_name = 'create_after_validation'
     if invalid?
@@ -48,6 +49,7 @@ class PreservedObjectHandler
     results.report_results
   end
 
+  # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
   def create(checksums_validated = false)
     results.check_name = 'create'
     if invalid?
@@ -56,7 +58,7 @@ class PreservedObjectHandler
       results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'PreservedObject')
     else
       creation_status = (checksums_validated ? PreservedCopy::OK_STATUS : PreservedCopy::VALIDITY_UNKNOWN_STATUS)
-      ran_moab_validation! if checksums_validated # set validation timestamps
+      ran_moab_validation! if checksums_validated # ensure validation timestamps updated
       create_db_objects(creation_status, checksums_validated)
     end
 
@@ -121,6 +123,7 @@ class PreservedObjectHandler
     results.report_results
   end
 
+  # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
   def update_version_after_validation(checksums_validated = false)
     results.check_name = 'update_version_after_validation'
     if invalid?
@@ -155,13 +158,14 @@ class PreservedObjectHandler
     results.report_results
   end
 
+  # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
   def update_version(checksums_validated = false)
     results.check_name = 'update_version'
     if invalid?
       results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
     else
       Rails.logger.debug "update_version #{druid} called"
-      # # only change status if checksums_validated is false
+      # only change status if checksums_validated is false
       new_status = (checksums_validated ? nil : PreservedCopy::VALIDITY_UNKNOWN_STATUS)
       # NOTE: we deal with active record transactions in update_online_version, not here
       update_online_version(new_status, true, checksums_validated)

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe PreservedObjectHandler do
       po_handler.create
     end
 
+    it 'creates the PreservedCopy with "ok" status if caller ran CV' do
+      pc_args[:status] = PreservedCopy::OK_STATUS
+      expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
+      po_handler.create(true)
+    end
+
     it_behaves_like 'attributes validated', :create
 
     it 'object already exists' do
@@ -129,6 +135,18 @@ RSpec.describe PreservedObjectHandler do
       po_handler.create_after_validation
     end
 
+    it 'creates PreservedCopy in "ok" status in db when there are no validation errors and caller ran CV' do
+      pc_args.merge!(
+        status: PreservedCopy::OK_STATUS,
+        last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
+        last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
+      )
+
+      expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
+      po_handler = described_class.new(valid_druid, incoming_version, incoming_size, ep)
+      po_handler.create_after_validation(true)
+    end
+
     it 'calls moab-versioning Stanford::StorageObjectValidator.validation_errors' do
       mock_sov = instance_double(Stanford::StorageObjectValidator)
       expect(mock_sov).to receive(:validation_errors).and_return([])
@@ -151,7 +169,7 @@ RSpec.describe PreservedObjectHandler do
         end
       end
 
-      it 'creates PreservedObject and PreservedCopy with "invalid_moab" status in database' do
+      it 'creates PreservedObject, and PreservedCopy with "invalid_moab" status in database' do
         po_args[:druid] = invalid_druid
         pc_args.merge!(
           status: PreservedCopy::INVALID_MOAB_STATUS,
@@ -162,6 +180,17 @@ RSpec.describe PreservedObjectHandler do
         expect(PreservedObject).to receive(:create!).with(po_args).and_call_original
         expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
         po_handler.create_after_validation
+      end
+
+      it 'creates PreservedCopy with "invalid_moab" status in database even if caller ran CV' do
+        pc_args.merge!(
+          status: PreservedCopy::INVALID_MOAB_STATUS,
+          last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
+          last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
+        )
+
+        expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
+        po_handler.create_after_validation(true)
       end
 
       it 'includes invalid moab result' do

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -38,8 +38,11 @@ RSpec.describe PreservedObjectHandler do
       po_handler.create
     end
 
-    it 'creates the PreservedCopy with "ok" status if caller ran CV' do
+    it 'creates the PreservedCopy with "ok" status and validation timestamps if caller ran CV' do
       pc_args[:status] = PreservedCopy::OK_STATUS
+      pc_args[:last_version_audit] = ActiveSupport::TimeWithZone
+      pc_args[:last_moab_validation] = ActiveSupport::TimeWithZone
+      pc_args[:last_checksum_validation] = ActiveSupport::TimeWithZone
       expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
       po_handler.create(true)
     end
@@ -135,11 +138,12 @@ RSpec.describe PreservedObjectHandler do
       po_handler.create_after_validation
     end
 
-    it 'creates PreservedCopy in "ok" status in db when there are no validation errors and caller ran CV' do
+    it 'creates PreservedCopy with "ok" status and validation timestamps if no validation errors and caller ran CV' do
       pc_args.merge!(
         status: PreservedCopy::OK_STATUS,
         last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
-        last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
+        last_version_audit: an_instance_of(ActiveSupport::TimeWithZone),
+        last_checksum_validation: an_instance_of(ActiveSupport::TimeWithZone)
       )
 
       expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original
@@ -186,7 +190,8 @@ RSpec.describe PreservedObjectHandler do
         pc_args.merge!(
           status: PreservedCopy::INVALID_MOAB_STATUS,
           last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
-          last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
+          last_version_audit: an_instance_of(ActiveSupport::TimeWithZone),
+          last_checksum_validation: an_instance_of(ActiveSupport::TimeWithZone)
         )
 
         expect(PreservedCopy).to receive(:create!).with(pc_args).and_call_original

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe PreservedObjectHandler do
                 end.not_to change { pc.reload.status }.from('ok')
               end
               context 'original status was not ok' do
-                shared_examples 'POH#update_version(true) does not change status to "ok"' do |orig_status|
+                shared_examples 'POH#update_version(true) does not change status' do |orig_status|
                   before do
                     pc.update!(status: orig_status)
                   end
@@ -113,12 +113,12 @@ RSpec.describe PreservedObjectHandler do
                   end
                 end
 
-                it_behaves_like 'POH#update_version(true) does not change status to "ok"', 'validity_unknown'
-                it_behaves_like 'POH#update_version(true) does not change status to "ok"', 'invalid_moab'
-                it_behaves_like 'POH#update_version(true) does not change status to "ok"', 'invalid_checksum'
+                it_behaves_like 'POH#update_version(true) does not change status', 'validity_unknown'
+                it_behaves_like 'POH#update_version(true) does not change status', 'invalid_moab'
+                it_behaves_like 'POH#update_version(true) does not change status', 'invalid_checksum'
                 # TODO: do these statuses change?
-                it_behaves_like 'POH#update_version(true) does not change status to "ok"', 'online_moab_not_found'
-                it_behaves_like 'POH#update_version(true) does not change status to "ok"', 'unexpected_version_on_storage'
+                it_behaves_like 'POH#update_version(true) does not change status', 'online_moab_not_found'
+                it_behaves_like 'POH#update_version(true) does not change status', 'unexpected_version_on_storage'
               end
             end
           end
@@ -443,7 +443,7 @@ RSpec.describe PreservedObjectHandler do
             it 'last_moab_validation updated' do
               expect do
                 po_handler.update_version_after_validation
-              end.to change { pc.reload.status }
+              end.to change { pc.reload.status }.from('ok').to('validity_unknown')
             end
             it 'size updated to incoming_size' do
               expect do
@@ -471,6 +471,7 @@ RSpec.describe PreservedObjectHandler do
                 shared_examples 'POH#update_version_after_validation changes status to "validity_unknown"' do |orig_status|
                   before { pc.update(status: orig_status) }
                   it "original status #{orig_status}" do
+                    # (due to newer version not checksum validated)
                     expect do
                       po_handler.update_version_after_validation
                     end.to change { pc.reload.status }.from(orig_status).to('validity_unknown')
@@ -491,7 +492,7 @@ RSpec.describe PreservedObjectHandler do
             it 'last_moab_validation updated' do
               expect do
                 po_handler.update_version_after_validation(true)
-              end.to change { pc.reload.status }
+              end.to change { pc.reload.last_moab_validation }
             end
             it 'size updated to incoming_size' do
               expect do
@@ -584,7 +585,7 @@ RSpec.describe PreservedObjectHandler do
               it 'version unchanged' do
                 expect { po_handler.update_version_after_validation }.not_to change { pc.reload.version }
               end
-              it 'status becomes validity_unknown' do
+              it 'status becomes validity_unknown (due to newer version not checksum validated)' do
                 expect { po_handler.update_version_after_validation }.to change { pc.reload.status }.to('validity_unknown')
               end
             end

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -292,6 +292,24 @@ RSpec.describe PreservedObjectHandler do
               expect(pc.reload.size).to eq incoming_size
               expect(pc.size).not_to eq orig
             end
+            context 'caller has run checksum validation, original status was not ok' do
+              shared_examples 'POH#update_version_after_validation(true) sets status to "ok"' do |orig_status|
+                before { pc.update(status: orig_status) }
+                it 'status' do
+                  expect do
+                    po_handler.update_version_after_validation(true)
+                  end.to change { pc.reload.status }.from(orig_status).to('ok')
+                end
+              end
+
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "ok"', 'validity_unknown'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "ok"', 'online_moab_not_found'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "ok"', 'unexpected_version_on_storage'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "ok"', 'invalid_moab'
+
+              # TODO: should caller CV clear this?  does it CV the whole moab, or just the new version?
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "ok"', 'invalid_checksum'
+            end
           end
           context 'unchanged' do
             it 'size if incoming size is nil' do
@@ -363,10 +381,24 @@ RSpec.describe PreservedObjectHandler do
               expect(pc.reload.last_moab_validation).to be > orig
             end
             it 'status' do
-              orig = pc.status
-              po_handler.update_version_after_validation
-              expect(pc.reload.status).to eq PreservedCopy::INVALID_MOAB_STATUS
-              expect(pc.status).not_to eq orig
+              expect do
+                po_handler.update_version_after_validation
+              end.to change { pc.reload.status }.from('ok').to('invalid_moab')
+            end
+            context 'caller has run checksum validation, original status was not ok' do
+              shared_examples 'POH#update_version_after_validation(true) sets status to "invalid_moab"' do |orig_status|
+                before { pc.update(status: orig_status) }
+                it 'status' do
+                  expect do
+                    po_handler.update_version_after_validation(true)
+                  end.to change { pc.reload.status }.from(orig_status).to('invalid_moab')
+                end
+              end
+
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "invalid_moab"', 'validity_unknown'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "invalid_moab"', 'online_moab_not_found'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "invalid_moab"', 'unexpected_version_on_storage'
+              it_behaves_like 'POH#update_version_after_validation(true) sets status to "invalid_moab"', 'invalid_checksum'
             end
           end
           context 'unchanged' do
@@ -384,6 +416,19 @@ RSpec.describe PreservedObjectHandler do
               orig = pc.last_version_audit
               po_handler.update_version_after_validation
               expect(pc.reload.last_version_audit).to eq orig
+            end
+            context 'original status was invalid_moab' do
+              before { pc.update(status: 'invalid_moab') }
+              it 'status remains invalid_moab if caller has not verified checksums' do
+                expect do
+                  po_handler.update_version_after_validation
+                end.not_to change { pc.reload.status }.from('invalid_moab')
+              end
+              it 'status remains invalid_moab evne if caller has verified checksums' do
+                expect do
+                  po_handler.update_version_after_validation(true)
+                end.not_to change { pc.reload.status }.from('invalid_moab')
+              end
             end
           end
         end

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -318,10 +318,14 @@ RSpec.describe PreservedObjectHandler do
               po_handler.update_version_after_validation
               expect(pc.reload.size).to eq orig
             end
-            it 'status' do
-              po_handler.update_version_after_validation
-              expect(pc.reload).to be_validity_unknown
-              skip 'is there a scenario when status should change here?  See #431'
+            it 'status started validity_unknown and caller has not verified checksums' do
+              pc.update(status: 'validity_unknown')
+              expect { po_handler.update_version_after_validation }.not_to change { pc.reload.status }.from('validity_unknown')
+            end
+            it 'status started ok and caller has verified checksums' do
+              expect do
+                po_handler.update_version_after_validation(true)
+              end.not_to change { pc.reload.status }.from('ok')
             end
           end
         end


### PR DESCRIPTION
### Why:

We need this so robots can set catalog entries to "ok" status when they update catalog, since they do checksum validation of the new content.  This is the guts of that work.  Still need to adjust controller and then the robot code.  (See #817)

### What's in this PR:

- pohandler.create and .update_version methods take an optional param to indicate if checksums have already been validated for the new moab (or new version for the moab).   Note that the addition of this param created all sorts of additional complexities re:  what status we should set in a variety of circumstances. (see table below)
- moved a block of tests out of shared_examples because it was only used in one of the update_version contexts and it was no longer correct.
- updated some tests to use rspec change matcher ... because I was having a hard time tracking what was being tested and why.  (I generally updated those tests near a test failure I had to tweak).
- teensy refactoring of C2M.check_existence because ... I thought of it?

### How to review this PR:  
(good luck!)  It doesn't hit a lot of files - I would consider doing it all in one shot.
- the non-test classes:  read changes carefully -- do they make sense?  Does the resulting status seem reasonable in each case?
- the test classes:
   - are we testing what we need to?
   - are tests at least as readable as they were before?

I am open to suggestions for improving tests or code, if you think of any.  This was super squirrelly to work on and I was elated to just get to a point where the tests passed.

supersedes #897
connected to #817

#### table showing what status should be after update_version methods

![img_2555](https://user-images.githubusercontent.com/96775/42664005-5821692e-85ed-11e8-811e-728497b68606.JPG)

