### PR TITLE
Add zip cache cleanup cronjob and capistrano role

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,7 +1,7 @@
 server 'preservation-catalog-prod-01.stanford.edu', user: 'pres', roles: %w[m2c c2m app db web]
 server 'preservation-catalog-prod-02.stanford.edu', user: 'pres', roles: %w[cv app]
 server 'preservation-catalog-prod-03.stanford.edu', user: 'pres', roles: %w[app resque]
-server 'preservation-catalog-prod-04.stanford.edu', user: 'pres', roles: %w[app resque]
+server 'preservation-catalog-prod-04.stanford.edu', user: 'pres', roles: %w[app resque cache_cleaner]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -26,3 +26,10 @@ every :sunday, at: '1am', roles: [:cv] do
   set :output, standard: nil, error: 'log/cv-err.log'
   rake "cv:all_roots"
 end
+
+every :hour, roles: [:cache_cleaner] do
+  set :output, standard: 'log/zip_cache_cleanup.log'
+  command <<-'END_OF_COMMAND'
+    find /sdr-transfers -mindepth 5 -type f -name "*.zip" -mtime +1 -exec bash -c 'TARGET="{}"; rm -v ${TARGET%ip}*' \;
+  END_OF_COMMAND
+end


### PR DESCRIPTION
Currently, this would run every hour and delete any files older than 1 day. So the oldest a file would be is 1 day (and 59 minutes). 

This may require further tuning depending on how we choose to enqueue backlog for `ZipmakerJob` or when we have completed the backlog and have different operational expectations for volume of work (i.e. drive less full, files could live longer).

The implication of cache purging is that the zip files must be kept longer than the latency between `ZipmakerJob`'s completion and completion of delivery job(s), inclusive of Plexer latency.  Otherwise the zip file will be deleted before it is delivered.  So any tuning should be measured against performance on those queues.

Closes #1032