### PR TITLE
have ZippedMoabVersion#replicate! guard clause return nil instead of false, for consistent return types

### DIFF
--- a/app/models/zipped_moab_version.rb
+++ b/app/models/zipped_moab_version.rb
@@ -31,9 +31,9 @@ class ZippedMoabVersion < ApplicationRecord
   }
 
   # Send to asynchronous replication pipeline
-  # @return [ZipmakerJob, false] false if unpersisted or parent PC has non-replicatable status
+  # @return [ZipmakerJob, nil] nil if unpersisted or parent PC has non-replicatable status
   def replicate!
-    return false unless persisted? && complete_moab.replicatable_status?
+    return nil unless persisted? && complete_moab.replicatable_status?
     ZipmakerJob.perform_later(preserved_object.druid, version)
   end
 end

--- a/spec/models/zipped_moab_version_spec.rb
+++ b/spec/models/zipped_moab_version_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ZippedMoabVersion, type: :model do
     it 'if PC is unreplicatable, returns false, does not enqueue' do
       expect(cm).to receive(:replicatable_status?).and_return(false)
       expect(ZipmakerJob).not_to receive(:perform_later)
-      expect(zmv.replicate!).to be(false)
+      expect(zmv.replicate!).to be(nil)
     end
     it 'if PC is replicatable, passes druid and version to Zipmaker' do
       expect(cm).to receive(:replicatable_status?).and_return(true)


### PR DESCRIPTION
just being a little OCD about return types here.

feel free to close if this feels silly or counterproductive.  seemed better to merge #1018 than to hold it up over this, and it wasn't really harder to put up a PR than it was to file a ticket describing the issue.