### PR TITLE
Replication trigger (part 1): auto-filling DMZ's on PC creation

### DIFF
--- a/app/jobs/plexer_job.rb
+++ b/app/jobs/plexer_job.rb
@@ -1,6 +1,6 @@
-# Preconditions:
+# Precondition(s):
 #  All needed PreservedCopy and ZippedMoabVersion rows are already made.
-#  Possible TODO: replace precondition w/ invocation of PO2PC/PC2APC method.
+# @see PreservedCopy#create_zipped_moab_versions!
 #
 # Responsibilities:
 # Record zip part metadata info in DB.

--- a/app/lib/audit/moab_to_catalog.rb
+++ b/app/lib/audit/moab_to_catalog.rb
@@ -94,11 +94,11 @@ module Audit
 
     # @todo This method may not be useful anymore.  Every PC has 1..n DMZs, so either this method must
     # figure out how to specially delete them too, or we can loosen the restrictions from PC to ZMV
-    # @todo Move this method (and pouplate_endpoint/seed_catalog_for_dir) onto the Endpoint model
-    def self.drop_moab_storage_root(endpoint_name)
-      endpoint = Endpoint.find_by!(endpoint_name: endpoint_name.to_s)
+    # @todo Move this method (and pouplate_m_s_r/seed_catalog_for_dir) onto the MoabStorageRoot model
+    def self.drop_moab_storage_root(name)
+      ms_root = MoabStorageRoot.find_by!(name: name.to_s)
       ApplicationRecord.transaction do
-        endpoint.preserved_copies.destroy_all
+        ms_root.preserved_copies.destroy_all
         PreservedObject.without_preserved_copies.destroy_all
       end
     end

--- a/app/lib/audit/moab_to_catalog.rb
+++ b/app/lib/audit/moab_to_catalog.rb
@@ -92,13 +92,14 @@ module Audit
       Profiler.print_profile('M2C_check_existence_for_all_storage_roots') { check_existence_for_all_storage_roots }
     end
 
-    def self.drop_moab_storage_root(name)
+    # @todo This method may not be useful anymore.  Every PC has 1..n DMZs, so either this method must
+    # figure out how to specially delete them too, or we can loosen the restrictions from PC to ZMV
+    # @todo Move this method (and pouplate_endpoint/seed_catalog_for_dir) onto the Endpoint model
+    def self.drop_moab_storage_root(endpoint_name)
+      endpoint = Endpoint.find_by!(endpoint_name: endpoint_name.to_s)
       ApplicationRecord.transaction do
-        PreservedCopy.joins(:moab_storage_root).where(
-          "moab_storage_roots.name = :name",
-          name: name.to_s
-        ).destroy_all
-        PreservedObject.left_outer_joins(:preserved_copies).where(preserved_copies: { id: nil }).destroy_all
+        endpoint.preserved_copies.destroy_all
+        PreservedObject.without_preserved_copies.destroy_all
       end
     end
 

--- a/app/lib/audit/moab_to_catalog.rb
+++ b/app/lib/audit/moab_to_catalog.rb
@@ -92,7 +92,7 @@ module Audit
       Profiler.print_profile('M2C_check_existence_for_all_storage_roots') { check_existence_for_all_storage_roots }
     end
 
-    # @todo This method may not be useful anymore.  Every PC has 1..n DMZs, so either this method must
+    # @todo This method may not be useful anymore.  Every PC has 1..n ZMVs, so either this method must
     # figure out how to specially delete them too, or we can loosen the restrictions from PC to ZMV
     # @todo Move this method (and pouplate_m_s_r/seed_catalog_for_dir) onto the MoabStorageRoot model
     def self.drop_moab_storage_root(name)

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -1,5 +1,5 @@
 ##
-# PreservedCopy represents a concrete instance of a PreservedObject version, in physical storage on some node.
+# PreservedCopy represents a concrete instance of a PreservedObject across ALL versions, in physical storage.
 class PreservedCopy < ApplicationRecord
   OK_STATUS = 'ok'.freeze
   INVALID_MOAB_STATUS = 'invalid_moab'.freeze

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -30,12 +30,14 @@ class PreservedCopy < ApplicationRecord
 
   delegate :s3_key, to: :druid_version_zip
 
+<<<<<<< HEAD
   validates :moab_storage_root, presence: true
   validates :preserved_object, presence: true
+=======
+  validates :endpoint, :preserved_object, :status, :version, presence: true
+>>>>>>> Remove redundant modeling
   # NOTE: size here is approximate and not used for fixity checking
   validates :size, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
