### PR TITLE
Remove PreservationPolicy.seed_from_config

### DIFF
--- a/app/models/preservation_policy.rb
+++ b/app/models/preservation_policy.rb
@@ -10,21 +10,15 @@ class PreservationPolicy < ApplicationRecord
   validates :archive_ttl, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :fixity_ttl, presence: true, numericality: { only_integer: true, greater_than: 0 }
 
-  # iterates over the preservation policies enumerated in the settings, creating any that don't already exist.
-  # @return [Array<PreservationPolicy>] the PreservationPolicy list for the preservation policies defined in the
-  #   config (all entries, including any entries that may have been seeded already).
-  # @note this adds new entries from the config, and leaves existing entries alone, but won't delete anything.
-  # TODO: figure out deletion/update based on config?
-  def self.seed_from_config
-    Settings.preservation_policies.policy_definitions.map do |policy_name, policy_config|
-      find_or_create_by!(preservation_policy_name: policy_name.to_s) do |preservation_policy|
-        preservation_policy.archive_ttl = policy_config.archive_ttl
-        preservation_policy.fixity_ttl = policy_config.fixity_ttl
-      end
+  # @return [PreservationPolicy] creates default record if necessary
+  def self.default_policy
+    find_or_create_by!(preservation_policy_name: default_name) do |preservation_policy|
+      preservation_policy.archive_ttl = 7_776_000 # 90 days
+      preservation_policy.fixity_ttl = 7_776_000 # 90 days
     end
   end
 
-  def self.default_policy
-    find_by!(preservation_policy_name: Settings.preservation_policies.default_policy_name)
+  def self.default_name
+    'default'
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,13 +15,6 @@ moab:
   path_method: druid_tree
   allow_content_subdirs: true
 
-preservation_policies:
-  default_policy_name: 'default'
-  policy_definitions:
-    default:
-      archive_ttl: 7_776_000 # 7,776,000 s == 90 days.
-      fixity_ttl: 7_776_000 # 7,776,000 s == 90 days.
-
 provlog:
   enable: false
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,6 @@
 # http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/DatabaseStatements.html#method-i-transaction
 # https://www.postgresql.org/docs/current/static/transaction-iso.html
 ApplicationRecord.transaction(isolation: :serializable) do
-  PreservationPolicy.seed_from_config
   MoabStorageRoot.seed_from_config([PreservationPolicy.default_policy])
   ZipEndpoint.seed_from_config([PreservationPolicy.default_policy])
 end

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Audit::MoabToCatalog do
   end
 
   before do
-    PreservationPolicy.seed_from_config
     allow(described_class.logger).to receive(:info) # silence STDOUT chatter
     allow(Dor::WorkflowService).to receive(:update_workflow_error_status)
   end


### PR DESCRIPTION
- We don't want to use `settings.yml` to manage individual database  records
- `default_policy` already has the signature needed for all of our app and tests, just do the `find_or_create!` there

This is one third of the `seed_from_config` that we should continue to excise.