### PR TITLE
dependent option is ignored when using :through option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,9 +6,10 @@ require: rubocop-rspec
 AllCops:
   DisplayCopNames: true
   Include:
-    - Rakefile
-    - config.ru
-    - lib/**/*.rake
+    - './Rakefile'
+    - './config.ru'
+    - '**/*.rb'
+    - '**/*.rake'
   Exclude:
     - 'Gemfile.lock'
     - '**/*.md'
@@ -41,10 +42,6 @@ Layout/EmptyLinesAroundModuleBody:
 Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: false
 
-Layout/SpaceInsideBrackets:
-  Exclude:
-    - 'app/services/preserved_object_handler.rb' # line 126 is clearer with the spaces
-
 # --- Lint ---
 
 Lint/AmbiguousBlockAssociation:
@@ -54,10 +51,6 @@ Lint/AmbiguousBlockAssociation:
     - spec/services/shared_examples_preserved_object_handler.rb
 
 Lint/HandleExceptions:
-  Exclude:
-    - 'spec/lib/audit/moab_to_catalog_spec.rb' # So method does not stop executing and can test the correct case
-
-Lint/RescueWithoutErrorClass:
   Exclude:
     - 'spec/lib/audit/moab_to_catalog_spec.rb' # So method does not stop executing and can test the correct case
 
@@ -162,6 +155,9 @@ RSpec/BeforeAfterAll:
     # we use after(:all) specifically to prevent state leakage
     - 'spec/models/preservation_policy_spec.rb'
 
+RSpec/ContextWording:
+  Enabled: false # too dogmatic
+
 RSpec/ExampleLength:
   Max: 25
 
@@ -193,6 +189,9 @@ RSpec/NestedGroups:
     - 'spec/services/preserved_object_handler_update_version_spec.rb'
 
 # --- Style ---
+Style/AccessModifierDeclarations:
+  Exclude:
+    - 'config/initializers/okcomputer.rb' # atypical multi-class file
 
 Style/BlockComments:
   Exclude:
@@ -221,6 +220,10 @@ Style/GuardClause:
   Exclude:
     - app/services/preserved_object_handler.rb # update_status method easy to read as is
     - lib/audit/catalog_to_moab.rb # wrapping method on line 17 is more readable
+
+Style/RescueStandardError:
+  Exclude:
+    - 'spec/lib/audit/moab_to_catalog_spec.rb' # So method does not stop executing and can test the correct case
 
 # because ' vs " isn't a big deal for readability or maintainability or execution time
 Style/StringLiterals:

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'coveralls'
   # Ruby static code analyzer http://rubocop.readthedocs.io/en/latest/
-  gem 'rubocop', '~> 0.50.0' # avoid code churn due to rubocop changes
+  gem 'rubocop', '~> 0.58'
   gem 'rubocop-rspec'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     honeybadger (3.3.0)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.1)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -256,8 +257,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.2.2)
-      rake
+    rainbow (3.0.0)
     rake (12.3.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -293,15 +293,16 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.50.0)
+    rubocop (0.58.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.18.0)
-      rubocop (>= 0.50.0)
+    rubocop-rspec (1.27.0)
+      rubocop (>= 0.56.0)
     ruby-prof (0.17.0)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
@@ -376,7 +377,7 @@ DEPENDENCIES
   resque-lock
   resque-pool
   rspec-rails (~> 3.6)
-  rubocop (~> 0.50.0)
+  rubocop (~> 0.58)
   rubocop-rspec
   ruby-prof
   shoulda-matchers!

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -16,7 +16,7 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def self.provlog
-    @provlogger ||= Logger.new Rails.root.join('log', 'prov.log')
+    @provlog ||= Logger.new Rails.root.join('log', 'prov.log')
   end
 
   def provlog

--- a/app/models/zipped_moab_version.rb
+++ b/app/models/zipped_moab_version.rb
@@ -9,7 +9,7 @@ class ZippedMoabVersion < ApplicationRecord
   belongs_to :complete_moab, inverse_of: :zipped_moab_versions
   belongs_to :zip_endpoint, inverse_of: :zipped_moab_versions
   has_many :zip_parts, dependent: :destroy, inverse_of: :zipped_moab_version
-  has_one :preserved_object, through: :complete_moab, dependent: :restrict_with_exception
+  has_one :preserved_object, through: :complete_moab
 
   # Note: In the context of creating many ZMV rows, this may *attempt* to queue the same druid/version multiple times,
   # but queue locking easily prevents duplicates (and the job is idempotent anyway).

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -136,7 +136,7 @@ class AuditResults
   end
 
   def contains_result_code?(code)
-    result_array.detect { |result_hash| result_hash.keys.include?(code) } != nil
+    result_array.detect { |result_hash| result_hash.key?(code) } != nil
   end
 
   def status_changed_to_ok?(result)

--- a/app/services/moab_validation_handler.rb
+++ b/app/services/moab_validation_handler.rb
@@ -26,7 +26,7 @@ module MoabValidationHandler
   end
 
   def moab_validation_errors
-    @moab_errors ||=
+    @moab_validation_errors ||=
       begin
         object_validator = Stanford::StorageObjectValidator.new(moab)
         moab_errors = object_validator.validation_errors(Settings.moab.allow_content_subdirs)

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -13,9 +13,7 @@ class PreservedObjectHandler
   validates :incoming_version, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :incoming_size, numericality: { only_integer: true, greater_than: 0 }
   validates_each :moab_storage_root do |record, attr, value|