-  validates :status, inclusion: { in: statuses.keys }
-  validates :version, presence: true
 
   scope :by_moab_storage_root_name, lambda { |name|
     joins(:moab_storage_root).where(moab_storage_roots: { name: name })

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -1,5 +1,5 @@
 ##
-# PreservedCopy represents a concrete instance of a PreservedObject, in physical storage on some node.
+# PreservedCopy represents a concrete instance of a PreservedObject version, in physical storage on some node.
 class PreservedCopy < ApplicationRecord
   OK_STATUS = 'ok'.freeze
   INVALID_MOAB_STATUS = 'invalid_moab'.freeze
@@ -93,7 +93,6 @@ class PreservedCopy < ApplicationRecord
   # @todo reroute to large object pipeline instead of raise
   def replicate!
     raise 'PreservedCopy must be persisted' unless persisted?
-    raise "#{size} is too large for pipeline" if size > 9_999_500_000 # build in overhead for zip structure
     ZipmakerJob.perform_later(preserved_object.druid, version)
   end
 

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -24,9 +24,8 @@ class PreservedCopy < ApplicationRecord
     REPLICATED_COPY_NOT_FOUND_STATUS => 8
   }
 
-  after_create do |pc| # rubocop:disable Style/SymbolProc
-    pc.create_zipped_moab_versions!
-  end
+  after_create :create_zipped_moab_versions!
+  after_update :create_zipped_moab_versions!, if: :saved_change_to_version? # an ActiveRecord dynamic method
 
   belongs_to :preserved_object, inverse_of: :preserved_copies
   belongs_to :moab_storage_root, inverse_of: :preserved_copies

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -24,18 +24,15 @@ class PreservedCopy < ApplicationRecord
     REPLICATED_COPY_NOT_FOUND_STATUS => 8
   }
 
+  after_create(&:create_zipped_moab_versions!)
+
   belongs_to :preserved_object, inverse_of: :preserved_copies
   belongs_to :moab_storage_root, inverse_of: :preserved_copies
   has_many :zipped_moab_versions, dependent: :restrict_with_exception, inverse_of: :preserved_copy
 
   delegate :s3_key, to: :druid_version_zip
 
-<<<<<<< HEAD
-  validates :moab_storage_root, presence: true
-  validates :preserved_object, presence: true
-=======
-  validates :endpoint, :preserved_object, :status, :version, presence: true
->>>>>>> Remove redundant modeling
+  validates :moab_storage_root, :preserved_object, :status, :version, presence: true
   # NOTE: size here is approximate and not used for fixity checking
   validates :size, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
 
@@ -71,19 +68,12 @@ class PreservedCopy < ApplicationRecord
     # to 0 for nulls, which sorts before 1 for non-nulls, which are then sorted by last_checksum_validation)
   }
 
-  # given a version, create any ZippedMoabVersion records for that version which don't yet exist for
-  #  zip_endpoints which implement the parent PreservedObject's PreservationPolicy.
-  # @param archive_vers [Integer] the version for which archive preserved copies should be created.  must be between
-  #   1 and this PreservedCopy's version (inclusive).  Because there's a ZippedMoabVersion for
-  #   each version for each zip_endpoint (whereas there is one PreservedCopy for an entire online Moab).
+  # For *this* version, create any ZippedMoabVersion records which don't yet exist for
+  # ZipEndpoints on the parent PreservedObject's PreservationPolicy.
   # @return [Array<ZippedMoabVersion>] the ZippedMoabVersion records that were created
-  def create_zipped_moab_versions!(archive_vers)
-    unless archive_vers > 0 && archive_vers <= version
-      raise ArgumentError, "archive_vers (#{archive_vers}) must be between 0 and version (#{version})"
-    end
-
-    params = ZipEndpoint.which_need_archive_copy(preserved_object.druid, archive_vers).map do |zep|
-      { version: archive_vers, zip_endpoint: zep, status: 'unreplicated' }
+  def create_zipped_moab_versions!
+    params = ZipEndpoint.which_need_archive_copy(preserved_object.druid, version).map do |zep|
+      { version: version, zip_endpoint: zep, status: 'unreplicated' }
     end
     zipped_moab_versions.create!(params)
   end

--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -24,7 +24,9 @@ class PreservedCopy < ApplicationRecord
     REPLICATED_COPY_NOT_FOUND_STATUS => 8
   }
 
-  after_create(&:create_zipped_moab_versions!)
+  after_create do |pc| # rubocop:disable Style/SymbolProc
+    pc.create_zipped_moab_versions!
+  end
 
   belongs_to :preserved_object, inverse_of: :preserved_copies
   belongs_to :moab_storage_root, inverse_of: :preserved_copies
@@ -79,8 +81,7 @@ class PreservedCopy < ApplicationRecord
   end
 
   # Send to asynchronous replication pipeline
