### PR TITLE
Replication trigger (part 2, take 2): auto-hook replication

### DIFF
--- a/app/models/preserved_copy.rb
+++ b/app/models/preserved_copy.rb
@@ -84,13 +84,6 @@ class PreservedCopy < ApplicationRecord
     zipped_moab_versions.create!(params)
   end
 
-  # Send to asynchronous replication pipeline
-  # @raise [RuntimeError] if object is unpersisted
-  def replicate!
-    raise 'PreservedCopy must be persisted' unless persisted?
-    ZipmakerJob.perform_later(preserved_object.druid, version)
-  end
-
   # Send to asynchronous checksum validation pipeline
   def validate_checksums!
     ChecksumValidationJob.perform_later(self)
@@ -98,6 +91,11 @@ class PreservedCopy < ApplicationRecord
 
   def druid_version_zip
     @druid_version_zip ||= DruidVersionZip.new(preserved_object.druid, version)
+  end
+
+  # Based on object state and status, can it be fully replicated?
+  def replicatable_status?
+    %w[ok unreplicated replicated_copy_not_found].include?(status)
   end
 
   def update_audit_timestamps(moab_validated, version_audited)

--- a/app/models/zipped_moab_version.rb
+++ b/app/models/zipped_moab_version.rb
@@ -1,6 +1,6 @@
 # Corresponds to a Moab-Version on a ZipEndpoint.
 #   There will be individual parts (at least one) - see ZipPart.
-# For a fully consistent system, given an (Online) PreservedCopy, the number of associated
+# For a fully consistent system, given a PreservedCopy, the number of associated
 # ZippedMoabVersion objects should be:
 #   pc.preserved_object.current_version * number_of_zip_endpoints
 #
@@ -10,6 +10,10 @@ class ZippedMoabVersion < ApplicationRecord
   belongs_to :zip_endpoint, inverse_of: :zipped_moab_versions
   has_many :zip_parts, dependent: :destroy, inverse_of: :zipped_moab_version
   has_one :preserved_object, through: :preserved_copy, dependent: :restrict_with_exception
+
+  # Note: In the context of creating many ZMV rows, this may *attempt* to queue the same druid/version multiple times,
+  # but queue locking easily prevents duplicates (and the job is idempotent anyway).
+  after_create :replicate!
 
   # @note Hash values cannot be modified without migrating any associated persisted data.
   # @see [enum docs] http://api.rubyonrails.org/classes/ActiveRecord/Enum.html
@@ -25,4 +29,11 @@ class ZippedMoabVersion < ApplicationRecord
   scope :by_druid, lambda { |druid|
     joins(preserved_copy: [:preserved_object]).where(preserved_objects: { druid: druid })
   }
+
+  # Send to asynchronous replication pipeline
+  # @return [ZipmakerJob, false] false if unpersisted or parent PC has non-replicatable status
+  def replicate!
+    return false unless persisted? && preserved_copy.replicatable_status?
+    ZipmakerJob.perform_later(preserved_object.druid, version)
+  end
 end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -13,7 +13,10 @@ describe ApplicationJob, type: :job do
   end
 
   context 'a subclass with message(s) queued' do
-    before { ZipmakerJob.perform_later('1234abc', 1) }
+    before do
+      allow(ZipmakerJob).to receive(:perform_later).and_call_original # undo rails_helper block
+      ZipmakerJob.perform_later('1234abc', 1)
+    end
 
     it 'does not add duplicate messages' do
       expect { ZipmakerJob.perform_later('1234abc', 1) }

--- a/spec/jobs/zipmaker_job_spec.rb
+++ b/spec/jobs/zipmaker_job_spec.rb
@@ -10,6 +10,7 @@ describe ZipmakerJob, type: :job do
   end
 
   before do
+    allow(ZipmakerJob).to receive(:perform_later).and_call_original # undo rails_helper block
     allow(PlexerJob).to receive(:perform_later).with(any_args)
     allow(Settings).to receive(:zip_storage).and_return('spec/fixtures/zip_storage')
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,4 +53,7 @@ RSpec.configure do |config|
     end
   end
 
+  config.before do
+    allow(ZipmakerJob).to receive(:perform_later).with(any_args) # by default, block callback replication
+  end
 end


### PR DESCRIPTION
Added `replicatable_status?` to PC to encapsulate logic about whether it is OK to push dependent objects into pipeline.

`replicate!` doesn't raise, because that would make us unable to create PCs with non-replicatable statuses (since that auto-creates ZMVs) or ZMVs from such PCs.  Method is public on the anticipation of audit processes that might also invoke it directly.

Closes #989