-    unless value.is_a?(MoabStorageRoot)
-      record.errors.add(attr, 'must be an actual MoabStorageRoot')
-    end
+    record.errors.add(attr, 'must be an actual MoabStorageRoot') unless value.is_a?(MoabStorageRoot)
   end
 
   attr_reader :druid, :incoming_version, :incoming_size, :moab_storage_root, :results

--- a/app/services/workflow_reporter.rb
+++ b/app/services/workflow_reporter.rb
@@ -1,7 +1,5 @@
-
 # send errors to preservationAuditWF workflow for an object via ReST calls.
 class WorkflowReporter
-
   DOR = 'dor'.freeze
   PRESERVATIONAUDITWF = 'preservationAuditWF'.freeze
   NO_WORKFLOW_HOOKUP = 'no workflow hookup - assume you are in test or dev environment'.freeze

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -24,7 +24,7 @@ class TablesHaveDataCheck < OkComputer::Check
   rescue ActiveRecord::RecordNotFound
     mark_failure
     "#{klass.name} has no data."
-  rescue => e # rubocop:disable Lint/RescueWithoutErrorClass
+  rescue => e # rubocop:disable Style/RescueStandardError
     mark_failure
     "#{e.class.name} received: #{e.message}."
   end

--- a/lib/benchmarking/checksum_testing.rb
+++ b/lib/benchmarking/checksum_testing.rb
@@ -94,3 +94,5 @@ puts "Time taken to compute all checksums: #{time_for_all_checksums}"
 puts "md5    = #{all_checksums_result['md5']}"
 puts "sha1   = #{all_checksums_result['sha1']}"
 puts "sha256 = #{all_checksums_result['sha256']}"
+
+# rubocop:enable Metrics/LineLength, Lint/AssignmentInCondition, Rails/Output

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe CatalogController, type: :controller do
         status: 'validity_unknown'
       )
     end
+
     let(:pres_obj) { PreservedObject.find_by(druid: bare_druid) }
     let(:comp_moab) { CompleteMoab.find_by(preserved_object: pres_obj) }
 
@@ -141,6 +142,7 @@ RSpec.describe CatalogController, type: :controller do
       before do
         patch :update, params: { druid: prefixed_druid, incoming_version: upd_version, incoming_size: size, storage_location: storage_location_param }
       end
+
       let(:upd_version) { 4 }
 
       it 'updates the version' do
@@ -156,6 +158,7 @@ RSpec.describe CatalogController, type: :controller do
       before do
         patch :update, params: { druid: prefixed_druid, incoming_version: ver, incoming_size: size, storage_location: nil }
       end
+
       it 'response contains error message' do
         errors = ["Moab storage root must be an actual MoabStorageRoot"]
         exp_msg = [{ AuditResults::INVALID_ARGUMENTS => "encountered validation error(s): #{errors}" }]
@@ -171,6 +174,7 @@ RSpec.describe CatalogController, type: :controller do
       before do
         patch :update, params: { druid: 'druid:rr111rr1111', incoming_version: ver, incoming_size: size, storage_location: storage_location_param }
       end
+
       it 'response contains error message' do
         error = "#<ActiveRecord::RecordNotFound: Couldn't find PreservedObject>"
         exp_msg = [{ AuditResults::DB_OBJ_DOES_NOT_EXIST => "#{error} db object does not exist" }]
@@ -188,6 +192,7 @@ RSpec.describe CatalogController, type: :controller do
         comp_moab.save!
         patch :update, params: { druid: prefixed_druid, incoming_version: ver, incoming_size: size, storage_location: storage_location_param }
       end
+
       it 'response contains error message' do
         exp_msg = [{ AuditResults::CM_PO_VERSION_MISMATCH => "CompleteMoab online Moab version 4 does not match PreservedObject current_version 3" }]
         expect(response.body).to include(exp_msg.to_json)
@@ -246,6 +251,7 @@ RSpec.describe CatalogController, type: :controller do
       before do
         post :create, params: { druid: prefixed_druid, incoming_version: ver, incoming_size: size, storage_location: storage_location_param }
       end
+
       let(:prefixed_druid) { "druid:#{bare_druid}" }
       let(:bare_druid) { 'jj925bx9565' }
 

--- a/spec/jobs/checksum_validation_job_spec.rb
+++ b/spec/jobs/checksum_validation_job_spec.rb
@@ -16,6 +16,7 @@ describe ChecksumValidationJob, type: :job do
 
   describe 'before_enqueue' do
     before { allow(ChecksumValidationJob).to receive(:perform_later).and_call_original } # undo rails_helper block
+
     it 'raises on bad param' do
       expect { described_class.perform_later(3) }.to raise_error(ArgumentError)
       expect { described_class.perform_later }.to raise_error(ArgumentError)

--- a/spec/lib/audit/catalog_to_moab_class_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_class_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Audit::CatalogToMoab do
         end
         c2m_list.each do |c2m|
           allow(described_class).to receive(:new).with(c2m.complete_moab, storage_dir).and_return(c2m)
-          expect(c2m).to receive(:check_catalog_version).exactly(1).times.and_call_original
+          expect(c2m).to receive(:check_catalog_version).once.and_call_original
         end
         described_class.check_version_on_dir(last_checked_version_b4_date, storage_dir, 2)
       end

--- a/spec/lib/audit/catalog_to_moab_instance_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_instance_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Audit::CatalogToMoab do
           end
         end
       end
+
       it 'stops processing .check_catalog_version' do
         moab = instance_double(Moab::StorageObject)
         allow(Moab::StorageObject).to receive(:new).with(druid, instance_of(String)).and_return(nil)