-  # @raise [RuntimeError] if object is unpersisted or too large (>=~10GB)
-  # @todo reroute to large object pipeline instead of raise
+  # @raise [RuntimeError] if object is unpersisted
   def replicate!
     raise 'PreservedCopy must be persisted' unless persisted?
     ZipmakerJob.perform_later(preserved_object.druid, version)

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -15,6 +15,8 @@ class PreservedObject < ApplicationRecord
   validates :current_version, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :preservation_policy, null: false
 
+  scope :without_preserved_copies, lambda { left_outer_joins(:preserved_copies).where(preserved_copies: { id: nil }) }
+
   # Spawn asynchronous checks of all existing archive preserved_copies.
   # This logic is similar to PlexerJob, for a different purpose.
   # This should implement the start of the replication process if status is unreplicated for an archival pres_copy

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -15,7 +15,7 @@ class PreservedObject < ApplicationRecord
   validates :current_version, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :preservation_policy, null: false
 
-  scope :without_preserved_copies, lambda { left_outer_joins(:preserved_copies).where(preserved_copies: { id: nil }) }
+  scope :without_preserved_copies, -> { left_outer_joins(:preserved_copies).where(preserved_copies: { id: nil }) }
 
   # Spawn asynchronous checks of all existing archive preserved_copies.
   # This logic is similar to PlexerJob, for a different purpose.

--- a/app/models/zipped_moab_version.rb
+++ b/app/models/zipped_moab_version.rb
@@ -6,8 +6,8 @@
 #
 # @note Does not have size independent of part(s)
 class ZippedMoabVersion < ApplicationRecord
-  belongs_to :preserved_copy
-  belongs_to :zip_endpoint
+  belongs_to :preserved_copy, inverse_of: :zipped_moab_versions
+  belongs_to :zip_endpoint, inverse_of: :zipped_moab_versions
   has_many :zip_parts, dependent: :destroy, inverse_of: :zipped_moab_version
   has_one :preserved_object, through: :preserved_copy, dependent: :restrict_with_exception
 

--- a/app/models/zipped_moab_version.rb
+++ b/app/models/zipped_moab_version.rb
@@ -11,8 +11,6 @@ class ZippedMoabVersion < ApplicationRecord
   has_many :zip_parts, dependent: :destroy, inverse_of: :zipped_moab_version
   has_one :preserved_object, through: :preserved_copy, dependent: :restrict_with_exception
 
-  delegate :preserved_object, to: :preserved_copy
-
   # @note Hash values cannot be modified without migrating any associated persisted data.
   # @see [enum docs] http://api.rubyonrails.org/classes/ActiveRecord/Enum.html
   enum status: {
@@ -22,10 +20,7 @@ class ZippedMoabVersion < ApplicationRecord
     'invalid_checksum' => 3
   }
 
