### PR TITLE
Pass file_path to upload_file instead of open filehandle

### DIFF
--- a/app/jobs/s3_west_delivery_job.rb
+++ b/app/jobs/s3_west_delivery_job.rb
@@ -17,7 +17,7 @@ class S3WestDeliveryJob < ZipPartJobBase
     s3_part = bucket.object(part_s3_key) # Aws::S3::Object
     return if s3_part.exists?
     s3_part.upload_file(
-      dvz_part.file,
+      dvz_part.file_path,
       metadata: stringify_values(metadata)
     )
     ResultsRecorderJob.perform_later(druid, version, part_s3_key, self.class.to_s)

--- a/spec/jobs/s3_west_delivery_job_spec.rb
+++ b/spec/jobs/s3_west_delivery_job_spec.rb
@@ -35,7 +35,7 @@ describe S3WestDeliveryJob, type: :job do
   context 'zip part is new to S3' do
     it 'uploads_file to S3' do
       expect(object).to receive(:upload_file).with(
-        File, metadata: a_hash_including(checksum_md5: md5)
+        dvz_part.file_path, metadata: a_hash_including(checksum_md5: md5)
       )
       described_class.perform_now(druid, version, part_s3_key, metadata)
     end

--- a/spec/lib/preservation_catalog/s3_spec.rb
+++ b/spec/lib/preservation_catalog/s3_spec.rb
@@ -103,7 +103,6 @@ describe PreservationCatalog::S3 do
       let(:dvz) { DruidVersionZip.new('bj102hs9687', 2) }
       let(:dvz_part) { DruidVersionZipPart.new(dvz, dvz.s3_key('.zip')) }
       let(:digest) { dvz_part.base64digest }
-      let(:file) { File.open(dvz_part.file) }
       let(:now) { Time.zone.now.iso8601 }
       let(:get_response) { s3_object.get }
 
@@ -113,7 +112,7 @@ describe PreservationCatalog::S3 do
 
       it 'accepts/returns File body and arbitrary metadata' do
         resp = nil
-        expect { s3_object.upload_file(file, metadata: { our_time: now }) }.not_to raise_error
+        expect { s3_object.upload_file(dvz_part.file_path, metadata: { our_time: now }) }.not_to raise_error
         expect { resp = s3_object.get }.not_to raise_error
         expect(resp).to be_a(Aws::S3::Types::GetObjectOutput)
         expect(resp.metadata.symbolize_keys).to eq(our_time: now)


### PR DESCRIPTION
This prevents us having to worry about closing the filehandle, which is something explicitly recommended in the S3 docs.