### PR TITLE
moab replication audit scheduling, etc

### DIFF
--- a/app/jobs/moab_replication_audit_job.rb
+++ b/app/jobs/moab_replication_audit_job.rb
@@ -1,7 +1,6 @@
 # Confirms that a CompleteMoab is fully/properly replicated to all target zip endpoints.
 # Usage info:
-# MoabReplicationAuditJob.set(queue: :endpoint_check_us_west_2).perform_later(cm)
-# MoabReplicationAuditJob.set(queue: :endpoint_check_us_east_1).perform_later(cm)
+# MoabReplicationAuditJob.perform_later(cm)
 class MoabReplicationAuditJob < ApplicationJob
   queue_as :moab_replication_audit
   delegate :check_child_zip_part_attributes, to: Audit::CatalogToArchive

--- a/app/jobs/moab_replication_audit_job.rb
+++ b/app/jobs/moab_replication_audit_job.rb
@@ -12,16 +12,8 @@ class MoabReplicationAuditJob < ApplicationJob
     druid = complete_moab.preserved_object.druid
 
     results = AuditResults.new(druid, nil, complete_moab.moab_storage_root, "MoabReplicationAuditJob")
-    # TODO: will also need to create a CompleteMoab.archive_check_expired scope, use that
-    # to queue jobs for this worker.
 
-    backfilled_zmvs = complete_moab.create_zipped_moab_versions!
-    unless backfilled_zmvs.empty?
-      results.add_result(
-        AuditResults::ZMV_BACKFILL,
-        version_endpoint_pairs: format_backfilled_zmvs(backfilled_zmvs)
-      )
-    end
+    backfill_missing_zmvs(complete_moab, results) if Settings.replication.audit_should_backfill
 
     complete_moab.zipped_moab_versions.each do |zmv|
       next unless check_child_zip_part_attributes(zmv, results)
@@ -34,6 +26,16 @@ class MoabReplicationAuditJob < ApplicationJob
   end
 
   private
+
+  def backfill_missing_zmvs(complete_moab, results)
+    backfilled_zmvs = complete_moab.create_zipped_moab_versions!
+    return if backfilled_zmvs.empty?
+
+    results.add_result(
+      AuditResults::ZMV_BACKFILL,
+      version_endpoint_pairs: format_backfilled_zmvs(backfilled_zmvs)
+    )
+  end
 
   def format_backfilled_zmvs(backfilled_zmvs)
     backfilled_zmvs.map { |bz| "#{bz.version} to #{bz.zip_endpoint.endpoint_name}" }.sort.join("; ")

--- a/app/jobs/moab_replication_audit_job.rb
+++ b/app/jobs/moab_replication_audit_job.rb
@@ -20,8 +20,6 @@ class MoabReplicationAuditJob < ApplicationJob
       check_aws_replicated_zipped_moab_version(zmv, results)
     end
 
-    # TODO: will need to test call to this once no longer integration testing what gets logged, make
-    # sure report_results, gets expected logger instance (from C2A)
     results.report_results(logger)
   end
 

--- a/app/lib/audit/catalog_to_archive.rb
+++ b/app/lib/audit/catalog_to_archive.rb
@@ -1,8 +1,6 @@
 module Audit
   # Catalog to cloud archive provider (what ZipEndpoint, ZippedMoabVersion etc represent) audit code
   class CatalogToArchive
-    # TODO: should we be capturing/reporting via AuditResults instance instead of just logging?  would be
-    # consistent with other audit checks.
     def self.logger
       @logger ||= Logger.new(Rails.root.join('log', 'c2a.log'))
     end

--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -72,6 +72,12 @@ class CompleteMoab < ApplicationRecord
     ChecksumValidationJob.perform_later(self)
   end
 
+  # Queue a job that will check to see whether this CompleteMoab has been
+  # fully replicated to all target ZipEndpoints
+  def audit_moab_version_replication!
+    MoabReplicationAuditJob.perform_later(self)
+  end
+
   def druid_version_zip
     @druid_version_zip ||= DruidVersionZip.new(preserved_object.druid, version)
   end

--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -110,11 +110,19 @@ class CompleteMoab < ApplicationRecord
     Time.parse(timestamp).utc
   end
 
+  # Sort the given relation by last_version_audit, nulls first.
   def self.order_last_version_audit(active_record_relation)
+    # possibly non-obvious: IS NOT NULL evaluates to 0 for nulls and 1 for non-nulls; thus, this
+    # sorts nulls (0) before non-nulls (1), and non-nulls are then sorted by last_version_audit.
+    # standard SQL doesn't have a NULLS FIRST sort built in.
     active_record_relation.order('last_version_audit IS NOT NULL, last_version_audit ASC')
   end
 
+  # Sort the given relation by last_checksum_validation, nulls first.
   def self.order_fixity_check_expired(active_record_relation)
