### PR TITLE
Custom capistrano for resque-pool

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,7 @@ Metrics/BlockLength:
     - 'lib/tasks/c2m_tasks.rake'
     - 'lib/tasks/cv_tasks.rake'
     - 'lib/tasks/m2c_tasks.rake'
+    - 'lib/capistrano/tasks/capistrano-resque-pool.rake' # shameless green cribbing from capistrano-resque-pool
     - 'spec/**/*'
 
 Metrics/BlockNesting:
@@ -112,6 +113,7 @@ Metrics/LineLength:
     - 'config/schedule.rb'
     - 'lib/tasks/c2m_tasks.rake'
     - 'lib/tasks/m2c_tasks.rake'
+    - 'lib/capistrano/tasks/capistrano-resque-pool.rake' # lines 12-13
     - 'spec/controllers/catalog_controller_spec.rb'
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # 1 line 126
     - 'spec/lib/audit/checksum_spec.rb'

--- a/Capfile
+++ b/Capfile
@@ -13,7 +13,6 @@ require "capistrano/rails/migrations"
 require "capistrano/passenger"
 require "capistrano/honeybadger"
 require "dlss/capistrano"
-require 'capistrano-resque-pool'
 require 'whenever/capistrano'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined

--- a/Gemfile
+++ b/Gemfile
@@ -56,5 +56,4 @@ group :deploy do
   gem 'capistrano-rails'
   gem 'capistrano-passenger'
   gem 'dlss-capistrano'
-  gem 'capistrano-resque-pool'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,9 +90,6 @@ GEM
     capistrano-rails (1.4.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capistrano-resque-pool (0.1.2)
-      capistrano
-      resque-pool
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
     coderay (1.1.2)
@@ -358,7 +355,6 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.9.1)
   capistrano-passenger
   capistrano-rails
-  capistrano-resque-pool
   config
   coveralls
   dlss-capistrano

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,7 +18,8 @@ set :deploy_to, "/opt/app/pres/#{fetch(:application)}"
 # set :pty, true
 
 # Default value for :linked_files is []
-append :linked_files, "config/database.yml", "config/resque.yml", "config/resque-pool.yml"
+append :linked_files, "config/database.yml", "config/resque.yml",
+       "config/resque-pool.yml", "config/resque-pool-east.yml", "config/resque-pool-west.yml"
 
 # Default value for linked_dirs is []
 append :linked_dirs, "log", "config/settings" # , "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
@@ -43,8 +44,6 @@ before 'deploy:migrate', 'shared_configs:update'
 after 'deploy:migrate', 'db_seed'
 
 before 'deploy:migrate', 'resque:pool:stop'
-# using stop and start instead of restart
-# because restart is not reliable
 after 'deploy:restart', 'resque:pool:start'
 
 desc 'Run rake db:seed'

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -7,3 +7,6 @@ set :rails_env, 'production'
 set :bundle_without, 'deploy test'
 set :deploy_to, '/opt/app/pres/preservation_catalog'
 set :whenever_roles, [:m2c, :c2m, :cv]
+
+set :east_bucket_name, 'sul-sdr-aws-us-east-1-archive'
+set :west_bukcet_name, 'sul-sdr-aws-us-west-2-archive'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -6,3 +6,6 @@ set :rails_env, 'production'
 set :bundle_without, 'deploy test'
 set :deploy_to, '/opt/app/pres/preservation_catalog'
 append :linked_files, "config/newrelic.yml", "config/resque.yml"
+
+set :east_bucket_name, 'sul-sdr-aws-us-east-1-test'
+set :west_bukcet_name, 'sul-sdr-aws-us-west-2-test'

--- a/lib/capistrano/tasks/capistrano-resque-pool.rake
+++ b/lib/capistrano/tasks/capistrano-resque-pool.rake
@@ -1,0 +1,95 @@
+namespace :resque do
+  namespace :pool do
+    def rails_env
+      fetch(:resque_rails_env) || fetch(:rails_env) || fetch(:stage)
+    end
+
+    desc 'Start all the workers and queues'
+    task :start do
+      on roles(workers) do
+        within app_path do
+          execute "cd preservation_catalog/current ; bundle exec resque-pool --daemon --environment #{rails_env}"
+          execute "cd preservation_catalog/current ; AWS_PROFILE=us_east_1 AWS_BUCKET_NAME=#{fetch(:east_bucket_name)} bundle exec resque-pool -d -E #{rails_env} -c #{east_config_path} -p #{east_pid_path}"
+          execute "cd preservation_catalog/current ; AWS_PROFILE=us_west_2 AWS_BUCKET_NAME=#{fetch(:west_bucket_name)} bundle exec resque-pool -d -E #{rails_env} -c #{west_config_path} -p #{west_pid_path}"
+        end
+      end
+    end
+
+    desc 'Gracefully shut down workers and shutdown the manager after all workers are done'
+    task :stop do
+      on roles(workers) do
+        if pid_file_exists?
+          pid = capture(:cat, pid_path)
+          if test "kill -0 #{pid} > /dev/null 2>&1"
+            execute :kill, "-s QUIT #{pid}"
+          else
+            info "Process #{pid} from #{pid_path} is not running, cleaning up stale PID file"
+            execute :rm, pid_path
+          end
+        end
+        if east_pid_file_exists?
+          pid = capture(:cat, east_pid_path)
+          if test "kill -0 #{pid} > /dev/null 2>&1"
+            execute :kill, "-s QUIT #{pid}"
+          else
+            info "Process #{pid} from #{east_pid_path} is not running, cleaning up stale PID file"
+            execute :rm, east_pid_path
+          end
+        end
+        if west_pid_file_exists?
+          pid = capture(:cat, west_pid_path)
+          if test "kill -0 #{pid} > /dev/null 2>&1"
+            execute :kill, "-s QUIT #{pid}"
+          else
+            info "Process #{pid} from #{west_pid_path} is not running, cleaning up stale PID file"
+            execute :rm, west_pid_path
+          end
+        end
+      end
+    end
+
+    def app_path
+      File.join(fetch(:deploy_to), 'current')
+    end
+
+    def config_path
+      File.join(app_path, '/config/resque-pool.yml')
+    end
+
+    def east_config_path
+      File.join(app_path, '/config/resque-pool-east.yml')
+    end
+
+    def west_config_path
+      File.join(app_path, '/config/resque-pool-west.yml')
+    end
+
+    def pid_path
+      File.join(app_path, '/tmp/pids/resque-pool.pid')
+    end
+
+    def east_pid_path
+      File.join(app_path, '/tmp/pids/resque-pool-east.pid')
+    end
+
+    def west_pid_path
+      File.join(app_path, '/tmp/pids/resque-pool-west.pid')
+    end
+
+    def pid_file_exists?
+      test("[ -f #{pid_path} ]")
+    end
+
+    def east_pid_file_exists?
+      test("[ -f #{east_pid_path} ]")
+    end
+
+    def west_pid_file_exists?
+      test("[ -f #{west_pid_path} ]")
+    end
+
+    def workers
+      fetch(:resque_server_roles) || :app
+    end
+  end
+end


### PR DESCRIPTION
The commands we were using from `capistrano-resque-pool` spun up a single pool of workers with no additional knowledge of their environment. The `resque-pool` service on the worker machines, however, spins up 3 pools of workers, where two of the pools have environment variables assigned telling them which credentials and buckets to use to replicate to. This PR intends to mirror the sevice set up through custom capistrano rake tasks, based off of what is in `capistrano-resque-pool`.

Happily, with this PR, objects make it all the way through the replication pipeline consistently across deployments.