### PR TITLE
Quiet tests

### DIFF
--- a/spec/lib/audit/catalog_to_moab_class_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_class_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe Audit::CatalogToMoab do
   context '.check_version_on_dir' do
     include_context 'fixture moabs in db'
     let(:subject) { described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir, limit) }
+    let(:logger_double) { instance_double(ActiveSupport::Logger, info: nil, add: nil) }
+
+    before { allow(described_class).to receive(:logger).and_return(logger_double) } # silence log output
 
     context 'when there are PreservedCopies to check' do
       let(:c2m_mock) { instance_double(described_class) }

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 require_relative '../../load_fixtures_helper.rb'
 
 RSpec.describe Audit::CatalogToMoab do
-  before do
-    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
-  end
-
   let(:last_checked_version_b4_date) { (Time.now.utc - 1.day).iso8601 }
   let(:storage_dir) { 'spec/fixtures/storage_root01/sdr2objects' }
   let(:druid) { 'bj102hs9687' }
@@ -13,6 +9,12 @@ RSpec.describe Audit::CatalogToMoab do
   let(:mock_sov) { instance_double(Stanford::StorageObjectValidator) }
   let(:po) { PreservedObject.find_by!(druid: druid) }
   let(:pres_copy) { Endpoint.find_by!(storage_location: storage_dir).preserved_copies.find_by!(preserved_object: po) }
+  let(:logger_double) { instance_double(ActiveSupport::Logger, info: nil, error: nil, add: nil) }
+
+  before do
+    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
+    allow(described_class).to receive(:logger).and_return(logger_double) # silence log output
+  end
 
   include_context 'fixture moabs in db'
 


### PR DESCRIPTION
- Silence spammy log output during tests
- Minor refactor for reuse, associations and `find_by!` in test setups for consistency and reliability

Note that the CI for this PR is not cluttered with 500 lines of log output in the middle of the "green dots".