@@ -336,6 +337,7 @@ RSpec.describe Audit::CatalogToMoab do
           allow(mock_sov).to receive(:validation_errors).and_return([foo: 'error message'])
           allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
         end
+
         it 'sets status to INVALID_MOAB_STATUS' do
           orig = comp_moab.status
           c2m.check_catalog_version
@@ -351,6 +353,7 @@ RSpec.describe Audit::CatalogToMoab do
           c2m.check_catalog_version
         end
       end
+
       it 'adds a CM_STATUS_CHANGED result' do
         results = instance_double(AuditResults, report_results: nil, :actual_version= => nil, :check_name= => nil)
         expect(results).to receive(:add_result).with(

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Audit::Checksum do
     let(:logfile) { Rails.root.join('log', 'cv.log') }
 
     before { allow(described_class).to receive(:logger).and_call_original } # undo silencing for 1 test
+
     after { FileUtils.rm_f(logfile) }
 
     it 'writes to STDOUT and its own log' do
@@ -62,7 +63,7 @@ RSpec.describe Audit::Checksum do
       CompleteMoab.by_druid(druid).each do |cm|
         cv = ChecksumValidator.new(cm)
         allow(ChecksumValidator).to receive(:new).with(cv.complete_moab).and_return(cv)
-        expect(cv).to receive(:validate_checksums).exactly(1).times.and_call_original
+        expect(cv).to receive(:validate_checksums).once.and_call_original
       end
       described_class.validate_druid(druid)
     end
@@ -108,7 +109,7 @@ RSpec.describe Audit::Checksum do
         expect(cv_list.size).to eq 3
         cv_list.each do |cv|
           allow(ChecksumValidator).to receive(:new).with(cv.complete_moab).and_return(cv)
-          expect(cv).to receive(:validate_checksums).exactly(1).times.and_call_original
+          expect(cv).to receive(:validate_checksums).once.and_call_original
         end
         described_class.validate_status_root('validity_unknown', ms_root_name, 2)
       end

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe Audit::MoabToCatalog do
     end
 
     it 'gets moab size and current version from Moab::StorageObject' do
-      expect(moab).to receive(:current_version_id).at_least(1).times
-      expect(moab).to receive(:size).at_least(1).times
+      expect(moab).to receive(:current_version_id).at_least(:once)
+      expect(moab).to receive(:size).at_least(:once)
       expect(Moab::StorageServices).not_to receive(:new)
       described_class.check_existence_for_dir(storage_dir)
     end
@@ -202,8 +202,8 @@ RSpec.describe Audit::MoabToCatalog do
     end
 
     it 'gets moab size and current version from Moab::StorageObject' do
-      expect(moab).to receive(:size).at_least(1).times
-      expect(moab).to receive(:current_version_id).at_least(1).times
+      expect(moab).to receive(:size).at_least(:once)
+      expect(moab).to receive(:current_version_id).at_least(:once)
       expect(Moab::StorageServices).not_to receive(:new)
       described_class.seed_catalog_for_dir(storage_dir)
     end
@@ -229,6 +229,7 @@ RSpec.describe Audit::MoabToCatalog do
           ).and_return(po_handler)
         end
       end
+
       it "call #create_after_validation" do
         expected_argument_list.each do |arg_hash|
           expect(arg_hash[:po_handler]).to receive(:create_after_validation)
@@ -256,12 +257,12 @@ RSpec.describe Audit::MoabToCatalog do
 
     it 'drops CompleteMoabs that correspond to the given moab storage root' do
       ZippedMoabVersion.destroy_all
-      expect { described_class.drop_moab_storage_root('fixture_sr1') }.to change { CompleteMoab.count }.from(16).to(13)
+      expect { described_class.drop_moab_storage_root('fixture_sr1') }.to change(CompleteMoab, :count).from(16).to(13)
     end
 
     it 'drops PreservedObjects that correspond to the given moab storage root' do
       ZippedMoabVersion.destroy_all
-      expect { described_class.drop_moab_storage_root('fixture_sr1') }.to change { PreservedObject.count }.from(16).to(13)
+      expect { described_class.drop_moab_storage_root('fixture_sr1') }.to change(PreservedObject, :count).from(16).to(13)
     end
 
     it 'rolls back pres obj delete if PCs cannot be deleted' do
@@ -275,7 +276,7 @@ RSpec.describe Audit::MoabToCatalog do
     before { described_class.seed_catalog_for_all_storage_roots }
 
     it "won't change objects in a fully seeded db" do
-      expect { described_class.populate_moab_storage_root('fixture_sr1') }.not_to change { CompleteMoab.count }.from(16)
+      expect { described_class.populate_moab_storage_root('fixture_sr1') }.not_to change(CompleteMoab, :count).from(16)
       expect(PreservedObject.count).to eq 16
     end
 
@@ -283,7 +284,7 @@ RSpec.describe Audit::MoabToCatalog do
       ZippedMoabVersion.destroy_all
       described_class.drop_moab_storage_root('fixture_sr1')
       expect(PreservedObject.count).to eq 13
-      expect { described_class.populate_moab_storage_root('fixture_sr1') }.to change { CompleteMoab.count }.from(13).to(16)
+      expect { described_class.populate_moab_storage_root('fixture_sr1') }.to change(CompleteMoab, :count).from(13).to(16)
       expect(PreservedObject.count).to eq 16
     end
   end

--- a/spec/lib/okcomputer_spec.rb
+++ b/spec/lib/okcomputer_spec.rb
@@ -7,6 +7,7 @@ describe 'OkComputer custom checks' do # rubocop:disable RSpec/DescribeClass
     it { is_expected.to be_successful }
     context 'without data' do
       before { allow(PreservationPolicy).to receive(:select).with(:id).and_return([]) }
