### PR TITLE
Schedule cv

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,3 +22,7 @@ every '0 5 22-28 * *', roles: [:c2m] do
   set :output, standard: 'log/c2m.log', error: 'log/c2m-err.log'
   sat_only_rake "c2m:all_roots[`date --iso-8601=s`]"
 end
+every :sunday, at: '1am' roles: [:cv] do
+  set :output, standard: 'log/cv.log', error: 'log/cv-err.log'
+  rake "cv:all_roots"
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,7 +22,7 @@ every '0 5 22-28 * *', roles: [:c2m] do
   set :output, standard: 'log/c2m.log', error: 'log/c2m-err.log'
   sat_only_rake "c2m:all_roots[`date --iso-8601=s`]"
 end
-every :sunday, at: '1am' roles: [:cv] do
+every :sunday, at: '1am', roles: [:cv] do
   set :output, standard: 'log/cv.log', error: 'log/cv-err.log'
   rake "cv:all_roots"
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,7 +20,7 @@ preservation_policies:
   policy_definitions:
     default:
       archive_ttl: 604_800 # _ttl values are in seconds. 604,800 s == one week.
-      fixity_ttl: 604_800
+      fixity_ttl: 7_776_000 # 7,776,000 s == 90 days.
 
 provlog:
   enable: false

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -278,10 +278,10 @@ RSpec.describe CompleteMoab, type: :model do
     describe '.fixity_check_expired' do
       let(:ms_root2) { MoabStorageRoot.find_by(name: 'fixture_sr2') }
       let!(:checked_before_threshold_cm1) do
-        create(:complete_moab, args.merge(version: 6, last_checksum_validation: now - 3.weeks))
+        create(:complete_moab, args.merge(version: 6, last_checksum_validation: now - 56.weeks))
       end
       let!(:checked_before_threshold_cm2) do
-        my_args = args.merge(version: 7, last_checksum_validation: now - 7.01.days, moab_storage_root: ms_root2)
+        my_args = args.merge(version: 7, last_checksum_validation: now - 90.01.days, moab_storage_root: ms_root2)
         create(:complete_moab, my_args)
       end
       let!(:recently_checked_cm1) do


### PR DESCRIPTION
- Use the `CV.validate_disk_all_storage_roots`  Rake task and run it every week. 
- The fixity time is now 90 days instead of 1 week. Didn't change the `archive_ttl` but added the question to StoryTime on whether or not we should change that too.
- Need to double check this runs smoothly.

closes #868 
closes #649 