-  validates :zip_endpoint, presence: true
-  validates :preserved_copy, presence: true
-  validates :status, inclusion: { in: statuses.keys }
-  validates :version, presence: true
+  validates :preserved_copy, :status, :version, :zip_endpoint, presence: true
 
   scope :by_druid, lambda { |druid|
     joins(preserved_copy: [:preserved_object]).where(preserved_objects: { druid: druid })

--- a/spec/factories/zipped_moab_versions.rb
+++ b/spec/factories/zipped_moab_versions.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
+  # Because ZMVs are auto-created in callback, you probably don't create from this factory directly.
+  # Instead create a :preserved_copy and get the zipped_moab_versions from it
   factory :zipped_moab_version do
     status 'unreplicated'
     version 1

--- a/spec/jobs/integration_spec.rb
+++ b/spec/jobs/integration_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'the whole replication pipeline', type: :job do # rubocop:disable RSpec/DescribeClass
   let(:s3_object) { instance_double(Aws::S3::Object, exists?: false, put: true) }
   let(:bucket) { instance_double(Aws::S3::Bucket, object: s3_object) }
-  let(:zmv) { create(:zipped_moab_version) }
+  let(:zmv) { create(:preserved_copy).zipped_moab_versions.first! }
   let(:druid) { zmv.preserved_object.druid }
   let(:version) { zmv.version }
   let(:deliverer) { zmv.zip_endpoint.delivery_class.to_s }
@@ -20,7 +20,6 @@ describe 'the whole replication pipeline', type: :job do # rubocop:disable RSpec
   end
 
   before do
-    ZipEndpoint.destroy_all # seeds are trash
     FactoryBot.reload # we need the "first" PO, bj102hs9687, for PC to line up w/ fixture
     allow(Settings).to receive(:zip_storage).and_return(Rails.root.join('spec', 'fixtures', 'zip_storage'))
     allow(PreservationCatalog::S3).to receive(:bucket).and_return(bucket)

--- a/spec/jobs/results_recorder_job_spec.rb
+++ b/spec/jobs/results_recorder_job_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 describe ResultsRecorderJob, type: :job do
-  let(:zmv) { create(:zipped_moab_version) }
+  let(:pc) { create(:preserved_copy) }
+  let(:zmv) { pc.zipped_moab_versions.first }
   let(:druid) { zmv.preserved_object.druid }
   let(:zip_endpoint) { zmv.zip_endpoint }
 
@@ -39,7 +40,7 @@ describe ResultsRecorderJob, type: :job do
     let(:other_ep) { create(:zip_endpoint, delivery_class: 2) }
 
     before do
-      create(:zipped_moab_version, preserved_copy: zmv.preserved_copy, zip_endpoint: other_ep)
+      pc.zipped_moab_versions.create!(version: zmv.version, status: 'unreplicated', zip_endpoint: other_ep)
     end
 
     it 'does not send to replication.results queue' do

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -4,6 +4,16 @@ require 'stringio'
 RSpec.describe Audit::MoabToCatalog do
   let(:storage_dir) { 'spec/fixtures/storage_root01/sdr2objects' }
   let(:ms_root) { MoabStorageRoot.find_by!(storage_location: storage_dir) }
+  let(:mock_profiler) do
+    prof = instance_double(Profiler, prof: nil)
+    allow(Profiler).to receive(:new).and_return(prof)
+    prof
+  end
+  let(:moab) do
+    m = instance_double(Moab::StorageObject, object_pathname: storage_dir, :storage_root= => nil)
+    allow(Moab::StorageObject).to receive(:new).and_return(m)
+    m
+  end
 
   before do
     PreservationPolicy.seed_from_config
@@ -23,94 +33,60 @@ RSpec.describe Audit::MoabToCatalog do
   end
 
   describe ".check_existence_for_all_storage_roots" do
-    let(:subject) { described_class.check_existence_for_all_storage_roots }
-
     it 'calls check_existence_for_dir once per storage root' do
       expect(described_class).to receive(:check_existence_for_dir).exactly(HostSettings.storage_roots.entries.count).times
-      subject
+      described_class.check_existence_for_all_storage_roots
     end
 
     it 'calls check_existence_for_dir with the right arguments' do
       HostSettings.storage_roots.to_h.each_value do |path|
         expect(described_class).to receive(:check_existence_for_dir).with("#{path}/#{Settings.moab.storage_trunk}")
       end
-      subject
+      described_class.check_existence_for_all_storage_roots
     end
   end
 
   describe ".check_existence_for_all_storage_roots_profiled" do
-    let(:subject) { described_class.check_existence_for_all_storage_roots_profiled }
-
     it "spins up a profiler, calling profiling and printing methods on it" do
-      mock_profiler = instance_double(Profiler)
-      expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
       expect(mock_profiler).to receive(:print_results_flat).with('M2C_check_existence_for_all_storage_roots')
-
-      subject
+      described_class.check_existence_for_all_storage_roots_profiled
     end
   end
 
   describe ".seed_catalog_for_all_storage_roots" do
-    let(:subject) { described_class.seed_catalog_for_all_storage_roots }
-
     it 'calls seed_catalog_for_dir once per storage root' do
       expect(described_class).to receive(:seed_catalog_for_dir).exactly(HostSettings.storage_roots.entries.count).times
-      subject
+      described_class.seed_catalog_for_all_storage_roots
     end
 
     it 'calls seed_catalog_for_dir with the right arguments' do
       HostSettings.storage_roots.to_h.each_value do |path|
         expect(described_class).to receive(:seed_catalog_for_dir).with("#{path}/#{Settings.moab.storage_trunk}")
       end
-      subject
+      described_class.seed_catalog_for_all_storage_roots
     end
   end
 
   describe ".seed_catalog_for_all_storage_roots_profiled" do
-    let(:subject) { described_class.seed_catalog_for_all_storage_roots_profiled }
-
     it "spins up a profiler, calling profiling and printing methods on it" do
-      mock_profiler = instance_double(Profiler)
-
-      expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
       expect(mock_profiler).to receive(:print_results_flat).with('seed_catalog_for_all_storage_roots')
-
-      subject
+      described_class.seed_catalog_for_all_storage_roots_profiled
     end
   end
 
   describe ".check_existence_for_dir" do
-    let(:subject) { described_class.check_existence_for_dir(storage_dir) }
-
     it "calls 'find_moab_paths' with appropriate argument" do
       expect(Stanford::MoabStorageDirectory).to receive(:find_moab_paths).with(storage_dir)
-      subject
+      described_class.check_existence_for_dir(storage_dir)
     end
 
-    it 'gets moab current version from Moab::StorageObject' do
-      moab = instance_double(Moab::StorageObject)
-      allow(moab).to receive(:storage_root=)
-      allow(moab).to receive(:object_pathname).and_return(storage_dir)
-      allow(moab).to receive(:size)
+    it 'gets moab size and current version from Moab::StorageObject' do
       expect(moab).to receive(:current_version_id).at_least(1).times
-      allow(Moab::StorageObject).to receive(:new).and_return(moab)
-
-      expect(Moab::StorageServices).not_to receive(:new)
-      subject
-    end
-
-    it 'gets moab size from Moab::StorageObject' do
-      moab = instance_double(Moab::StorageObject)
-      allow(moab).to receive(:storage_root=)
-      allow(moab).to receive(:object_pathname).and_return(storage_dir)
-      allow(moab).to receive(:current_version_id)
       expect(moab).to receive(:size).at_least(1).times
-      allow(Moab::StorageObject).to receive(:new).and_return(moab)
-
       expect(Moab::StorageServices).not_to receive(:new)
-      subject
+      described_class.check_existence_for_dir(storage_dir)
     end
 
     context "(calls check_existence)" do
@@ -141,12 +117,12 @@ RSpec.describe Audit::MoabToCatalog do
           expect(arg_hash[:po_handler]).to receive(:check_existence).and_return(fake_codes)
         end
         # * 3 will magically give us a flat, 6 element array
-        expect(subject).to eq(fake_codes * 3)
+        expect(described_class.check_existence_for_dir(storage_dir)).to eq(fake_codes * 3)
       end
     end
 
     it "return correct number of results" do
-      expect(subject.count).to eq 6
+      expect(described_class.check_existence_for_dir(storage_dir).count).to eq 6
     end
     it "storage directory doesn't exist (misspelling, read write permissions)" do
       allow(MoabStorageRoot).to receive(:find_by!).and_return(instance_double(MoabStorageRoot))
@@ -155,28 +131,22 @@ RSpec.describe Audit::MoabToCatalog do
       )
     end
     it "storage directory exists but it is empty" do
