### PR TITLE
Fix TypeError when running M2C for a druid

### DIFF
--- a/app/lib/audit/moab_to_catalog.rb
+++ b/app/lib/audit/moab_to_catalog.rb
@@ -20,6 +20,8 @@ module Audit
       results = po_handler.check_existence
       logger.info "#{results} for #{druid}"
       results
+    rescue TypeError
+      logger.info "#{Time.now.utc.iso8601} Moab object path does not exist."
     ensure
       logger.info "#{Time.now.utc.iso8601} M2C check_existence_for_druid ended for #{druid}"
     end

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -205,6 +205,14 @@ RSpec.describe Audit::MoabToCatalog do
     it 'returns results' do
       expect(subject).to eq results
     end
+    context 'given a druid that does not exist' do
+      let(:druid) { 'db102hs2345' }
+
+      it 'does not call pohandler.check_existence' do
+        expect(PreservedObjectHandler).not_to receive(:new)
+        subject
+      end
+    end
   end
 
   describe '.check_existence_for_druid_list' do


### PR DESCRIPTION
When calling `Audit::MoabToCatalog.check_existence_for_druid('db102hs3456')` with a druid that doesn't exist, the method errors out with a `TypeError` because when we pass in `moab.size` to the `po_handler` it calls this method: 

```
def size
      size = 0
      Find.find(object_pathname) do |path|
        size += FileTest.size(path) unless FileTest.directory?(path)
      end
      size
end
```


If the path does not exist, then calling `size` will give `TypeError: no implicit conversion of Pathname into String`

closes #953 