### PR TITLE
Additional rspec tests for ResultsRecorderJob and ZipParts

### DIFF
--- a/spec/jobs/results_recorder_job_spec.rb
+++ b/spec/jobs/results_recorder_job_spec.rb
@@ -18,13 +18,11 @@ describe ResultsRecorderJob, type: :job do
       expect(zmv.reload).to be_ok
     end
     it 'sets part status to ok' do
-      skip 'write test for individual part status'
-    end
-  end
-
-  context 'when some parts for zip_endpoint are replicated' do
-    it 'does not set parent zipped_moab_version status to ok' do
-      skip 'write test for parent zmv status'
+      expect {
+        described_class.perform_now(druid, zmv.version, 'fake.zip', zip_endpoint.delivery_class.to_s)
+      }.to change {
+        zmv.zip_parts.first.status
+      }.from("unreplicated").to("ok")
     end
   end
 

--- a/spec/models/zip_part_spec.rb
+++ b/spec/models/zip_part_spec.rb
@@ -29,6 +29,26 @@ RSpec.describe ZipPart, type: :model do
     end
   end
 
+  describe "#all_parts_replicated?" do
+    let(:zp) { described_class.new(args) }
+
+    it "returns false if status is 'unreplicated'" do
+      expect(zp.all_parts_replicated?).to be false
+    end
+    it "returns true if status is 'ok'" do
+      zp.ok!
+      expect(zp.all_parts_replicated?).to be true
+    end
+  end
+
+  describe "#suffixes_in_set" do
+    let(:zp) { described_class.new(args.merge(parts_count: 3)) }
+
+    it 'returns suffixes of all parts' do
+      expect(zp.suffixes_in_set).to eq [".zip", ".z01", ".z02"]
+    end
+  end
+
   it { is_expected.to validate_presence_of(:create_info) }
   it { is_expected.to validate_presence_of(:md5) }
   it { is_expected.to validate_presence_of(:parts_count) }


### PR DESCRIPTION
```
context 'when some parts for zip_endpoint are replicated' do
    it 'does not set parent zipped_moab_version status to ok' do
      skip
    end
end
```
- Moved this test to the the zip_part model to test the actual method that is doing this.
 ```
     zmv.ok! if part.all_parts_replicated? # are all of the parts replicated for this zip_endpoint?
    # only publish result if all of the parts replicated for all zip_endpoints
```


closes #967 
closes #964 