+
       it { is_expected.not_to be_successful }
     end
   end
@@ -15,6 +16,7 @@ describe 'OkComputer custom checks' do # rubocop:disable RSpec/DescribeClass
     it { is_expected.to be_successful }
     context 'with old data' do
       before { allow(CompleteMoab).to receive(:least_recent_version_audit).with(any_args).and_return([double]) }
+
       it { is_expected.not_to be_successful }
     end
   end

--- a/spec/lib/preservation_catalog/s3_spec.rb
+++ b/spec/lib/preservation_catalog/s3_spec.rb
@@ -7,6 +7,7 @@ describe PreservationCatalog::S3 do
         expect(described_class.bucket_name).to eq 'sul-sdr-aws-us-west-2-test'
       end
     end
+
     context 'with ENV variable AWS_BUCKET_NAME' do
       around do |example|
         old_val = ENV['AWS_BUCKET_NAME']
@@ -14,6 +15,7 @@ describe PreservationCatalog::S3 do
         example.run
         ENV['AWS_BUCKET_NAME'] = old_val
       end
+
       it 'returns the ENV value' do
         expect(described_class.bucket_name).to eq 'bucket_44'
       end
@@ -37,6 +39,7 @@ describe PreservationCatalog::S3 do
         example.run
         old_vals.each { |k, v| ENV[k] = v }
       end
+
       it 'pulls from ENV vars' do
         expect(config.region).to eq 'us-east-1'
         expect(config.credentials).to be_an(Aws::Credentials)
@@ -72,6 +75,7 @@ describe PreservationCatalog::S3 do
           expect(config.credentials.credentials.secret_access_key).to eq 'bar'
         end
       end
+
       context 'profile us_east_1' do
         let(:envs) { Hash['AWS_PROFILE' => 'us_east_1'] }
 
@@ -81,6 +85,7 @@ describe PreservationCatalog::S3 do
           example.run
           old_vals.each { |k, v| ENV[k] = v }
         end
+
         it 'pulls the other profile from a config file' do
           Aws.config.update(region: 'us-east-1', credentials: shared_credentials)
           expect(config.region).to eq 'us-east-1'

--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Profiler do
     let(:path) { 'log/profile_test-flat.txt' }
 
     before { allow(profiler).to receive(:output_path).and_return(path) }
+
     after { FileUtils.rm_f(path) } # cleanup
 
     it 'returns the printer and prints to the path we pass in' do

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -63,11 +63,11 @@ RSpec.describe CompleteMoab, type: :model do
   describe '#replicatable_status?' do
     it 'reponds true IFF status should allow replication' do
       # validity_unknown initial status implicitly tested (otherwise assignment wouldn't change the reponse)
-      expect { cm.status = 'ok'                        }.to change { cm.replicatable_status? }.to(true)
-      expect { cm.status = 'invalid_checksum'          }.to change { cm.replicatable_status? }.to(false)
-      expect { cm.status = 'replicated_copy_not_found' }.to change { cm.replicatable_status? }.to(true)
-      expect { cm.status = 'invalid_moab'              }.to change { cm.replicatable_status? }.to(false)
-      expect { cm.status = 'unreplicated'              }.to change { cm.replicatable_status? }.to(true)
+      expect { cm.status = 'ok'                        }.to change(cm, :replicatable_status?).to(true)
+      expect { cm.status = 'invalid_checksum'          }.to change(cm, :replicatable_status?).to(false)
+      expect { cm.status = 'replicated_copy_not_found' }.to change(cm, :replicatable_status?).to(true)
+      expect { cm.status = 'invalid_moab'              }.to change(cm, :replicatable_status?).to(false)
+      expect { cm.status = 'unreplicated'              }.to change(cm, :replicatable_status?).to(true)
     end
   end
 
@@ -104,25 +104,25 @@ RSpec.describe CompleteMoab, type: :model do
 
   describe '#update_audit_timestamps' do
     it 'updates last_moab_validation time if moab_validated is true' do
-      expect { cm.update_audit_timestamps(true, false) }.to change { cm.last_moab_validation }.from(nil)
+      expect { cm.update_audit_timestamps(true, false) }.to change(cm, :last_moab_validation).from(nil)
     end
     it 'does not update last_moab_validation time if moab_validated is false' do
-      expect { cm.update_audit_timestamps(false, false) }.not_to change { cm.last_moab_validation }.from(nil)
+      expect { cm.update_audit_timestamps(false, false) }.not_to change(cm, :last_moab_validation).from(nil)
     end
     it 'updates last_version_audit time if version_audited is true' do
-      expect { cm.update_audit_timestamps(false, true) }.to change { cm.last_version_audit }.from(nil)
+      expect { cm.update_audit_timestamps(false, true) }.to change(cm, :last_version_audit).from(nil)
     end
     it 'does not update last_version_audit time if version_audited is false' do
-      expect { cm.update_audit_timestamps(false, false) }.not_to change { cm.last_version_audit }.from(nil)
+      expect { cm.update_audit_timestamps(false, false) }.not_to change(cm, :last_version_audit).from(nil)
     end
   end
 
   describe '#upd_audstamps_version_size' do
     it 'updates version' do
-      expect { cm.upd_audstamps_version_size(false, 3, nil) }.to change { cm.version }.to(3)
+      expect { cm.upd_audstamps_version_size(false, 3, nil) }.to change(cm, :version).to(3)
     end
     it 'updates size if size is not nil' do