+    # possibly non-obvious: IS NOT NULL evaluates to 0 for nulls and 1 for non-nulls; thus, this
+    # sorts nulls (0) before non-nulls (1), and non-nulls are then sorted by last_checksum_validation.
+    # standard SQL doesn't have a NULLS FIRST sort built in.
     active_record_relation.order('last_checksum_validation IS NOT NULL, last_checksum_validation ASC')
   end
 end

--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -44,6 +44,16 @@ class CompleteMoab < ApplicationRecord
       )
   }
 
+  scope :archive_check_expired, lambda {
+    joins(:preserved_object)
+      .joins(
+        'INNER JOIN preservation_policies'\
+        ' ON preservation_policies.id = preserved_objects.preservation_policy_id'\
+        ' AND (last_archive_audit + (archive_ttl * INTERVAL \'1 SECOND\')) < CURRENT_TIMESTAMP'\
+        ' OR last_archive_audit IS NULL'
+      )
+  }
+
   # This is where we make sure we have ZMV rows for all needed ZipEndpoints and versions.
   # Endpoints may have been added, so we must check all dimensions.
   # For *this* and *previous* versions, create any ZippedMoabVersion records which don't yet exist for

--- a/app/services/preserved_object_handler.rb
+++ b/app/services/preserved_object_handler.rb
@@ -139,8 +139,6 @@ class PreservedObjectHandler
           # for case when no db updates b/c pres_obj version != comp_moab version
           update_cm_invalid_moab unless comp_moab.invalid_moab?
         else
-          # TODO: we don't know checksum validity of incoming version, and we also have invalid moab
-          #   so ideally we could report on moab validation errors (done) *and* queue up a checksum validity check
           update_online_version('validity_unknown', false, false)
           # for case when no db updates b/c pres_obj version != comp_moab version
           update_cm_validity_unknown unless comp_moab.validity_unknown?

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,5 +1,5 @@
-server 'preservation-catalog-prod-01.stanford.edu', user: 'pres', roles: %w[m2c c2m app db web]
-server 'preservation-catalog-prod-02.stanford.edu', user: 'pres', roles: %w[cv app resque]
+server 'preservation-catalog-prod-01.stanford.edu', user: 'pres', roles: %w[app db web]
+server 'preservation-catalog-prod-02.stanford.edu', user: 'pres', roles: %w[app resque queue_populator]
 server 'preservation-catalog-prod-03.stanford.edu', user: 'pres', roles: %w[app resque]
 server 'preservation-catalog-prod-04.stanford.edu', user: 'pres', roles: %w[app resque cache_cleaner]
 
@@ -7,7 +7,7 @@ Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 set :bundle_without, 'deploy test'
 set :deploy_to, '/opt/app/pres/preservation_catalog'
-set :whenever_roles, [:m2c, :c2m, :cv]
+set :whenever_roles, [:queue_populator]
 
 set :east_bucket_name, 'sul-sdr-aws-us-east-1-archive'
 set :west_bucket_name, 'sul-sdr-aws-us-west-2-archive'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,15 +2,19 @@
 # Learn more: http://github.com/javan/whenever
 
 # these append to existing logs
-every :tuesday, roles: [:m2c] do
+every :tuesday, roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/m2c-err.log'
   runner 'MoabStorageRoot.find_each(&:m2c_check!)'
 end
-every :friday, roles: [:c2m] do
+every :wednesday, roles: [:queue_populator] do
+  set :output, standard: nil, error: 'log/c2a-err.log'
+  runner 'CompleteMoab.archive_check_expired.find_each(&:audit_moab_version_replication!)'
+end
+every :friday, roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/c2m-err.log'
   runner 'MoabStorageRoot.find_each(&:c2m_check!)'
 end
-every :sunday, at: '1am', roles: [:cv] do
+every :sunday, at: '1am', roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/cv-err.log'
   runner 'Audit::Checksum.validate_disk_all_storage_roots'
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,3 +38,12 @@ zip_storage: '/tmp' # override in #{RAILS_ENV}.yml
 resque_dashboard_hostnames: # tells the router where to mount the resque dashboard
   - 'worker-hostname-01.example.com'
   - 'worker-hostname-02.example.com'
+
+# When the backlog of unreplicated moabs is very large, e.g. when first spinning up
+# the catalog, or when adding a new ZipEndpoint after the catalog has been running, we
+# want to manually choose batches of moabs to replicate, so that we don't accidentally
+# overrun the zip creation temp space.
+# In normal steady state operation, this should be set to true, either here, or in the
+# instance specific configs.
+replication:
+  audit_should_backfill: false

