### PR TITLE
ZipPart#s3_key and helper #druid_version_zip fixed to generate keys with the appropriate version

### DIFF
--- a/app/models/zip_part.rb
+++ b/app/models/zip_part.rb
@@ -37,7 +37,7 @@ class ZipPart < ApplicationRecord
   end
 
   def druid_version_zip
-    @druid_version_zip ||= DruidVersionZip.new(preserved_object.druid, complete_moab.version)
+    @druid_version_zip ||= DruidVersionZip.new(preserved_object.druid, zipped_moab_version.version)
   end
 
   def s3_key

--- a/spec/models/druid_version_zip_spec.rb
+++ b/spec/models/druid_version_zip_spec.rb
@@ -15,6 +15,14 @@ describe DruidVersionZip do
     it 'returns a tree path-based key' do
       expect(dvz.s3_key).to eq 'bj/102/hs/9687/bj102hs9687.v0001.zip'
     end
+
+    context 'version is greater than 1' do
+      let(:version) { 2 }
+
+      it 'uses the right version in the path' do
+        expect(dvz.s3_key).to eq 'bj/102/hs/9687/bj102hs9687.v0002.zip'
+      end
+    end
   end
 
   describe '#ensure_zip_directory' do

--- a/spec/models/zip_part_spec.rb
+++ b/spec/models/zip_part_spec.rb
@@ -43,6 +43,26 @@ RSpec.describe ZipPart, type: :model do
     end
   end
 
+  describe '#druid_version_zip' do
+    let(:cm) { build(:complete_moab, version: 3) }
+    let(:zmv) { build(:zipped_moab_version, complete_moab: cm, version: 1) }
+    let(:zp) { described_class.new(args) }
+
+    it 'gets a DruidVersionZip of the correct version' do
+      expect(zp.druid_version_zip.version).to eq 1
+    end
+  end
+
+  describe '#s3_key' do
+    let(:cm) { build(:complete_moab, version: 3) }
+    let(:zmv) { build(:zipped_moab_version, complete_moab: cm, version: 1) }
+    let(:zp) { described_class.new(args) }
+
+    it 'generates an s3_key with the correct version and suffix' do
+      expect(zp.s3_key).to eq "#{DruidTools::Druid.new(cm.preserved_object.druid).tree.join('/')}.v0001.zip"
+    end
+  end
+
   describe "#suffixes_in_set" do
     let(:zp) { described_class.new(args.merge(parts_count: 3)) }
 


### PR DESCRIPTION
use the `ZMV`'s version (instead of `CompleteMoab`'s) when creating `DruidVersionZip` instance, which fixes `s3_key` always ending up with the `CompleteMoab`'s latest version, regardless of that `ZipPart`'s `ZMV` parent's specific version.

also, add test cases that speak to the original oversight.

worked w/ @tallenaz, @atz, and @SaravShah on investigation and writing of new tests.

closes #1088