-      expect { cm.upd_audstamps_version_size(false, 0, 123) }.to change { cm.size }.to(123)
+      expect { cm.upd_audstamps_version_size(false, 0, 123) }.to change(cm, :size).to(123)
     end
     it 'does not update size if size is nil' do
       expect { cm.upd_audstamps_version_size(false, 0, nil) }.not_to change(cm, :size)
@@ -206,6 +206,7 @@ RSpec.describe CompleteMoab, type: :model do
       expect { described_class.send(:normalize_date, '2014') }.to raise_error(ArgumentError, /argument out of range/)
     end
   end
+
   context 'ordered (by fixity_check_expired) and unordered fixity_check_expired methods' do
     let(:fixity_ttl) { preserved_object.preservation_policy.fixity_ttl }
     let!(:old_check_cm1) do
@@ -383,6 +384,7 @@ RSpec.describe CompleteMoab, type: :model do
 
   describe '.after_save callback' do
     before { allow(ChecksumValidationJob).to receive(:perform_later).and_call_original } # undo rails_helper block
+
     it 'does not call validate_checksums when status is unchanged' do
       cm.size = 234
       expect(cm).not_to receive(:validate_checksums!)

--- a/spec/models/druid_version_zip_spec.rb
+++ b/spec/models/druid_version_zip_spec.rb
@@ -112,6 +112,7 @@ describe DruidVersionZip do
         FileUtils.touch("/tmp/dc/048/cw/1328/dc048cw1328.v0001.#{f}")
       end
     end
+
     after { FileUtils.rm_rf('/tmp/dc') } # cleanup
 
     it 'lists the multiple files produced' do
@@ -134,6 +135,7 @@ describe DruidVersionZip do
       allow(dvz).to receive(:zip_split_size).and_return('1m')
       FileUtils.rm_rf('/tmp/dc') # prep clean dir
     end
+
     after { FileUtils.rm_rf('/tmp/dc') } # cleanup
 
     it 'lists the multiple files produced' do

--- a/spec/models/preservation_policy_spec.rb
+++ b/spec/models/preservation_policy_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe PreservationPolicy, type: :model do
   describe '.default_policy' do
     # clear the cache before each test (and after all) to reset
     before { described_class.default_policy = nil }
+
     after(:all) { described_class.default_policy = nil }
 
     it 'returns the default preservation policy object' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe AuditResults do
         addl_hash = { cm_version: 1, po_version: 2 }
         audit_results.add_result(result_code, addl_hash)
       end
+
       it 'with log_msg_prefix' do
         expected = "FooCheck(#{druid}, fixture_sr1)"
         expect(Rails.logger).to receive(:add).with(Logger::ERROR, a_string_matching(Regexp.escape(expected)))
@@ -124,6 +125,7 @@ RSpec.describe AuditResults do
           im_audit_results.report_results
         end
       end
+
       it "does not send results that aren't in WORKFLOW_REPORT_CODES" do
         code = AuditResults::CREATED_NEW_OBJECT
         audit_results.add_result(code)
@@ -276,6 +278,7 @@ RSpec.describe AuditResults do
       code = AuditResults::INVALID_MOAB
       audit_results.add_result(code, 'foo')
     end
+
     it 'removes results matching DB_UPDATED_CODES' do
       expect(audit_results.result_array.size).to eq 4
       audit_results.remove_db_updated_results

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe ChecksumValidator do
         it "sets status to OK_STATUS if it was previously #{initial_status}" do
           comp_moab.status = initial_status
           comp_moab.save!
-          expect { cv.validate_checksums }.to change { comp_moab.status }.to 'ok'
+          expect { cv.validate_checksums }.to change(comp_moab, :status).to 'ok'
           expect(comp_moab.reload.status).to eq 'ok'
         end
       end
@@ -240,7 +240,7 @@ RSpec.describe ChecksumValidator do
       it "leaves status of OK_STATUS as-is" do
         comp_moab.status = 'ok'
         comp_moab.save!
-        expect { cv.validate_checksums }.not_to(change { comp_moab.status })
+        expect { cv.validate_checksums }.not_to(change(comp_moab, :status))
         expect(comp_moab.reload.status).to eq 'ok'
       end
 
@@ -270,7 +270,7 @@ RSpec.describe ChecksumValidator do
             it "sets status to UNEXPECTED_VERSION_ON_STORAGE_STATUS if it was previously #{initial_status}" do
               comp_moab.status = initial_status
               comp_moab.save!
-              expect { cv.validate_checksums }.to change { comp_moab.status }.to 'unexpected_version_on_storage'
+              expect { cv.validate_checksums }.to change(comp_moab, :status).to 'unexpected_version_on_storage'
               expect(cv.results.contains_result_code?(AuditResults::UNEXPECTED_VERSION)).to be true
               expect(comp_moab.reload.status).to eq 'unexpected_version_on_storage'
             end
@@ -279,7 +279,7 @@ RSpec.describe ChecksumValidator do
           it 'leaves status as UNEXPECTED_VERSION_ON_STORAGE_STATUS if complete moab started in that state' do
             comp_moab.status = 'unexpected_version_on_storage'
             comp_moab.save!
-            expect { cv.validate_checksums }.not_to(change { comp_moab.status })
+            expect { cv.validate_checksums }.not_to(change(comp_moab, :status))
             expect(cv.results.contains_result_code?(AuditResults::UNEXPECTED_VERSION)).to be true
             expect(comp_moab.reload.status).to eq 'unexpected_version_on_storage'
           end