--- a/db/migrate/20180813235728_add_last_archive_audit_to_complete_moab.rb
+++ b/db/migrate/20180813235728_add_last_archive_audit_to_complete_moab.rb
@@ -1,0 +1,6 @@
+class AddLastArchiveAuditToCompleteMoab < ActiveRecord::Migration[5.1]
+  def change
+    add_column :complete_moabs, :last_archive_audit, :datetime
+    add_index :complete_moabs, :last_archive_audit
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180802230025) do
+ActiveRecord::Schema.define(version: 20180813235728) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,7 +26,9 @@ ActiveRecord::Schema.define(version: 20180802230025) do
     t.bigint "size"
     t.integer "status", null: false
     t.datetime "last_version_audit"
+    t.datetime "last_archive_audit"
     t.index ["created_at"], name: "index_complete_moabs_on_created_at"
+    t.index ["last_archive_audit"], name: "index_complete_moabs_on_last_archive_audit"
     t.index ["last_checksum_validation"], name: "index_complete_moabs_on_last_checksum_validation"
     t.index ["last_moab_validation"], name: "index_complete_moabs_on_last_moab_validation"
     t.index ["last_version_audit"], name: "index_complete_moabs_on_last_version_audit"

--- a/spec/jobs/moab_replication_audit_job_spec.rb
+++ b/spec/jobs/moab_replication_audit_job_spec.rb
@@ -8,6 +8,7 @@ describe MoabReplicationAuditJob, type: :job do
   before do
     allow(AuditResults).to receive(:new).and_return(results)
     allow(results).to receive(:report_results)
+    allow(Settings.replication).to receive(:audit_should_backfill).and_return(true) # default to enabled for tests
   end
 
   describe '#perform' do
@@ -22,10 +23,21 @@ describe MoabReplicationAuditJob, type: :job do
     context 'there are zipped_moab_versions to backfill for complete_moab' do
       before { cm.zipped_moab_versions.destroy_all } # undo auto-spawned rows from callback
 
-      it 'logs a warning about uncreated ZMVs' do
+      it 'tries to create missing ZMVs and logs a warning about uncreated ZMVs' do
+        expect(cm).to receive(:create_zipped_moab_versions!).and_call_original
         job.perform(cm)
         msg = "backfilled the following ZippedMoabVersions: 1 to mock_archive1; 2 to mock_archive1"
         expect(results.result_array).to include(a_hash_including(AuditResults::ZMV_BACKFILL => msg))
+      end
+
+      context 'automatic backfilling is disabled' do
+        before { allow(Settings.replication).to receive(:audit_should_backfill).and_return(false) }
+
+        it 'does not try to create ZippedMoabVersions for the CompleteMoab' do
+          expect(cm).not_to receive(:create_zipped_moab_versions!)
+          job.perform(cm)
+          expect(results.result_array).not_to include(a_hash_including(AuditResults::ZMV_BACKFILL))
+        end
       end
     end
 

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -331,6 +331,13 @@ RSpec.describe CompleteMoab, type: :model do
     end
   end
 
+  describe '#audit_moab_version_replication!' do
+    it 'queues a replication audit job for its CompleteMoab' do
+      expect(MoabReplicationAuditJob).to receive(:perform_later).with(cm)
+      cm.audit_moab_version_replication!
+    end
+  end
+
   describe '.after_update callback' do
     it 'does not call create_zipped_moab_versions when version is unchanged' do
       cm.size = 234

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -221,8 +221,6 @@ RSpec.describe CompleteMoab, type: :model do
       create(:complete_moab, args.merge(version: 9, last_checksum_validation: now - (fixity_ttl * 0.1)))
     end
 
-    before { cm.save! }
-
     describe '.fixity_check_expired' do
       it 'returns PreservedCopies that need fixity check' do
         expect(described_class.fixity_check_expired.to_a.sort).to eq [cm, old_check_cm1, old_check_cm2]
@@ -272,8 +270,6 @@ RSpec.describe CompleteMoab, type: :model do
   end
 
   context 'with a persisted object' do
-    before { cm.save! }
-
     describe '.by_druid' do
       it 'returns the expected complete moabs' do
         expect(described_class.by_druid(druid).length).to eq 1

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -295,11 +295,6 @@ RSpec.describe CompleteMoab, type: :model do
       expect(zmvs_by_druid.pluck(:version).sort).to eq [1, 2, 3]
     end
 
-    # TODO: is there some test that should replace this now that ZMV#status is gone?
-    # it 'creates ZMVs so that they start with unreplicated status' do
-    #   expect(cm.create_zipped_moab_versions!.all?(&:unreplicated?)).to be true
-    # end
-
     it "creates ZMVs that don't yet exist for new endpoint, but should" do
       expect { cm.create_zipped_moab_versions! }.to change {
         ZipEndpoint.which_need_archive_copy(druid, cm_version).to_a


### PR DESCRIPTION
as discussed F2F in the handoff meeting on monday (see #780), this adds a setting that enables/disables automatic backfilling of unreplicated moab versions when the replication audit finds such things.  that flag defaults to disabling the backfill in this PR.  it can be re-enabled when we're in more of a steady state, where we have less of a backlog, or no expected backlog.

also does some other random touchups.

closes #901