### PR TITLE
Update amazon SDK

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) do |repo_name|
 end
 
 # general Ruby/Rails gems
-gem 'aws-sdk-s3', '~> 1.9.1'
+gem 'aws-sdk-s3', '~> 1.17'
 gem 'config' # Settings to manage configs on different instances
 gem 'dor-workflow-service' # audit errors are reported to the workflow service
 gem 'honeybadger' # for error reporting / tracking / notifications

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,16 +54,16 @@ GEM
     ast (2.4.0)
     aws-eventstream (1.0.1)
     aws-partitions (1.96.0)
-    aws-sdk-core (3.22.1)
+    aws-sdk-core (3.23.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.6.0)
+    aws-sdk-kms (1.7.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.9.1)
-      aws-sdk-core (~> 3)
+    aws-sdk-s3 (1.17.0)
+      aws-sdk-core (~> 3, >= 3.21.2)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
@@ -352,7 +352,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk-s3 (~> 1.9.1)
+  aws-sdk-s3 (~> 1.17)
   capistrano-passenger
   capistrano-rails
   config


### PR DESCRIPTION
There have been many releases in recent months including several bugfixes around memory allocation and filehandle closing on file upload, including:
- `Ensure file handlers are closed when an exception is raised in Aws::S3::FileUploader`

See: https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-s3/CHANGELOG.md#1170-2018-07-11