-      storage_dir = 'spec/fixtures/empty/sdr2objects'
-      expect(described_class.check_existence_for_dir(storage_dir)).to eq []
+      expect(described_class.check_existence_for_dir('spec/fixtures/empty/sdr2objects')).to eq []
     end
   end
 
   describe ".check_existence_for_dir_profiled" do
     let(:storage_dir) { "spec/fixtures/storage_root01/sdr2objects" }
-    let(:subject) { described_class.check_existence_for_dir_profiled(storage_dir) }
 
     it "spins up a profiler, calling profiling and printing methods on it" do
-      mock_profiler = instance_double(Profiler)
-      expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
       expect(mock_profiler).to receive(:print_results_flat).with('M2C_check_existence_for_dir')
-
-      subject
+      described_class.check_existence_for_dir_profiled(storage_dir)
     end
   end
 
   describe '.check_existence_for_druid' do
     let(:druid) { 'bz514sm9647' }
-    let(:subject) { described_class.check_existence_for_druid(druid) }
     let(:results) do
       [{ db_obj_does_not_exist: "PreservedObject db object does not exist" },
        { created_new_object: "added object to db as it did not exist" }]
@@ -184,11 +154,11 @@ RSpec.describe Audit::MoabToCatalog do
 
     it 'finds the relevant moab' do
       expect(Stanford::StorageServices).to receive(:find_storage_object).with(druid).and_call_original
-      subject
+      described_class.check_existence_for_druid(druid)
     end
     it 'finds the correct MoabStorageRoot' do
       expect(MoabStorageRoot).to receive(:find_by!).with(storage_location: storage_dir)
-      subject
+      described_class.check_existence_for_druid(druid)
     end
     it 'calls pohandler.check_existence' do
       po_handler = instance_double('PreservedObjectHandler')
@@ -200,10 +170,10 @@ RSpec.describe Audit::MoabToCatalog do
       ).and_return(po_handler)
       expect(po_handler).to receive(:logger=)
       expect(po_handler).to receive(:check_existence)
-      subject
+      described_class.check_existence_for_druid(druid)
     end
     it 'returns results' do
-      expect(subject).to eq results
+      expect(described_class.check_existence_for_druid(druid)).to eq results
     end
   end
 
@@ -218,35 +188,16 @@ RSpec.describe Audit::MoabToCatalog do
   end
 
   describe ".seed_catalog_for_dir" do
-    let(:subject) { described_class.seed_catalog_for_dir(storage_dir) }
-
     it "calls 'find_moab_paths' with appropriate argument" do
       expect(Stanford::MoabStorageDirectory).to receive(:find_moab_paths).with(storage_dir)
-      subject
+      described_class.seed_catalog_for_dir(storage_dir)
     end
 
