### PR TITLE
Make zip command output less verbose

### DIFF
--- a/app/models/druid_version_zip.rb
+++ b/app/models/druid_version_zip.rb
@@ -107,7 +107,7 @@ class DruidVersionZip
   # @see #work_dir
   # @return [String] shell command to create this zip
   def zip_command
-    "zip -vr0X -sv -s #{zip_split_size} #{file_path} #{druid.id}/#{v_version}"
+    "zip -r0X -s #{zip_split_size} #{file_path} #{druid.id}/#{v_version}"
   end
 
   # We presume the system guts do not change underneath a given class instance.

--- a/spec/models/druid_version_zip_spec.rb
+++ b/spec/models/druid_version_zip_spec.rb
@@ -47,7 +47,7 @@ describe DruidVersionZip do
       before { allow(dvz).to receive(:zip_command).and_return(zip_command) }
 
       context 'when inpath is incorrect' do
-        let(:zip_command) { "zip -vr0X -sv -s 10g #{zip_path} /wrong/path" }
+        let(:zip_command) { "zip -r0X -s 10g #{zip_path} /wrong/path" }
 
         it 'raises error' do
           expect { dvz.create_zip! }.to raise_error(RuntimeError, %r{zipmaker failure.*/wrong/path}m)
@@ -63,7 +63,7 @@ describe DruidVersionZip do
       end
 
       context 'if the utility "moved"' do
-        let(:zip_command) { "zap -vr0X -sv -s 10g #{zip_path} #{druid}/v0003" }
+        let(:zip_command) { "zap -r0X -s 10g #{zip_path} #{druid}/v0003" }
 
         it 'raises error' do
           expect { dvz.create_zip! }.to raise_error(Errno::ENOENT, /No such file/)
@@ -152,7 +152,7 @@ describe DruidVersionZip do
     let(:zip_path) { '/tmp/bj/102/hs/9687/bj102hs9687.v0001.zip' }
 
     it 'returns zip string to execute for this druid/version' do
-      expect(dvz.zip_command).to eq "zip -vr0X -sv -s 10g #{zip_path} bj102hs9687/v0001"
+      expect(dvz.zip_command).to eq "zip -r0X -s 10g #{zip_path} bj102hs9687/v0001"
     end
   end
 


### PR DESCRIPTION
  Closes #1034 

  This should help `open3` from deadlocking due to generating too much output
  