### PR TITLE
Stop nuking the DB every time rspec runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - postgresql
   - redis-server
 before_script:
-  - bundle exec rake travis_setup_postgres
+  - bundle exec rake travis_setup_postgres db:reset
 bundler_args: "--without 'production development deploy'"
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -44,12 +44,15 @@ Using the `psql` utility, run these two setup scripts from the command line, lik
 ```sh
 psql -f db/scripts/pres_setup.sql postgres
 psql -f db/scripts/pres_test_setup.sql postgres
+bundle exec rails db:seed
+RAILS_ENV=test bundle exec rails db:seed
 ```
 
 These scripts do the following for you:
 * create the test and dev PostgreSQL users.
 * create the test and dev databases.
 * setup the needed ownership and permissions between the DBs and the users.
+* seed data into development and test environments
 
 For more info on postgres commands, see https://www.postgresql.org/docs/
 
@@ -321,12 +324,19 @@ Audit::Checksum.validate_status_root('validity_unknown', 'services-disk15')
 
 ## Development
 
+### Seed
+
+You should only need to do this once, or after nuking your test database:
+```
+RAILS_ENV=test bundle exec rails db:reset
+```
+
 ### Running Tests
 
 To run the tests:
 
 ```sh
-rake spec
+bundle exec rake spec
 ```
 
 ## Deploying

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,8 +6,6 @@ require File.expand_path('../config/environment', __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
-Rails.application.load_tasks
-Rake::Task["db:reset"].invoke
 
 # auto-require all ruby files in the support directory
 Dir[Rails.root.join('spec', 'support', '*.rb')].each { |f| require f }
@@ -18,7 +16,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
This practice seems to have derived from having non-rails_helper'd code writing to the database, as with our old `./lib` directory.  It is unnecessary for anything using rails_helper, however, which now includes all the code that writes to the DB during tests.

We already have transactional fixtures turned on so every change during the rspec suite is atomically rolled back at the end of the example where it was made.

Also, we use the fixtures directory, but we don't use it for ActiveRecord fixtures, so that config in rails_helper is misleading.