-    it 'gets moab current version from Moab::StorageObject' do
-      moab = instance_double(Moab::StorageObject)
-      allow(moab).to receive(:storage_root=)
-      allow(moab).to receive(:object_pathname).and_return(storage_dir)
-      allow(moab).to receive(:size)
-      expect(moab).to receive(:current_version_id).at_least(1).times
-      allow(Moab::StorageObject).to receive(:new).and_return(moab)
-
-      expect(Moab::StorageServices).not_to receive(:new)
-      subject
-    end
-
-    it 'gets moab size from Moab::StorageObject' do
-      moab = instance_double(Moab::StorageObject)
-      allow(moab).to receive(:storage_root=)
-      allow(moab).to receive(:object_pathname).and_return(storage_dir)
-      allow(moab).to receive(:current_version_id)
+    it 'gets moab size and current version from Moab::StorageObject' do
       expect(moab).to receive(:size).at_least(1).times
-      allow(Moab::StorageObject).to receive(:new).and_return(moab)
-
+      expect(moab).to receive(:current_version_id).at_least(1).times
       expect(Moab::StorageServices).not_to receive(:new)
-      subject
+      described_class.seed_catalog_for_dir(storage_dir)
     end
 
     context "(creates after validation)" do
@@ -274,12 +225,12 @@ RSpec.describe Audit::MoabToCatalog do
         expected_argument_list.each do |arg_hash|
           expect(arg_hash[:po_handler]).to receive(:create_after_validation)
         end
-        subject
+        described_class.seed_catalog_for_dir(storage_dir)
       end
     end
 
     it "return correct number of results" do
-      expect(subject.count).to eq 3
+      expect(described_class.seed_catalog_for_dir(storage_dir).count).to eq 3
     end
     it "storage directory doesn't exist (misspelling, read write permissions)" do
       allow(MoabStorageRoot).to receive(:find_by!).and_return(instance_double(MoabStorageRoot))
@@ -288,28 +239,19 @@ RSpec.describe Audit::MoabToCatalog do
       )
     end
     it "storage directory exists but it is empty" do
-      storage_dir = 'spec/fixtures/empty/sdr2objects'
-      expect(described_class.check_existence_for_dir(storage_dir)).to eq []
+      expect(described_class.check_existence_for_dir('spec/fixtures/empty/sdr2objects')).to eq []
     end
   end
 
   describe ".drop_moab_storage_root" do
-    let(:subject) { described_class.drop_moab_storage_root('fixture_sr1') }
-
-    before do
-      described_class.seed_catalog_for_all_storage_roots
-    end
+    before { described_class.seed_catalog_for_all_storage_roots }
 
     it 'drops PreservedCopies that correspond to the given moab storage root' do
-      expect(PreservedCopy.count).to eq 16
-      subject
-      expect(PreservedCopy.count).to eq 13
+      expect { described_class.drop_moab_storage_root('fixture_sr1') }.to change { PreservedCopy.count }.from(16).to(13)
     end
 
     it 'drops PreservedObjects that correspond to the given moab storage root' do
-      expect(PreservedObject.count).to eq 16
-      subject
-      expect(PreservedObject.count).to eq 13
+      expect { described_class.drop_moab_storage_root('fixture_sr1') }.to change { PreservedObject.count }.from(16).to(13)
     end
 
     it 'rolls back pres obj delete if pres copy cannot be deleted' do
@@ -318,52 +260,33 @@ RSpec.describe Audit::MoabToCatalog do
       allow(PreservedObject).to receive(:left_outer_joins).with(:preserved_copies).and_return(active_record_double1)
       allow(active_record_double1).to receive(:where).with(preserved_copies: { id: nil }).and_return(active_record_double2)
       allow(active_record_double2).to receive(:destroy_all).and_raise(ActiveRecord::ActiveRecordError, 'foo')
-      begin
-        subject
-      rescue
-        # Expect this to fail and don't need error handling in the .drop_moab_storage_root class method
-        # let subject still run instead of catching ActiveRecordError and stop the execution
-      end
+      expect { described_class.drop_moab_storage_root('fixture_sr1') }.to raise_error(ActiveRecord::ActiveRecordError)
       expect(PreservedCopy.count).to eq 16
       expect(PreservedObject.count).to eq 16
     end
   end
 
   describe ".populate_moab_storage_root" do
-    let(:root_name) { 'fixture_sr1' }
-    let(:subject) { described_class.populate_moab_storage_root(root_name) }
-
-    before do
-      described_class.seed_catalog_for_all_storage_roots
-    end
+    before { described_class.seed_catalog_for_all_storage_roots }
 
     it "won't change objects in a fully seeded db" do
-      subject
-      expect(PreservedCopy.count).to eq 16
+      expect { described_class.populate_moab_storage_root('fixture_sr1') }.not_to change { PreservedCopy.count }.from(16)
       expect(PreservedObject.count).to eq 16
     end
 
     it 're-adds objects for a dropped MoabStorageRoot' do