@@ -300,7 +300,7 @@ RSpec.describe ChecksumValidator do
             it "sets status as INVALID_MOAB_STATUS if it was #{initial_status}" do
               comp_moab.status = initial_status
               comp_moab.save!
-              expect { cv.validate_checksums }.to change { comp_moab.status }.to 'invalid_moab'
+              expect { cv.validate_checksums }.to change(comp_moab, :status).to 'invalid_moab'
               expect(comp_moab.reload.status).to eq 'invalid_moab'
             end
           end
@@ -308,7 +308,7 @@ RSpec.describe ChecksumValidator do
           it 'leaves status as INVALID_MOAB_STATUS if complete moab started in that state' do
             comp_moab.status = 'invalid_moab'
             comp_moab.save!
-            expect { cv.validate_checksums }.not_to(change { comp_moab.status })
+            expect { cv.validate_checksums }.not_to(change(comp_moab, :status))
             expect(comp_moab.reload.status).to eq 'invalid_moab'
           end
         end
@@ -330,13 +330,13 @@ RSpec.describe ChecksumValidator do
       ].each do |initial_status|
         it "sets CompleteMoab status to INVALID_CHECKSUM_STATUS if it was initially #{initial_status}" do
           comp_moab.status = initial_status
-          expect { cv.validate_checksums }.to change { comp_moab.status }.to 'invalid_checksum'
+          expect { cv.validate_checksums }.to change(comp_moab, :status).to 'invalid_checksum'
         end
       end
 
       it 'leaves CompleteMoab status as INVALID_CHECKSUM_STATUS if it already was' do
         comp_moab.status = 'invalid_checksum'
-        expect { cv.validate_checksums }.not_to(change { comp_moab.status })
+        expect { cv.validate_checksums }.not_to(change(comp_moab, :status))
       end
 
       context 'fails other moab validation' do
@@ -356,7 +356,7 @@ RSpec.describe ChecksumValidator do
             it "sets status to INVALID_CHECKSUM_STATUS if it was previously #{initial_status}" do
               comp_moab.status = initial_status
               comp_moab.save!
-              expect { cv.validate_checksums }.to change { comp_moab.status }.to 'invalid_checksum'
+              expect { cv.validate_checksums }.to change(comp_moab, :status).to 'invalid_checksum'
               expect(comp_moab.reload.status).to eq 'invalid_checksum'
             end
           end
@@ -364,7 +364,7 @@ RSpec.describe ChecksumValidator do
           it 'leaves status as INVALID_CHECKSUM_STATUS if complete moab started in that state' do
             comp_moab.status = 'invalid_checksum'
             comp_moab.save!
-            expect { cv.validate_checksums }.not_to(change { comp_moab.status })
+            expect { cv.validate_checksums }.not_to(change(comp_moab, :status))
             expect(comp_moab.reload.status).to eq 'invalid_checksum'
           end
         end
@@ -384,7 +384,7 @@ RSpec.describe ChecksumValidator do
             it "sets status as INVALID_CHECKSUM_STATUS if it was #{initial_status}" do
               comp_moab.status = initial_status
               comp_moab.save!
-              expect { cv.validate_checksums }.to change { comp_moab.status }.to 'invalid_checksum'
+              expect { cv.validate_checksums }.to change(comp_moab, :status).to 'invalid_checksum'
               expect(comp_moab.reload.status).to eq 'invalid_checksum'
             end
           end
@@ -392,7 +392,7 @@ RSpec.describe ChecksumValidator do
           it 'leaves status as INVALID_CHECKSUM_STATUS if complete moab started in that state' do
             comp_moab.status = 'invalid_checksum'
             comp_moab.save!
-            expect { cv.validate_checksums }.not_to(change { comp_moab.status })
+            expect { cv.validate_checksums }.not_to(change(comp_moab, :status))
             expect(comp_moab.reload.status).to eq 'invalid_checksum'
           end
         end

--- a/spec/services/preserved_object_handler_check_exist_spec.rb
+++ b/spec/services/preserved_object_handler_check_exist_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe PreservedObjectHandler do
               expect(cm.reload.updated_at).to be > orig
             end
           end
+
           context 'unchanged' do
             it 'status' do
               orig = cm.status
@@ -75,6 +76,7 @@ RSpec.describe PreservedObjectHandler do
             end
           end
         end
+
         it 'PreservedObject is not updated' do
           orig = po.updated_at
           po_handler.check_existence
@@ -116,6 +118,7 @@ RSpec.describe PreservedObjectHandler do
                 allow(po_handler).to receive(:moab_validation_errors).and_return([])
                 allow(po_handler).to receive(:ran_moab_validation?).and_return(true)
               end
+
               it 'version to incoming_version' do
                 orig = cm.version
                 po_handler.check_existence
@@ -154,10 +157,12 @@ RSpec.describe PreservedObjectHandler do
                 expect(cm.reload.status).to eq 'validity_unknown'
               end
             end
+
             context 'unchanged' do
               before do
                 allow(po_handler).to receive(:moab_validation_errors).and_return([])
               end
+
               it 'status if former status was ok' do
                 cm.status = 'ok'
                 cm.save!
@@ -172,11 +177,13 @@ RSpec.describe PreservedObjectHandler do
               end
             end
           end
+
           context 'PreservedObject' do
             context 'changed' do
               before do
                 allow(po_handler).to receive(:moab_validation_errors).and_return([])
               end
+
               it 'current_version' do
                 orig = po.current_version
                 po_handler.check_existence
@@ -199,6 +206,7 @@ RSpec.describe PreservedObjectHandler do
             before do
               allow(po_handler).to receive(:moab_validation_errors).and_return([])
             end
