### PR TITLE
POH use more OO, especially in specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,8 +47,7 @@ Layout/SpaceAroundEqualsInParameterDefault:
 Lint/AmbiguousBlockAssociation:
   # doesn't play nicely with rspec change syntax, e.g. "expect { foo }.to change { bar.field }"
   Exclude:
-    - spec/services/preserved_object_handler_update_version_spec.rb
-    - spec/services/shared_examples_preserved_object_handler.rb
+    - spec/services/*.rb
 
 Lint/HandleExceptions:
   Exclude:

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -6,7 +6,7 @@
 class PreservedObject < ApplicationRecord
   PREFIX_RE = /druid:/i
   belongs_to :preservation_policy
-  has_many :complete_moabs, dependent: :restrict_with_exception
+  has_many :complete_moabs, dependent: :restrict_with_exception, autosave: true
   validates :druid,
             presence: true,
             uniqueness: true,

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -174,15 +174,13 @@ class PreservedObjectHandler
     results.report_results
   end
 
-  protected
-
   def pres_object
     @pres_object ||= PreservedObject.find_by!(druid: druid)
   end
 
   def comp_moab
     # FIXME: what if there is more than one associated comp_moab?
-    @comp_moab ||= CompleteMoab.find_by!(preserved_object: pres_object, moab_storage_root: moab_storage_root)
+    @comp_moab ||= pres_object.complete_moabs.find_by!(moab_storage_root: moab_storage_root)
   end
 
   alias complete_moab comp_moab
@@ -190,11 +188,10 @@ class PreservedObjectHandler
   private
 
   def create_db_objects(status, checksums_validated = false)
-    pp_default_id = PreservationPolicy.default_policy.id
     transaction_ok = with_active_record_transaction_and_rescue do
       po = PreservedObject.create!(druid: druid,
                                    current_version: incoming_version,
-                                   preservation_policy_id: pp_default_id)
+                                   preservation_policy_id: PreservationPolicy.default_policy.id)
       cm_attrs = {
         preserved_object: po,
         version: incoming_version,
@@ -208,7 +205,7 @@ class PreservedObjectHandler
         cm_attrs[:last_moab_validation] = t
       end
       cm_attrs[:last_checksum_validation] = t if checksums_validated
-      CompleteMoab.create!(cm_attrs)
+      po.complete_moabs.create!(cm_attrs)
     end
 
     results.add_result(AuditResults::CREATED_NEW_OBJECT) if transaction_ok

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe PreservedObjectHandler do
 
         context 'when moab is valid' do
           before { allow(po_handler).to receive(:moab_validation_errors).and_return([]) }
+
           context 'CompleteMoab' do
             context 'changed' do
               before { allow(po_handler).to receive(:ran_moab_validation?).and_return(true) }
@@ -154,6 +155,7 @@ RSpec.describe PreservedObjectHandler do
               end
             end
           end
+
           context 'PreservedObject changed' do
             it 'current_version' do
               expect { po_handler.check_existence }.to change { po_handler.pres_object.current_version }
@@ -173,7 +175,7 @@ RSpec.describe PreservedObjectHandler do
 
             it 'ACTUAL_VERS_GT_DB_OBJ results' do
               expect(results).to be_an Array
-              expect(results.size).to eq 1 #
+              expect(results.size).to eq 1
               expect(results.first).to include(AuditResults::ACTUAL_VERS_GT_DB_OBJ => version_gt_cm_msg)
             end
           end

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -224,6 +224,7 @@ RSpec.describe PreservedObjectHandler do
           allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
           allow(po.complete_moabs).to receive(:find_by!).with(moab_storage_root: ms_root).and_return(cm)
         end
+
         it 'if the existing record is altered' do
           allow(po_handler).to receive(:moab_validation_errors).and_return([])
           expect(cm).to receive(:save!)

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe PreservedObjectHandler do
 
         context 'incoming_version > db version' do
           let(:incoming_version) { cm.version + 1 }
+
           before { allow(po_handler).to receive(:moab_validation_errors).and_return([]) }
 
           it 'had OK_STATUS, but is now UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
@@ -203,6 +204,7 @@ RSpec.describe PreservedObjectHandler do
       context 'db update error (ActiveRecordError)' do
         let(:result_code) { AuditResults::DB_UPDATE_FAILED }
         let(:incoming_version) { 2 }
+
         before do
           po = create(:preserved_object, current_version: 2)
           cm = create(:complete_moab, preserved_object: po, version: po.current_version)

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe PreservedObjectHandler do
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }
   let!(:default_prez_policy) { PreservationPolicy.default_policy }
-  let(:po) { PreservedObject.find_by(druid: druid) }
-  let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
-  let(:cm) { CompleteMoab.find_by(preserved_object: po, moab_storage_root: ms_root) }
+  let(:po) { PreservedObject.find_by!(druid: druid) }
+  let(:ms_root) { MoabStorageRoot.find_by!(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
+  let(:cm) { po.complete_moabs.find_by!(moab_storage_root: ms_root) }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ms_root) }
 
   describe '#confirm_version' do
@@ -36,12 +36,11 @@ RSpec.describe PreservedObjectHandler do
           name: 'diff_root',
           storage_location: 'blah'
         )
-        PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
+        create(:preserved_object, druid: druid, current_version: 2)
         po_handler = described_class.new(druid, 3, incoming_size, diff_root)
         results = po_handler.confirm_version
-        code = AuditResults::DB_OBJ_DOES_NOT_EXIST
-        exp_str = "ActiveRecord::RecordNotFound: Couldn't find CompleteMoab> db object does not exist"
-        expect(results).to include(a_hash_including(code => a_string_matching(exp_str)))
+        exp_str = "ActiveRecord::RecordNotFound: Couldn't find CompleteMoab.* db object does not exist"
+        expect(results).to include(a_hash_including(AuditResults::DB_OBJ_DOES_NOT_EXIST => a_string_matching(exp_str)))
         expect(PreservedObject.find_by(druid: druid).current_version).to eq 2
       end
 
@@ -52,39 +51,25 @@ RSpec.describe PreservedObjectHandler do
         context 'CompleteMoab' do
           context 'changed' do
             it 'last_version_audit' do
-              orig = Time.current
-              cm.last_version_audit = orig
-              cm.save!
-              po_handler.confirm_version
-              expect(cm.reload.last_version_audit).to be > orig
+              expect { po_handler.confirm_version }.to change { po_handler.complete_moab.last_version_audit }
             end
             it 'updated_at' do
-              orig = cm.updated_at
-              po_handler.confirm_version
-              expect(cm.reload.updated_at).to be > orig
+              expect { po_handler.confirm_version }.to change { po_handler.complete_moab.reload.updated_at }
             end
           end
 
           context 'unchanged' do
             it 'status' do
-              orig = cm.status
-              po_handler.confirm_version
-              expect(cm.reload.status).to eq orig
+              expect { po_handler.confirm_version }.not_to change { po_handler.complete_moab.status }
             end
             it 'version' do
-              orig = cm.version
-              po_handler.confirm_version
-              expect(cm.reload.version).to eq orig
+              expect { po_handler.confirm_version }.not_to change { po_handler.complete_moab.version }
             end
             it 'size' do
-              orig = cm.size
-              po_handler.confirm_version
-              expect(cm.reload.size).to eq orig
+              expect { po_handler.confirm_version }.not_to change { po_handler.complete_moab.size }
             end
             it 'last_moab_validation' do
-              orig = cm.last_moab_validation
-              po_handler.confirm_version
-              expect(cm.reload.last_moab_validation).to eq orig
+              expect { po_handler.confirm_version }.not_to change { po_handler.complete_moab.last_moab_validation }
             end
           end
         end
@@ -96,15 +81,12 @@ RSpec.describe PreservedObjectHandler do
         end
         it_behaves_like 'calls AuditResults.report_results', :confirm_version
         context 'returns' do
-          let!(:results) { po_handler.confirm_version }
+          let(:results) { po_handler.confirm_version }
 
-          it '1 result' do
+          it '1 result of VERSION_MATCHES' do
             expect(results).to be_an_instance_of Array
             expect(results.size).to eq 1
-          end
-          it 'VERSION_MATCHES results' do
-            code = AuditResults::VERSION_MATCHES
-            expect(results).to include(a_hash_including(code => version_matches_cm_msg))
+            expect(results.first).to match(a_hash_including(AuditResults::VERSION_MATCHES => version_matches_cm_msg))
           end
         end
       end
@@ -116,17 +98,15 @@ RSpec.describe PreservedObjectHandler do
 
         context 'incoming_version > db version' do
           let(:incoming_version) { cm.version + 1 }
+          before { allow(po_handler).to receive(:moab_validation_errors).and_return([]) }
 
           it 'had OK_STATUS, but is now UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
-            cm.status = 'ok'
-            cm.save!
-            allow(po_handler).to receive(:moab_validation_errors).and_return([])
+            cm.ok!
             po_handler.confirm_version
             expect(cm.reload.status).to eq 'unexpected_version_on_storage'
           end
           it 'had INVALID_MOAB_STATUS, structure seems to be remediated, but is now UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
-            cm.status = 'invalid_moab'
-            cm.save!
+            cm.invalid_moab!
             allow(po_handler).to receive(:moab_validation_errors).and_return([])
             po_handler.confirm_version
             expect(cm.reload.status).to eq 'unexpected_version_on_storage'
@@ -141,10 +121,8 @@ RSpec.describe PreservedObjectHandler do
         it_behaves_like 'calls AuditResults.report_results', :confirm_version
 
         context '' do
-          before do
-            # Note this context cannot work with shared_examples 'calls AuditResults.report_results
-            allow(po_handler).to receive(:moab_validation_errors).and_return([])
-          end
+          before { allow(po_handler).to receive(:moab_validation_errors).and_return([]) }
+          # Note this context cannot work with shared_examples 'calls AuditResults.report_results
 
           context 'CompleteMoab' do
             context 'changed' do
@@ -222,59 +200,48 @@ RSpec.describe PreservedObjectHandler do
         it_behaves_like 'PreservedObject current_version does not match online CM version', :confirm_version, 3, 2, 8
       end
 
-      context 'db update error' do
-        context 'ActiveRecordError' do
-          let(:result_code) { AuditResults::DB_UPDATE_FAILED }
-          let(:incoming_version) { 2 }
-          let(:results) do
-            po = create :preserved_object, current_version: 2
-            allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-            cm = create :complete_moab, preserved_object: po, version: 2
-            allow(CompleteMoab).to receive(:find_by).and_return(cm)
-            allow(po_handler).to receive(:moab_validation_errors).and_return([])
+      context 'db update error (ActiveRecordError)' do
+        let(:result_code) { AuditResults::DB_UPDATE_FAILED }
+        let(:incoming_version) { 2 }
+        before do
+          po = create(:preserved_object, current_version: 2)
+          cm = create(:complete_moab, preserved_object: po, version: po.current_version)
+          allow(PreservedObject).to receive(:find_by!).with(druid: druid).and_return(po)
+          allow(po.complete_moabs).to receive(:find_by!).and_return(cm)
+          allow(po_handler).to receive(:moab_validation_errors).and_return([])
+          allow(cm).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+        end
 
-            allow(cm).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
-            po_handler.confirm_version
-          end
-
-          it 'DB_UPDATE_FAILED error' do
-            expect(results).to include(a_hash_including(AuditResults::DB_UPDATE_FAILED))
-          end
+        it 'DB_UPDATE_FAILED error' do
+          expect(po_handler.confirm_version).to include(a_hash_including(AuditResults::DB_UPDATE_FAILED))
         end
       end
 
-      it 'calls CompleteMoab.save! (but not PreservedObject.save!) if the existing record is altered' do
-        po = create :preserved_object
-        allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-        cm = create :complete_moab, preserved_object: po
-        allow(CompleteMoab).to receive(:find_by).with(preserved_object: po, moab_storage_root: ms_root).and_return(cm)
-        allow(po_handler).to receive(:moab_validation_errors).and_return([])
-
-        allow(po).to receive(:save!)
-        allow(cm).to receive(:save!)
-        po_handler.confirm_version
-        expect(po).not_to have_received(:save!)
-        expect(cm).to have_received(:save!)
+      describe 'calls CompleteMoab.save! (but not PreservedObject.save!)' do
+        before do
+          allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
+          allow(po.complete_moabs).to receive(:find_by!).with(moab_storage_root: ms_root).and_return(cm)
+        end
+        it 'if the existing record is altered' do
+          allow(po_handler).to receive(:moab_validation_errors).and_return([])
+          expect(cm).to receive(:save!)
+          expect(po).not_to receive(:save!)
+          po_handler.confirm_version
+        end
+        it 'calls CompleteMoab.save! (but not PreservedObject.save!) if the existing record is NOT altered' do
+          po_handler = described_class.new(druid, 1, 1, ms_root)
+          allow(po_handler).to receive(:moab_validation_errors).and_return([]) # different po_handler now
+          expect(cm).to receive(:save!)
+          expect(po).not_to receive(:save!)
+          po_handler.confirm_version
+        end
       end
-      it 'calls CompleteMoab.save! (but not PreservedObject.save!) if the existing record is NOT altered' do
-        po_handler = described_class.new(druid, 1, 1, ms_root)
-        po = create :preserved_object
-        allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-        cm = create :complete_moab, preserved_object: po
-        allow(CompleteMoab).to receive(:find_by).with(preserved_object: po, moab_storage_root: ms_root).and_return(cm)
 
-        allow(po).to receive(:save!)
-        allow(cm).to receive(:save!)
-        po_handler.confirm_version
-        expect(cm).to have_received(:save!)
-        expect(po).not_to have_received(:save!)
-      end
       it 'logs a debug message' do
-        msg = "confirm_version #{druid} called"
         allow(Rails.logger).to receive(:debug)
+        expect(Rails.logger).to receive(:debug).with("confirm_version #{druid} called")
         allow(po_handler).to receive(:moab_validation_errors).and_return([])
         po_handler.confirm_version
-        expect(Rails.logger).to have_received(:debug).with(msg)
       end
     end
 

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe PreservedObjectHandler do
           allow(PreservedObject).to receive(:create!).with(hash_including(druid: druid))
                                                      .and_raise(ActiveRecord::ActiveRecordError, 'foo')
         end
+
         it 'DB_UPDATE_FAILED result' do
           expect(po_handler.create).to include(a_hash_including(AuditResults::DB_UPDATE_FAILED))
         end

--- a/spec/services/preserved_object_handler_create_spec.rb
+++ b/spec/services/preserved_object_handler_create_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 require 'services/shared_examples_preserved_object_handler'
 
 RSpec.describe PreservedObjectHandler do
-  before do
-    allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
-  end
-
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }
@@ -13,38 +9,26 @@ RSpec.describe PreservedObjectHandler do
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: storage_dir) }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ms_root) }
   let(:exp_msg) { "added object to db as it did not exist" }
-  let(:po_args) do
-    {
-      druid: druid,
-      current_version: incoming_version,
-      preservation_policy_id: PreservationPolicy.default_policy.id
-    }
-  end
-  let(:cm_args) do
-    {
-      preserved_object: an_instance_of(PreservedObject), # TODO: ensure we got the preserved object that we expected
-      version: incoming_version,
-      size: incoming_size,
-      moab_storage_root: ms_root,
-      status: 'validity_unknown' # NOTE: ensuring this particular status is the default
-      # NOTE: lack of validation timestamps here
-    }
-  end
+
+  before { allow(Dor::WorkflowService).to receive(:update_workflow_error_status) }
 
   describe '#create' do
     it 'creates PreservedObject and CompleteMoab in database' do
-      expect(PreservedObject).to receive(:create!).with(po_args).and_call_original
-      expect(CompleteMoab).to receive(:create!).with(cm_args).and_call_original
       po_handler.create
+      new_po = PreservedObject.find_by(druid: druid)
+      new_cm = new_po.complete_moabs.find_by(version: incoming_version)
+      expect(new_po.current_version).to eq incoming_version
+      expect(new_cm.moab_storage_root).to eq ms_root
+      expect(new_cm.size).to eq incoming_size
     end
 
     it 'creates the CompleteMoab with "ok" status and validation timestamps if caller ran CV' do
-      cm_args[:status] = 'ok'
-      cm_args[:last_version_audit] = ActiveSupport::TimeWithZone
-      cm_args[:last_moab_validation] = ActiveSupport::TimeWithZone
-      cm_args[:last_checksum_validation] = ActiveSupport::TimeWithZone
-      expect(CompleteMoab).to receive(:create!).with(cm_args).and_call_original
       po_handler.create(true)
+      new_cm = po_handler.pres_object.complete_moabs.find_by(version: incoming_version)
+      expect(new_cm.status).to eq 'ok'
+      expect(new_cm.last_version_audit).to be_a ActiveSupport::TimeWithZone
+      expect(new_cm.last_moab_validation).to be_a ActiveSupport::TimeWithZone
+      expect(new_cm.last_checksum_validation).to be_a ActiveSupport::TimeWithZone
     end
 
     it_behaves_like 'attributes validated', :create
@@ -61,37 +45,34 @@ RSpec.describe PreservedObjectHandler do
 
     context 'db update error' do
       context 'ActiveRecordError' do
-        let(:results) do
+        before do
           allow(PreservedObject).to receive(:create!).with(hash_including(druid: druid))
                                                      .and_raise(ActiveRecord::ActiveRecordError, 'foo')
-          po_handler.create
         end
-
         it 'DB_UPDATE_FAILED result' do
-          expect(results).to include(a_hash_including(AuditResults::DB_UPDATE_FAILED))
+          expect(po_handler.create).to include(a_hash_including(AuditResults::DB_UPDATE_FAILED))
         end
         it 'does NOT get CREATED_NEW_OBJECT result' do
-          expect(results).not_to include(hash_including(AuditResults::CREATED_NEW_OBJECT))
+          expect(po_handler.create).not_to include(hash_including(AuditResults::CREATED_NEW_OBJECT))
         end
       end
 
       it "rolls back PreservedObject creation if the CompleteMoab can't be created (e.g. due to DB constraint violation)" do
-        allow(CompleteMoab).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+        po = instance_double(PreservedObject, complete_moabs: instance_double(ActiveRecord::Relation))
+        allow(PreservedObject).to receive(:create!).with(hash_including(druid: druid)).and_return(po)
+        allow(po.complete_moabs).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
         po_handler.create
-        expect(PreservedObject.where(druid: druid)).not_to exist
+        expect(PreservedObject.find_by(druid: druid)).to be_nil
       end
     end
 
     context 'returns' do
-      let!(:result) { po_handler.create }
+      let(:result) { po_handler.create }
 
-      it '1 result' do
+      it '1 result of CREATED_NEW_OBJECT' do
         expect(result).to be_an_instance_of Array
         expect(result.size).to eq 1
-      end
-      it 'CREATED_NEW_OBJECT result' do
-        code = AuditResults::CREATED_NEW_OBJECT
-        expect(result).to include(a_hash_including(code => exp_msg))
+        expect(result.first).to match(a_hash_including(AuditResults::CREATED_NEW_OBJECT => exp_msg))
       end
     end
   end
@@ -108,14 +89,9 @@ RSpec.describe PreservedObjectHandler do
     context 'sets validation timestamps' do
       let(:t) { Time.current }
       let(:ms_root) { MoabStorageRoot.find_by(storage_location: storage_dir) }
-      let(:po_db_obj) { PreservedObject.find_by(druid: valid_druid) }
-      let(:cm_db_obj) { CompleteMoab.find_by(preserved_object: po_db_obj) }
-      let(:results) do
-        po_handler = described_class.new(valid_druid, incoming_version, incoming_size, ms_root)
-        po_handler.create_after_validation
-      end
+      let(:cm_db_obj) { po_handler.pres_object.complete_moabs.first! }
 
-      before { results }
+      before { po_handler.create_after_validation }
 
       it "sets last_moab_validation with current time" do
         expect(cm_db_obj.last_moab_validation).to be_within(10).of(t)
@@ -126,29 +102,24 @@ RSpec.describe PreservedObjectHandler do
     end
 
     it 'creates PreservedObject and CompleteMoab in database when there are no validation errors' do
-      po_args[:druid] = valid_druid
-      cm_args.merge!(
-        last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
-        last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
-      )
-
-      expect(PreservedObject).to receive(:create!).with(po_args).and_call_original
-      expect(CompleteMoab).to receive(:create!).with(cm_args).and_call_original
       po_handler = described_class.new(valid_druid, incoming_version, incoming_size, ms_root)
       po_handler.create_after_validation
+      new_po = PreservedObject.find_by(druid: valid_druid, current_version: incoming_version)
+      expect(new_po).not_to be_nil
+      new_cm = new_po.complete_moabs.find_by(moab_storage_root: ms_root, version: incoming_version)
+      expect(new_cm).not_to be_nil
+      expect(new_cm.status).to eq 'validity_unknown'
     end
 
     it 'creates CompleteMoab with "ok" status and validation timestamps if no validation errors and caller ran CV' do
-      cm_args.merge!(
-        status: 'ok',
-        last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
-        last_version_audit: an_instance_of(ActiveSupport::TimeWithZone),
-        last_checksum_validation: an_instance_of(ActiveSupport::TimeWithZone)
-      )
-
-      expect(CompleteMoab).to receive(:create!).with(cm_args).and_call_original
       po_handler = described_class.new(valid_druid, incoming_version, incoming_size, ms_root)
       po_handler.create_after_validation(true)
+      new_po = PreservedObject.find_by(druid: valid_druid, current_version: incoming_version)
+      expect(new_po).not_to be_nil
+      new_cm = new_po.complete_moabs.find_by(moab_storage_root: ms_root, version: incoming_version)
+      expect(new_cm).not_to be_nil
+      expect(new_cm.status).to eq 'ok'
+      expect(new_cm.last_checksum_validation).to be_an ActiveSupport::TimeWithZone
     end
 
     it 'calls moab-versioning Stanford::StorageObjectValidator.validation_errors' do
@@ -173,34 +144,28 @@ RSpec.describe PreservedObjectHandler do
       end
 
       it 'creates PreservedObject, and CompleteMoab with "invalid_moab" status in database' do
-        po_args[:druid] = invalid_druid
-        cm_args.merge!(
-          status: 'invalid_moab',
-          last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
-          last_version_audit: an_instance_of(ActiveSupport::TimeWithZone)
-        )
-
-        expect(PreservedObject).to receive(:create!).with(po_args).and_call_original
-        expect(CompleteMoab).to receive(:create!).with(cm_args).and_call_original
         po_handler.create_after_validation
+        new_po = PreservedObject.find_by(druid: invalid_druid, current_version: incoming_version)
+        expect(new_po).not_to be_nil
+        new_cm = new_po.complete_moabs.find_by(moab_storage_root: ms_root, version: incoming_version)
+        expect(new_cm).not_to be_nil
+        expect(new_cm.status).to eq 'invalid_moab'
+        expect(new_cm.last_moab_validation).to be_a ActiveSupport::TimeWithZone
+        expect(new_cm.last_version_audit).to be_a ActiveSupport::TimeWithZone
       end
 
       it 'creates CompleteMoab with "invalid_moab" status in database even if caller ran CV' do
-        cm_args.merge!(
-          status: 'invalid_moab',
-          last_moab_validation: an_instance_of(ActiveSupport::TimeWithZone),
-          last_version_audit: an_instance_of(ActiveSupport::TimeWithZone),
-          last_checksum_validation: an_instance_of(ActiveSupport::TimeWithZone)
-        )
-
-        expect(CompleteMoab).to receive(:create!).with(cm_args).and_call_original
         po_handler.create_after_validation(true)
+        new_po = PreservedObject.find_by(druid: invalid_druid, current_version: incoming_version)
+        expect(new_po).not_to be_nil
+        new_cm = new_po.complete_moabs.find_by(moab_storage_root: ms_root, version: incoming_version)
+        expect(new_cm).not_to be_nil
+        expect(new_cm.status).to eq 'invalid_moab'
       end
 
       it 'includes invalid moab result' do
         results = po_handler.create_after_validation
-        code = AuditResults::INVALID_MOAB
-        expect(results).to include(a_hash_including(code => a_string_matching('Invalid Moab, validation errors:')))
+        expect(results).to include(a_hash_including(AuditResults::INVALID_MOAB => /Invalid Moab, validation errors:/))
       end
 
       context 'db update error' do
@@ -230,15 +195,12 @@ RSpec.describe PreservedObjectHandler do
     end
 
     context 'returns' do
-      let!(:result) { po_handler.create_after_validation }
+      let(:result) { po_handler.create_after_validation }
 
-      it '1 result' do
+      it '1 CREATED_NEW_OBJECT result' do
         expect(result).to be_an_instance_of Array
         expect(result.size).to eq 1
-      end
-      it 'CREATED_NEW_OBJECT result' do
-        code = AuditResults::CREATED_NEW_OBJECT
-        expect(result).to include(a_hash_including(code => exp_msg))
+        expect(result.first).to include(AuditResults::CREATED_NEW_OBJECT => exp_msg)
       end
     end
   end

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -83,14 +83,14 @@ RSpec.describe PreservedObjectHandler do
 
             context 'checksums_validated = true' do
               it 'starting status ok unchanged' do
-                expect { po_handler.update_version(true) }.not_to change { cm.status }.from('ok')
+                expect { po_handler.update_version(true) }.not_to change(cm, :status).from('ok')
               end
               context 'original status was not ok' do
                 shared_examples 'POH#update_version(true) does not change status' do |orig_status|
                   before { cm.update!(status: orig_status) }
 
                   it "original status #{orig_status}" do
-                    expect { po_handler.update_version(true) }.not_to change { cm.status }
+                    expect { po_handler.update_version(true) }.not_to change(cm, :status)
                   end
                 end
 

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -7,15 +7,14 @@ RSpec.describe PreservedObjectHandler do
     allow(Dor::WorkflowService).to receive(:update_workflow_status)
   end
 
-  let(:druid) { 'ab123cd4567' }
-  let(:incoming_version) { 6 }
-  let(:incoming_size) { 9876 }
-  let!(:default_prez_policy) { PreservationPolicy.default_policy }
-  let(:po) { PreservedObject.find_by(druid: druid) }
-  let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
-  let(:cm) { CompleteMoab.find_by(preserved_object: po, moab_storage_root: ms_root) }
   let(:db_update_failed_prefix) { "db update failed" }
-
+  let(:default_prez_policy) { PreservationPolicy.default_policy }
+  let(:druid) { 'ab123cd4567' }
+  let(:incoming_size) { 9876 }
+  let(:incoming_version) { 6 }
+  let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
+  let(:cm) { po_handler.complete_moab }
+  let(:po) { PreservedObject.find_by(druid: druid) }
   let(:po_handler) { described_class.new(druid, incoming_version, incoming_size, ms_root) }
 
   describe '#update_version' do
@@ -23,11 +22,9 @@ RSpec.describe PreservedObjectHandler do
 
     context 'in Catalog' do
       before do
-        po = create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_prez_policy)
-        create(
-          :complete_moab,
-          preserved_object: po,
-          version: po.current_version,
+        v2 = create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_prez_policy)
+        v2.complete_moabs.create!(
+          version: v2.current_version,
           size: 1,
           moab_storage_root: ms_root,
           status: 'ok', # pretending we checked for moab validation errs at create time
@@ -40,35 +37,23 @@ RSpec.describe PreservedObjectHandler do
         context 'CompleteMoab' do
           context 'changed' do
             it "version becomes incoming_version" do
-              orig = cm.version
-              po_handler.update_version
-              expect(cm.reload.version).to be > orig
-              expect(cm.version).to eq incoming_version
+              expect { po_handler.update_version }.to change(cm, :version).to be(incoming_version)
             end
             it 'last_version_audit' do
-              orig = cm.last_version_audit
-              po_handler.update_version
-              expect(cm.reload.last_version_audit).to be > orig
+              expect { po_handler.update_version }.to change(cm, :last_version_audit)
             end
             it 'size if supplied' do
-              orig = cm.size
-              po_handler.update_version
-              expect(cm.reload.size).to eq incoming_size
-              expect(cm.size).not_to eq orig
+              expect { po_handler.update_version }.to change(cm, :size)
             end
           end
 
           context 'unchanged' do
             it 'size if incoming size is nil' do
-              orig = cm.size
               po_handler = described_class.new(druid, incoming_version, nil, ms_root)
-              po_handler.update_version
-              expect(cm.reload.size).to eq orig
+              expect { po_handler.update_version }.not_to change { po_handler.complete_moab.size }
             end
             it 'last_moab_validation' do
-              orig = cm.last_moab_validation
-              po_handler.update_version
-              expect(cm.reload.last_moab_validation).to eq orig
+              expect { po_handler.update_version }.not_to change(cm, :last_moab_validation)
             end
           end
 
@@ -76,18 +61,15 @@ RSpec.describe PreservedObjectHandler do
             context 'checksums_validated = false' do
               it 'starting status validity_unknown unchanged' do
                 cm.update!(status: 'validity_unknown')
-                expect do
-                  po_handler.update_version
-                end.not_to change { cm.reload.status }.from('validity_unknown')
+                expect { po_handler.update_version }.not_to change(cm, :status).from('validity_unknown')
               end
               context 'starting status not validity_unknown' do
                 shared_examples 'POH#update_version changes status to "validity_unknown"' do |orig_status|
                   before { cm.update!(status: orig_status) }
 
                   it "original status #{orig_status}" do
-                    expect do
-                      po_handler.update_version
-                    end.to change { cm.reload.status }.from(orig_status).to('validity_unknown')
+                    expect { po_handler.update_version }.to change(cm, :status)
+                      .from(orig_status).to('validity_unknown')
                   end
                 end
 
@@ -101,20 +83,14 @@ RSpec.describe PreservedObjectHandler do
 
             context 'checksums_validated = true' do
               it 'starting status ok unchanged' do
-                expect do
-                  po_handler.update_version(true)
-                end.not_to change { cm.reload.status }.from('ok')
+                expect { po_handler.update_version(true) }.not_to change { cm.status }.from('ok')
               end
               context 'original status was not ok' do
                 shared_examples 'POH#update_version(true) does not change status' do |orig_status|
-                  before do
-                    cm.update!(status: orig_status)
-                  end
+                  before { cm.update!(status: orig_status) }
 
                   it "original status #{orig_status}" do
-                    expect do
-                      po_handler.update_version(true)
-                    end.not_to change { cm.reload.status }
+                    expect { po_handler.update_version(true) }.not_to change { cm.status }
                   end
                 end
 
@@ -142,14 +118,10 @@ RSpec.describe PreservedObjectHandler do
           end
         end
 
-        context 'PreservedObject' do
-          context 'changed' do
-            it "current_version becomes incoming version" do
-              orig = po.current_version
-              po_handler.update_version
-              expect(po.reload.current_version).to be > orig
-              expect(po.current_version).to eq incoming_version
-            end
+        context 'PreservedObject changed' do
+          it "current_version becomes incoming version" do
+            expect { po_handler.update_version }.to change(po_handler.pres_object, :current_version)
+              .to(incoming_version)
           end
         end
 
@@ -171,9 +143,7 @@ RSpec.describe PreservedObjectHandler do
       end
 
       context 'CompleteMoab and PreservedObject versions do not match' do
-        before do
-          cm.update(version: cm.version + 1)
-        end
+        before { cm.update(version: cm.version + 1) }
 
         it_behaves_like 'PreservedObject current_version does not match online CM version', :update_version, 3, 3, 2
       end
@@ -193,11 +163,8 @@ RSpec.describe PreservedObjectHandler do
           context 'ActiveRecordError' do
             let(:results) do
               allow(Rails.logger).to receive(:log)
-              po = instance_double(PreservedObject, current_version: 1)
-              allow(PreservedObject).to receive(:find_by!).with(druid: druid).and_return(po)
-              cm = create :complete_moab
-              allow(CompleteMoab).to receive(:find_by!).with(preserved_object: po, moab_storage_root: ms_root).and_return(cm)
-
+              allow(po_handler).to receive(:pres_object).and_return(po)
+              allow(po_handler).to receive(:comp_moab).and_return(cm)
               allow(cm).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
               po_handler.update_version
             end
@@ -218,13 +185,10 @@ RSpec.describe PreservedObjectHandler do
 
         context 'PreservedObject' do
           context 'ActiveRecordError' do
+            let(:druid) { 'zy666xw4567' }
             let(:results) do
               allow(Rails.logger).to receive(:log)
-              po = create :preserved_object, current_version: 5
-              allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-              cm = create :complete_moab
-              allow(CompleteMoab).to receive(:find_by).with(preserved_object: po, moab_storage_root: ms_root).and_return(cm)
-
+              allow(po_handler).to receive(:pres_object).and_return(po)
               allow(po).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
               po_handler.update_version
             end
@@ -245,37 +209,26 @@ RSpec.describe PreservedObjectHandler do
       end
 
       it 'calls PreservedObject.save! and CompleteMoab.save! if the records are altered' do
-        po = create :preserved_object
-        allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-        cm = create :complete_moab
-        allow(CompleteMoab).to receive(:find_by).with(preserved_object: po, moab_storage_root: ms_root).and_return(cm)
-
-        allow(po).to receive(:save!)
-        allow(cm).to receive(:save!)
+        allow(po_handler).to receive(:pres_object).and_return(po)
+        allow(po_handler.pres_object.complete_moabs).to receive(:find_by!).with(moab_storage_root: ms_root).and_return(cm)
+        expect(po).to receive(:save!)
+        expect(cm).to receive(:save!)
         po_handler.update_version
-        expect(po).to have_received(:save!)
-        expect(cm).to have_received(:save!)
       end
 
       it 'does not call PreservedObject.save when CompleteMoab only has timestamp updates' do
-        po = create :preserved_object
-        allow(PreservedObject).to receive(:find_by).with(druid: druid).and_return(po)
-        cm = create :complete_moab
-        allow(CompleteMoab).to receive(:find_by).with(preserved_object: po, moab_storage_root: ms_root).and_return(cm)
-
-        allow(po).to receive(:save!)
-        allow(cm).to receive(:save!)
         po_handler = described_class.new(druid, 1, 1, ms_root)
+        allow(po_handler).to receive(:pres_object).and_return(po)
+        allow(po_handler.pres_object.complete_moabs).to receive(:find_by!).with(moab_storage_root: ms_root).and_return(cm)
+        expect(cm).to receive(:save!)
+        expect(po).not_to receive(:save!)
         po_handler.update_version
-        expect(po).not_to have_received(:save!)
-        expect(cm).to have_received(:save!)
       end
 
       it 'logs a debug message' do
-        msg = "update_version #{druid} called"
         allow(Rails.logger).to receive(:debug)
         po_handler.update_version
-        expect(Rails.logger).to have_received(:debug).with(msg)
+        expect(Rails.logger).to have_received(:debug).with("update_version #{druid} called")
       end
     end
 
@@ -301,8 +254,7 @@ RSpec.describe PreservedObjectHandler do
       context 'when moab is valid' do
         before do
           t = Time.current
-          CompleteMoab.create!(
-            preserved_object: po,
+          po.complete_moabs.create!(
             version: po.current_version,
             size: 1,
             moab_storage_root: ms_root,
@@ -313,7 +265,7 @@ RSpec.describe PreservedObjectHandler do
         end
 
         let(:po) { PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy) }
-        let(:cm) { CompleteMoab.find_by!(preserved_object: po, moab_storage_root: ms_root) }
+        let(:cm) { po.complete_moabs.find_by!(moab_storage_root: ms_root) }
 
         context 'CompleteMoab' do
           context 'changed' do
@@ -698,11 +650,8 @@ RSpec.describe PreservedObjectHandler do
             context 'ActiveRecordError' do
               let(:results) do
                 allow(Rails.logger).to receive(:log)
-                po = instance_double(PreservedObject, current_version: 1)
-                allow(PreservedObject).to receive(:find_by!).with(druid: druid).and_return(po)
-                cm = create :complete_moab
-                allow(CompleteMoab).to receive(:find_by!).with(preserved_object: po, moab_storage_root: ms_root).and_return(cm)
-
+                allow(po_handler).to receive(:pres_object).and_return(po)
+                allow(po_handler.pres_object.complete_moabs).to receive(:find_by!).with(moab_storage_root: ms_root).and_return(cm)
                 allow(cm).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
                 po_handler.update_version_after_validation
               end

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -45,11 +45,9 @@ end
 
 RSpec.shared_examples 'calls AuditResults.report_results' do |method_sym|
   it 'outputs results to Rails.logger and sends errors to WorkflowErrorReporter' do
-    mock_results = instance_double(AuditResults)
-    allow(mock_results).to receive(:add_result)
-    allow(mock_results).to receive(:check_name=)
+    mock_results = instance_double(AuditResults, add_result: nil, :check_name= => nil)
     expect(mock_results).to receive(:report_results)
-    expect(AuditResults).to receive(:new).and_return(mock_results)
+    allow(po_handler).to receive(:results).and_return(mock_results)
     po_handler.send(method_sym)
   end
 end
@@ -63,8 +61,7 @@ RSpec.shared_examples 'druid not in catalog' do |method_sym|
   end
 
   it 'DB_OBJ_DOES_NOT_EXIST error' do
-    code = AuditResults::DB_OBJ_DOES_NOT_EXIST
-    expect(results).to include(a_hash_including(code => a_string_matching(exp_msg)))
+    expect(results).to include(a_hash_including(AuditResults::DB_OBJ_DOES_NOT_EXIST => a_string_matching(exp_msg)))
   end
 end
 

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -69,16 +69,13 @@ RSpec.shared_examples 'druid not in catalog' do |method_sym|
 end
 
 RSpec.shared_examples 'CompleteMoab does not exist' do |method_sym|
-  before do
-    PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
-  end
-
   let(:exp_msg) { "#<ActiveRecord::RecordNotFound: foo> db object does not exist" }
   let(:results) do
     allow(Rails.logger).to receive(:log)
-    po = create :preserved_object, current_version: 2
-    allow(PreservedObject).to receive(:find_by!).and_return(po)
-    allow(CompleteMoab).to receive(:find_by!).and_raise(ActiveRecord::RecordNotFound, 'foo')
+    allow(po_handler).to receive(:pres_object).and_return(create(:preserved_object))
+    allow(PreservedObject).to receive(:exists?).with(druid: po_handler.druid).and_return(true)
+    allow(po_handler.pres_object.complete_moabs).to receive(:find_by!)
+      .with(any_args).and_raise(ActiveRecord::RecordNotFound, 'foo')
     po_handler.send(method_sym)
   end
 


### PR DESCRIPTION
Small revisions to app code:
- `PO#complete_moabs` gets `autosave: true`
- 2 "getter" methods go public in POH
- associations are used to find and create
- keep non-transactional code outside the transaction block

Larger revisions to tests:
- remove unnecessarily eager `let!` statements
- associations are used to find and create
- intercept POH `pres_object` and `complete_moab` directly when desirable, rather than go underneath it to intercept the model's `.find_by!`
- use `change` matcher
- use imperative enum calls (e.g. `cm.ok!`)

Rebased to make mergeable after PC renaming.