-      described_class.drop_moab_storage_root(root_name)
-      expect(PreservedCopy.count).to eq 13
+      described_class.drop_moab_storage_root('fixture_sr1')
       expect(PreservedObject.count).to eq 13
-      subject
-      expect(PreservedCopy.count).to eq 16
+      expect { described_class.populate_endpoint('fixture_sr1') }.to change { PreservedCopy.count }.from(13).to(16)
       expect(PreservedObject.count).to eq 16
     end
   end
 
   describe ".populate_moab_storage_root_profiled" do
-    let(:root) { 'fixture_sr1' }
-    let(:subject) { described_class.populate_moab_storage_root_profiled(root) }
-
     it "spins up a profiler, calling profiling and printing methods on it" do
-      mock_profiler = instance_double(Profiler)
-      expect(Profiler).to receive(:new).and_return(mock_profiler)
       expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat).with('populate_moab_storage_root')
-
-      subject
+      expect(mock_profiler).to receive(:print_results_flat).with('populate_endpoint')
+      described_class.populate_endpoint_profiled('fixture_sr1')
     end
   end
 end

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Audit::MoabToCatalog do
       ZippedMoabVersion.destroy_all
       described_class.drop_moab_storage_root('fixture_sr1')
       expect(PreservedObject.count).to eq 13
-      expect { described_class.populate_endpoint('fixture_sr1') }.to change { PreservedCopy.count }.from(13).to(16)
+      expect { described_class.populate_moab_storage_root('fixture_sr1') }.to change { PreservedCopy.count }.from(13).to(16)
       expect(PreservedObject.count).to eq 16
     end
   end
@@ -283,8 +283,8 @@ RSpec.describe Audit::MoabToCatalog do
   describe ".populate_moab_storage_root_profiled" do
     it "spins up a profiler, calling profiling and printing methods on it" do
       expect(mock_profiler).to receive(:prof)
-      expect(mock_profiler).to receive(:print_results_flat).with('populate_endpoint')
-      described_class.populate_endpoint_profiled('fixture_sr1')
+      expect(mock_profiler).to receive(:print_results_flat).with('populate_moab_storage_root')
+      described_class.populate_moab_storage_root_profiled('fixture_sr1')
     end
   end
 end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -321,49 +321,42 @@ RSpec.describe PreservedCopy, type: :model do
   describe '#create_zipped_moab_versions!' do
     let(:pc_version) { 3 }
     let(:archive_ep) { ZipEndpoint.find_by!(endpoint_name: 'mock_archive1') }
-    let(:new_archive_ep) { create(:zip_endpoint, endpoint_name: 'mock_archive2') }
+    let(:zmvs_by_druid) { ZippedMoabVersion.by_druid(druid) }
+
+    before { pc.zipped_moab_versions.destroy_all } # undo auto-spawned rows from callback
 
     it "creates pres copies that don't yet exist for the given version, but should" do
-      expect { pc.create_zipped_moab_versions!(pc_version) }.to change {
+      expect { pc.create_zipped_moab_versions! }.to change {
         ZipEndpoint.which_need_archive_copy(druid, pc_version).to_a
-      }.from([archive_ep]).to([])
+      }.from([archive_ep]).to([]).and change {
+        zmvs_by_druid.where(version: pc_version).count
+      }.from(0).to(1)
 
-      expect(ZippedMoabVersion.by_druid(druid).count).to eq 1
-
-      expect { pc.create_zipped_moab_versions!(pc_version - 1) }.to change {
-        ZipEndpoint.which_need_archive_copy(druid, pc_version - 1).to_a
-      }.from([archive_ep]).to([])
-      expect(ZippedMoabVersion.by_druid(druid).count).to eq 2
-
-      expect(ZippedMoabVersion.by_druid(druid).where(version: 1).count).to eq 0
+      expect(zmvs_by_druid.where(version: 1).count).to eq 0
     end
 
     it 'creates the pres copies so that they start with unreplicated status' do
-      expect(pc.create_zipped_moab_versions!(pc_version).all?(&:unreplicated?)).to be true
+      expect(pc.create_zipped_moab_versions!.all?(&:unreplicated?)).to be true
     end
 
-    it "creates pres copies that don't yet exist for the given moab_storage_root, but should" do
-      expect { pc.create_zipped_moab_versions!(pc_version) }.to change {
+    it "creates pres copies that don't yet exist for new endpoint, but should" do
+      expect { pc.create_zipped_moab_versions! }.to change {
         ZipEndpoint.which_need_archive_copy(druid, pc_version).to_a
-      }.from([archive_ep]).to([])
-      expect(ZippedMoabVersion.by_druid(druid).where(version: pc_version).count).to eq 1
+      }.from([archive_ep]).to([]).and change {
+        zmvs_by_druid.where(version: pc_version).count
+      }.from(0).to(1)
 