+
             it '1 result' do
               expect(results).to be_an_instance_of Array
               expect(results.size).to eq 1
@@ -271,6 +279,7 @@ RSpec.describe PreservedObjectHandler do
                 expect(invalid_cm.reload.status).to eq 'invalid_moab'
               end
             end
+
             context 'unchanged' do
               it 'version' do
                 orig = invalid_cm.version
@@ -284,6 +293,7 @@ RSpec.describe PreservedObjectHandler do
               end
             end
           end
+
           it 'PreservedObject is not updated' do
             orig_timestamp = invalid_po.updated_at
             invalid_po_handler.check_existence

--- a/spec/services/preserved_object_handler_confirm_version_spec.rb
+++ b/spec/services/preserved_object_handler_confirm_version_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe PreservedObjectHandler do
               expect(cm.reload.updated_at).to be > orig
             end
           end
+
           context 'unchanged' do
             it 'status' do
               orig = cm.status
@@ -87,6 +88,7 @@ RSpec.describe PreservedObjectHandler do
             end
           end
         end
+
         it 'PreservedObject is not updated' do
           orig_timestamp = po.updated_at
           po_handler.confirm_version
@@ -164,6 +166,7 @@ RSpec.describe PreservedObjectHandler do
                 expect(cm.reload.updated_at).to be > orig
               end
             end
+
             context 'unchanged' do
               it 'version' do
                 orig = cm.version
@@ -182,6 +185,7 @@ RSpec.describe PreservedObjectHandler do
               end
             end
           end
+
           it 'PreservedObject is not updated' do
             orig_timestamp = po.updated_at
             po_handler.confirm_version

--- a/spec/services/preserved_object_handler_spec.rb
+++ b/spec/services/preserved_object_handler_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe PreservedObjectHandler do
         end
       end
     end
+
     context 'sets incoming_size' do
       { # passed value => expected parsed value
         6 => 6,
@@ -58,6 +59,7 @@ RSpec.describe PreservedObjectHandler do
         end
       end
     end
+
     it 'exposes storage_location (from MoabStorageRoot)' do
       po_handler = described_class.new(druid, incoming_version, nil, ms_root)
       expect(po_handler.storage_location).to eq ms_root.storage_location

--- a/spec/services/preserved_object_handler_update_version_spec.rb
+++ b/spec/services/preserved_object_handler_update_version_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe PreservedObjectHandler do
               expect(cm.size).not_to eq orig
             end
           end
+
           context 'unchanged' do
             it 'size if incoming size is nil' do
               orig = cm.size
@@ -70,6 +71,7 @@ RSpec.describe PreservedObjectHandler do
               expect(cm.reload.last_moab_validation).to eq orig
             end
           end
+
           context 'status' do
             context 'checksums_validated = false' do
               it 'starting status validity_unknown unchanged' do
@@ -81,6 +83,7 @@ RSpec.describe PreservedObjectHandler do
               context 'starting status not validity_unknown' do
                 shared_examples 'POH#update_version changes status to "validity_unknown"' do |orig_status|
                   before { cm.update!(status: orig_status) }
+
                   it "original status #{orig_status}" do
                     expect do
                       po_handler.update_version
@@ -95,6 +98,7 @@ RSpec.describe PreservedObjectHandler do
                 it_behaves_like 'POH#update_version changes status to "validity_unknown"', 'unexpected_version_on_storage'
               end
             end
+
             context 'checksums_validated = true' do
               it 'starting status ok unchanged' do
                 expect do
@@ -106,6 +110,7 @@ RSpec.describe PreservedObjectHandler do
                   before do
                     cm.update!(status: orig_status)
                   end
+
                   it "original status #{orig_status}" do
                     expect do
                       po_handler.update_version(true)
@@ -147,6 +152,7 @@ RSpec.describe PreservedObjectHandler do
             end
           end
         end
+
         it_behaves_like 'calls AuditResults.report_results', :update_version
 
         context 'returns' do
@@ -209,6 +215,7 @@ RSpec.describe PreservedObjectHandler do
             end
           end
         end
+
         context 'PreservedObject' do
           context 'ActiveRecordError' do
             let(:results) do
@@ -304,6 +311,7 @@ RSpec.describe PreservedObjectHandler do
             last_moab_validation: t
           )
         end
+
         let(:po) { PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy) }
         let(:cm) { CompleteMoab.find_by!(preserved_object: po, moab_storage_root: ms_root) }
 
@@ -332,6 +340,7 @@ RSpec.describe PreservedObjectHandler do
               expect(cm.size).not_to eq orig
             end
           end
+
           context 'unchanged' do
             it 'size if incoming size is nil' do
               orig = cm.size
@@ -340,6 +349,7 @@ RSpec.describe PreservedObjectHandler do
               expect(cm.reload.size).to eq orig
             end
           end
+
           context 'status' do
             context 'checksums_validated = false' do
               it 'starting status validity_unknown unchanged' do
@@ -351,6 +361,7 @@ RSpec.describe PreservedObjectHandler do
               context 'starting status not validity_unknown' do
                 shared_examples 'POH#update_version_after_validation changes status to "validity_unknown"' do |orig_status|
                   before { cm.update(status: orig_status) }
+
                   it "original status #{orig_status}" do
                     expect do
                       po_handler.update_version_after_validation
@@ -365,6 +376,7 @@ RSpec.describe PreservedObjectHandler do
                 it_behaves_like 'POH#update_version_after_validation changes status to "validity_unknown"', 'unexpected_version_on_storage'
               end
             end
+
             context 'checksums_validated = true' do
               it 'starting status ok unchanged' do
                 expect do