-      new_archive_ep.preservation_policies = [PreservationPolicy.default_policy]
-      expect { pc.create_zipped_moab_versions!(pc_version) }.to change {
+      new_archive_ep = create(
+        :zip_endpoint,
+        endpoint_name: 'mock_archive2',
+        preservation_policies: [PreservationPolicy.default_policy]
+      )
+
+      expect { pc.create_zipped_moab_versions! }.to change {
         ZipEndpoint.which_need_archive_copy(druid, pc_version).to_a
-      }.from([new_archive_ep]).to([])
-      expect(ZippedMoabVersion.by_druid(druid).where(version: pc_version).count).to eq 2
-    end
-
-    it 'checks that version is in range' do
-      [-1, 0, 4, 5].each do |version|
-        exp_err_msg = "archive_vers (#{version}) must be between 0 and version (#{pc_version})"
-        expect { pc.create_zipped_moab_versions!(version) }.to raise_error ArgumentError, exp_err_msg
-      end
-
-      (1..3).each do |version|
-        expect { pc.create_zipped_moab_versions!(version) }.not_to raise_error
-      end
+      }.from([new_archive_ep]).to([]).and change {
+        zmvs_by_druid.where(version: pc_version).count
+      }.from(1).to(2)
     end
   end
 end

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -325,21 +325,21 @@ RSpec.describe PreservedCopy, type: :model do
 
     before { pc.zipped_moab_versions.destroy_all } # undo auto-spawned rows from callback
 
-    it "creates pres copies that don't yet exist for the given version, but should" do
+    it "creates ZMVs that don't yet exist for expected versions, but should" do
       expect { pc.create_zipped_moab_versions! }.to change {
         ZipEndpoint.which_need_archive_copy(druid, pc_version).to_a
       }.from([archive_ep]).to([]).and change {
         zmvs_by_druid.where(version: pc_version).count
       }.from(0).to(1)
 
-      expect(zmvs_by_druid.where(version: 1).count).to eq 0
+      expect(zmvs_by_druid.pluck(:version).sort).to eq [1, 2, 3]
     end
 
-    it 'creates the pres copies so that they start with unreplicated status' do
+    it 'creates ZMVs so that they start with unreplicated status' do
       expect(pc.create_zipped_moab_versions!.all?(&:unreplicated?)).to be true
     end
 
-    it "creates pres copies that don't yet exist for new endpoint, but should" do
+    it "creates ZMVs that don't yet exist for new endpoint, but should" do
       expect { pc.create_zipped_moab_versions! }.to change {
         ZipEndpoint.which_need_archive_copy(druid, pc_version).to_a
       }.from([archive_ep]).to([]).and change {

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -73,12 +73,13 @@ RSpec.describe PreservedCopy, type: :model do
   it { is_expected.to have_many(:zipped_moab_versions) }
 
   describe '#replicate!' do
-    it 'raises if too large' do
-      pc.size = 10_000_000_000
-      expect { pc.replicate! }.to raise_error(RuntimeError, /too large/)
-    end
     it 'raises if unsaved' do
       expect { described_class.new(size: 1).replicate! }.to raise_error(RuntimeError, /must be persisted/)
+    end
+    it 'accepts large objects' do
+      allow(ZipmakerJob).to receive(:perform_later).with(preserved_object.druid, pc.version)
+      pc.size = 30_000_000_000
+      expect { pc.replicate! }.not_to raise_error
     end
     it 'passes druid and version to Zipmaker' do
       expect(ZipmakerJob).to receive(:perform_later).with(preserved_object.druid, pc.version)

--- a/spec/models/preserved_copy_spec.rb
+++ b/spec/models/preserved_copy_spec.rb
@@ -359,4 +359,17 @@ RSpec.describe PreservedCopy, type: :model do
       }.from(1).to(2)
     end
   end
+
+  describe '.after_update callback' do
+    it 'does not call create_zipped_moab_versions when version is unchanged' do
+      pc.size = 234
+      expect(pc).not_to receive(:create_zipped_moab_versions!)
+      pc.save!
+    end
+    it 'calls create_zipped_moab_versions when version was changed' do
+      pc.version = 55
+      expect(pc).to receive(:create_zipped_moab_versions!)
+      pc.save!
+    end
+  end
 end

--- a/spec/models/zip_part_spec.rb
+++ b/spec/models/zip_part_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ZipPart, type: :model do
-  let(:zmv) { create(:zipped_moab_version) }
+  let(:zmv) { build(:zipped_moab_version) }
   let(:args) { attributes_for(:zip_part).merge(zipped_moab_version: zmv) }
 
   it 'defines a status enum with the expected values' do


### PR DESCRIPTION
This mostly required revision of some bulky tests' expectations.

Note: 10GB cap on `replicate!` now removed!

Next phase would include handoff to replication after ZMV rows are created.