@@ -374,6 +386,7 @@ RSpec.describe PreservedObjectHandler do
               context 'starting status not ok' do
                 shared_examples 'POH#update_version_after_validation(true) changes status to "ok"' do |orig_status|
                   before { cm.update(status: orig_status) }
+
                   it "original status #{orig_status}" do
                     expect do
                       po_handler.update_version_after_validation(true)
@@ -390,6 +403,7 @@ RSpec.describe PreservedObjectHandler do
             end
           end
         end
+
         context 'PreservedObject' do
           context 'changed' do
             it 'current_version' do
@@ -469,6 +483,7 @@ RSpec.describe PreservedObjectHandler do
               context 'starting status was not validity_unknown' do
                 shared_examples 'POH#update_version_after_validation changes status to "validity_unknown"' do |orig_status|
                   before { cm.update(status: orig_status) }
+
                   it "original status #{orig_status}" do
                     # (due to newer version not checksum validated)
                     expect do
@@ -486,6 +501,7 @@ RSpec.describe PreservedObjectHandler do
             end
           end
         end
+
         context 'checksums_validated = true' do
           context 'CompleteMoab' do
             it 'last_moab_validation updated' do
@@ -518,6 +534,7 @@ RSpec.describe PreservedObjectHandler do
               context 'starting status was not invalid_moab' do
                 shared_examples 'POH#update_version_after_validation(true) changes status to "invalid_moab"' do |orig_status|
                   before { cm.update(status: orig_status) }
+
                   it "original status #{orig_status}" do
                     expect do
                       po_handler.update_version_after_validation(true)
@@ -534,6 +551,7 @@ RSpec.describe PreservedObjectHandler do
             end
           end
         end
+
         context 'PreservedObject' do
           context 'unchanged' do
             it 'current_version' do
@@ -588,6 +606,7 @@ RSpec.describe PreservedObjectHandler do
                 expect { po_handler.update_version_after_validation }.to change { cm.reload.status }.to('validity_unknown')
               end
             end
+
             it 'does not update PreservedObject' do
               expect { po_handler.update_version_after_validation }.not_to change { po.reload.updated_at }
             end
@@ -615,6 +634,7 @@ RSpec.describe PreservedObjectHandler do
               end
             end
           end
+
           context 'checksums_validated = true' do
             context 'CompleteMoab' do
               it 'last_moab_validation updated' do
@@ -633,6 +653,7 @@ RSpec.describe PreservedObjectHandler do
                 expect { po_handler.update_version_after_validation(true) }.to change { cm.reload.status }.to('invalid_moab')
               end
             end
+
             it 'does not update PreservedObject' do
               expect { po_handler.update_version_after_validation(true) }.not_to change { po.reload.updated_at }
             end

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -72,6 +72,7 @@ RSpec.shared_examples 'CompleteMoab does not exist' do |method_sym|
   before do
     PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy)
   end
+
   let(:exp_msg) { "#<ActiveRecord::RecordNotFound: foo> db object does not exist" }
   let(:results) do
     allow(Rails.logger).to receive(:log)
@@ -114,6 +115,7 @@ RSpec.shared_examples 'unexpected version' do |method_sym, actual_version|
         end
       end
     end
+
     context 'unchanged' do
       it "version" do
         orig = cm.version
@@ -144,6 +146,7 @@ RSpec.shared_examples 'unexpected version' do |method_sym, actual_version|
       end
     end
   end
+
   context 'PreservedObject' do
     context 'unchanged' do
       it "PreservedObject current_version stays the same" do
@@ -215,6 +218,7 @@ RSpec.shared_examples 'unexpected version with validation' do |method_sym, incom
         end
       end
     end
+
     describe 'status becomes' do
       before { cm.ok! }
 
@@ -232,6 +236,7 @@ RSpec.shared_examples 'unexpected version with validation' do |method_sym, incom
       end
     end
   end
+
   context 'PreservedObject' do
     it "current_version" do
       expect { po_handler.send(method_sym) }.not_to change { po.reload.current_version }
@@ -365,10 +370,12 @@ RSpec.shared_examples 'CompleteMoab may have its status checked when incoming_ve
     context 'without moab validation errors' do
       it_behaves_like 'cannot validate something with INVALID_CHECKSUM_STATUS', method_sym
     end
+
     context 'with moab validation errors' do
       before do
         allow(po_handler).to receive(:moab_validation_errors).and_return([{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }])
       end
+
       it_behaves_like 'cannot validate something with INVALID_CHECKSUM_STATUS', method_sym
     end
   end
@@ -416,10 +423,12 @@ RSpec.shared_examples 'CompleteMoab may have its status checked when incoming_ve
     context 'without moab validation errors' do
       it_behaves_like 'cannot validate something with INVALID_CHECKSUM_STATUS', method_sym
     end
+
     context 'with moab validation errors' do
       before do
         allow(po_handler).to receive(:moab_validation_errors).and_return([{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }])
       end
+
       it_behaves_like 'cannot validate something with INVALID_CHECKSUM_STATUS', method_sym
     end
   end

--- a/spec/services/workflow_reporter_spec.rb
+++ b/spec/services/workflow_reporter_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe WorkflowReporter do
       expect(described_class.report_error(druid, process_name, result)).to be true
     end
   end
+
   describe '.report_completed' do
     it 'returns true' do
       full_url = 'https://workflows.example.org/workflow/dor/objects/druid:jj925bx9565/workflows/preservationAuditWF/preservation-audit'


### PR DESCRIPTION
See: https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-has_one

Closes #1014