### PR TITLE
Part audit

### DIFF
--- a/app/jobs/moab_replication_audit_job.rb
+++ b/app/jobs/moab_replication_audit_job.rb
@@ -1,43 +1,34 @@
-# Confirms that a CompleteMoab is fully/properly replicated to all target zip endpoints.
-# Usage info:
-# MoabReplicationAuditJob.perform_later(cm)
+# Confirms a CompleteMoab has all versions/parts replicated for each of its target endpoints.
+# @note Enqueues a check per endpoint
+# @example usage
+#   MoabReplicationAuditJob.perform_later(cm)
 class MoabReplicationAuditJob < ApplicationJob
   queue_as :moab_replication_audit
-  delegate :check_child_zip_part_attributes, to: Audit::CatalogToArchive
-  delegate :check_aws_replicated_zipped_moab_version, to: PreservationCatalog::S3::Audit
-  delegate :logger, to: Audit::CatalogToArchive
 
   # @param [CompleteMoab] verify that the zip exists on the endpoint
   def perform(complete_moab)
-    druid = complete_moab.preserved_object.druid
-
-    results = AuditResults.new(druid, nil, complete_moab.moab_storage_root, "MoabReplicationAuditJob")
-
-    backfill_missing_zmvs(complete_moab, results) if Settings.replication.audit_should_backfill
-
-    complete_moab.zipped_moab_versions.each do |zmv|
-      next unless check_child_zip_part_attributes(zmv, results)
-      check_aws_replicated_zipped_moab_version(zmv, results)
-    end
-
+    backfill_missing_zmvs(complete_moab)
+    ZipEndpoint
+      .includes(:zipped_moab_versions)
+      .where(zipped_moab_versions: { complete_moab: complete_moab }).each do |endpoint|
+        PartReplicationAuditJob.perform_later(complete_moab, endpoint)
+      end
     complete_moab.update(last_archive_audit: Time.current)
-
-    results.report_results(logger)
   end
 
   private
 
-  def backfill_missing_zmvs(complete_moab, results)
-    backfilled_zmvs = complete_moab.create_zipped_moab_versions!
-    return if backfilled_zmvs.empty?
-
-    results.add_result(
-      AuditResults::ZMV_BACKFILL,
-      version_endpoint_pairs: format_backfilled_zmvs(backfilled_zmvs)
+  def backfill_missing_zmvs(complete_moab)
+    return unless Settings.replication.audit_should_backfill
+    zmvs = complete_moab.create_zipped_moab_versions!
+    return if zmvs.empty?
+    Audit::CatalogToArchive.logger.warn(
+      "#{self.class}: #{complete_moab.preserved_object.druid} backfilled #{zmvs.count} ZippedMoabVersions: #{format_zmvs(zmvs)}"
     )
   end
 
-  def format_backfilled_zmvs(backfilled_zmvs)
-    backfilled_zmvs.map { |bz| "#{bz.version} to #{bz.zip_endpoint.endpoint_name}" }.sort.join("; ")
+  # @return [String] a potentially large message
+  def format_zmvs(zmvs)
+    zmvs.map { |bz| "#{bz.version} to #{bz.zip_endpoint.endpoint_name}" }.sort.join("; ")
   end
 end

--- a/app/jobs/part_replication_audit_job.rb
+++ b/app/jobs/part_replication_audit_job.rb
@@ -1,0 +1,26 @@
+# Confirms that a CompleteMoab is fully/properly replicated to ONE target endpoint.
+# The endpoint is used to build the queue name which much be serviced by a worker with
+# corresponding (AWS) credentials.
+# @example usage
+#  PartReplicationAuditJob.perform_later(cm, endpoint)
+class PartReplicationAuditJob < ApplicationJob
+  queue_as { "part_audit_#{arguments.second.endpoint_name}" }
+  delegate :check_child_zip_part_attributes, :logger, to: Audit::CatalogToArchive
+
+  # @param [CompleteMoab] complete_moab
+  # @param [ZipEndpoint] zip_endpoint endpoint being checked
+  def perform(complete_moab, zip_endpoint)
+    results = new_results(complete_moab)
+    complete_moab.zipped_moab_versions.where(zip_endpoint: zip_endpoint).each do |zmv|
+      next unless check_child_zip_part_attributes(zmv, results)
+      PreservationCatalog::S3::Audit.check_aws_replicated_zipped_moab_version(zmv, results)
+    end
+    results.report_results(logger)
+  end
+
+  private
+
+  def new_results(complete_moab)
+    AuditResults.new(complete_moab.preserved_object.druid, nil, complete_moab.moab_storage_root, 'PartReplicationAuditJob')
+  end
+end

--- a/app/lib/preservation_catalog/s3/audit.rb
+++ b/app/lib/preservation_catalog/s3/audit.rb
@@ -1,8 +1,7 @@
 module PreservationCatalog
   module S3
-    # Methods for auditing checking the state of a ZippedMoabVersion on an S3 endpoint.  Requires that AWS credentials
-    # are available in the environment.  At the time of this comment, only running queue workers will have proper creds
-    # loaded.
+    # Methods for auditing checking the state of a ZippedMoabVersion on an S3 endpoint.  Requires AWS credentials are
+    # available in the environment.  At the time of this comment, ONLY running queue workers will have proper creds loaded.
     class Audit
       delegate :bucket, :bucket_name, to: ::PreservationCatalog::S3
 

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -34,7 +34,6 @@ class AuditResults
   SIGNATURE_CATALOG_NOT_IN_MOAB = :signature_catalog_not_in_moab
   INVALID_MANIFEST = :invalid_manifest
   UNABLE_TO_CHECK_STATUS = :unable_to_check_status
-  ZMV_BACKFILL = :zmv_backfill
   ZIP_PART_NOT_FOUND = :zip_part_not_found
   ZIP_PART_CHECKSUM_MISMATCH = :zip_part_checksum_mismatch
   ZIP_PARTS_NOT_CREATED = :zip_parts_not_created
@@ -65,7 +64,6 @@ class AuditResults
     SIGNATURE_CATALOG_NOT_IN_MOAB => "%{signature_catalog_path} not found in Moab",
     INVALID_MANIFEST => "unable to parse %{manifest_file_path} in Moab",
     UNABLE_TO_CHECK_STATUS => "unable to validate when CompleteMoab status is %{current_status}",
-    ZMV_BACKFILL => "backfilled the following ZippedMoabVersions: %{version_endpoint_pairs}",
     ZIP_PART_NOT_FOUND => "replicated part not found on %{endpoint_name}: %{s3_key} was not found on %{bucket_name}",
     ZIP_PART_CHECKSUM_MISMATCH => "replicated md5 mismatch on %{endpoint_name}: %{s3_key} catalog md5 (%{md5}) doesn't match the replicated md5 (%{replicated_checksum}) on %{bucket_name}",
     ZIP_PARTS_NOT_CREATED => "%{version} on %{endpoint_name}: no zip_parts exist yet for this ZippedMoabVersion",
@@ -118,7 +116,7 @@ class AuditResults
 
   def self.logger_severity_level(result_code)
     case result_code
-    when DB_OBJ_DOES_NOT_EXIST, ZIP_PARTS_NOT_CREATED, ZIP_PARTS_NOT_ALL_REPLICATED, ZMV_BACKFILL
+    when DB_OBJ_DOES_NOT_EXIST, ZIP_PARTS_NOT_CREATED, ZIP_PARTS_NOT_ALL_REPLICATED
       Logger::WARN
     when VERSION_MATCHES, ACTUAL_VERS_GT_DB_OBJ, CREATED_NEW_OBJECT, CM_STATUS_CHANGED, MOAB_CHECKSUM_VALID
       Logger::INFO

--- a/spec/jobs/moab_replication_audit_job_spec.rb
+++ b/spec/jobs/moab_replication_audit_job_spec.rb
@@ -1,65 +1,55 @@
 require 'rails_helper'
 
 describe MoabReplicationAuditJob, type: :job do
-  let!(:cm) { create(:complete_moab, version: 2) }
+  let(:cm) { create(:complete_moab, version: 2) }
   let(:job) { described_class.new(cm) }
-  let(:results) { AuditResults.new(cm.preserved_object.druid, nil, cm.moab_storage_root, "MoabReplicationAuditJob") }
+  let(:logger) { instance_double(Logger) }
 
   before do
-    allow(AuditResults).to receive(:new).and_return(results)
-    allow(results).to receive(:report_results)
-    allow(Settings.replication).to receive(:audit_should_backfill).and_return(true) # default to enabled for tests
+    allow(Audit::CatalogToArchive).to receive(:logger).and_return(logger)
+    allow(Settings.replication).to receive(:audit_should_backfill).and_return(true) # enable for tests
+  end
+
+  describe '#backfill_missing_zmvs' do
+    it 'when backfilling is disabled, does nothing' do
+      allow(Settings.replication).to receive(:audit_should_backfill).and_return(false)
+      expect(cm).not_to receive(:create_zipped_moab_versions!)
+      job.send(:backfill_missing_zmvs, cm)
+    end
+
+    context 'when there are no zipped moab versions to backfill' do
+      it 'does not log a warning' do
+        expect(logger).not_to receive(:warn)
+        job.send(:backfill_missing_zmvs, cm)
+      end
+    end
+
+    context 'when there are zipped_moab_versions to backfill' do
+      before { cm.zipped_moab_versions.destroy_all } # undo auto-spawned rows from callback
+
+      it 'creates missing ZMVs and logs a warning' do
+        expect(cm).to receive(:create_zipped_moab_versions!).and_call_original
+        expect(logger).to receive(:warn).with(/backfilled 2 ZippedMoabVersions: 1 to mock_archive1; 2 to mock_archive1/)
+        job.send(:backfill_missing_zmvs, cm)
+      end
+    end
   end
 
   describe '#perform' do
-    context 'there are no zipped moab versions to backfill' do
-      # zipped moab versions are automatically created for cm
-      it 'does not log a warning about uncreated ZMVs' do
-        job.perform(cm)
-        expect(results.result_array).not_to include(a_hash_including(AuditResults::ZMV_BACKFILL))
-      end
-    end
-
-    context 'there are zipped_moab_versions to backfill for complete_moab' do
-      before { cm.zipped_moab_versions.destroy_all } # undo auto-spawned rows from callback
-
-      it 'tries to create missing ZMVs and logs a warning about uncreated ZMVs' do
-        expect(cm).to receive(:create_zipped_moab_versions!).and_call_original
-        job.perform(cm)
-        msg = "backfilled the following ZippedMoabVersions: 1 to mock_archive1; 2 to mock_archive1"
-        expect(results.result_array).to include(a_hash_including(AuditResults::ZMV_BACKFILL => msg))
-      end
-
-      context 'automatic backfilling is disabled' do
-        before { allow(Settings.replication).to receive(:audit_should_backfill).and_return(false) }
-
-        it 'does not try to create ZippedMoabVersions for the CompleteMoab' do
-          expect(cm).not_to receive(:create_zipped_moab_versions!)
-          job.perform(cm)
-          expect(results.result_array).not_to include(a_hash_including(AuditResults::ZMV_BACKFILL))
-        end
-      end
-    end
-
-    it "calls update on last_archive_audit timestamp" do
-      expect(cm).to receive(:update)
+    it 'calls backfill_missing_zmvs' do
+      expect(job).to receive(:backfill_missing_zmvs)
       job.perform(cm)
     end
 
-    it "calls report_results with the right logger" do
-      expect(results).to receive(:report_results).with(Audit::CatalogToArchive.logger)
+    it 'updates last_archive_audit timestamp' do
+      expect(cm).to receive(:update).with(last_archive_audit: Time)
       job.perform(cm)
     end
 
-    it 'checks all of the zipped_moab_versions that check_child_zip_part_attributes indicates are checkable' do
-      expect(Audit::CatalogToArchive).to receive(:check_child_zip_part_attributes)
-        .with(cm.zipped_moab_versions.first, results).and_return(true)
-      expect(Audit::CatalogToArchive).to receive(:check_child_zip_part_attributes)
-        .with(cm.zipped_moab_versions.second, results).and_return(false)
-      expect(PreservationCatalog::S3::Audit).to receive(:check_aws_replicated_zipped_moab_version)
-        .with(cm.zipped_moab_versions.first, results)
-      expect(PreservationCatalog::S3::Audit).not_to receive(:check_aws_replicated_zipped_moab_version)
-        .with(cm.zipped_moab_versions.second, results)
+    it 'calls PartReplicationAuditJob once per related endpoint' do
+      new_ep = create(:zip_endpoint)
+      expect(PartReplicationAuditJob).to receive(:perform_later).with(cm, cm.zipped_moab_versions.first.zip_endpoint)
+      expect(PartReplicationAuditJob).to receive(:perform_later).with(cm, new_ep)
       job.perform(cm)
     end
   end

--- a/spec/jobs/part_replication_audit_job_spec.rb
+++ b/spec/jobs/part_replication_audit_job_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe PartReplicationAuditJob, type: :job do
+  let(:cm) { create(:complete_moab, version: 2) }
+  let(:job) { described_class.new(cm, endpoint) }
+  let(:endpoint) { cm.zipped_moab_versions.first.zip_endpoint }
+  let(:logger) { instance_double(Logger) }
+
+  before do
+    allow(Audit::CatalogToArchive).to receive(:logger).and_return(logger)
+  end
+
+  describe '#queue_as' do
+    it 'builds the queue name' do
+      expect(job.queue_name).to eq("part_audit_#{endpoint.endpoint_name}")
+    end
+
+    context 'with a different endpoint' do
+      let(:endpoint) { create(:zip_endpoint, endpoint_name: 'north_foobar') }
+
+      it 'adapts the queue name' do
+        expect(job.queue_name).to eq('part_audit_north_foobar')
+      end
+    end
+  end
+
+  describe '#perform' do
+    let(:zmv1) { cm.zipped_moab_versions.first }
+    let(:zmv2) { cm.zipped_moab_versions.second }
+    let(:results) { job.send(:new_results, cm) }
+
+    it 'only checks parts for one endpoint' do
+      other_ep = create(:zip_endpoint)
+      other_zmv = cm.zipped_moab_versions.find_by(zip_endpoint: other_ep)
+      count = cm.zipped_moab_versions.where(zip_endpoint: endpoint).count
+      expect(job).to receive(:check_child_zip_part_attributes).with(ZippedMoabVersion, AuditResults).exactly(count).times
+      expect(job).not_to receive(:check_child_zip_part_attributes).with(other_zmv, AuditResults)
+      job.perform(cm, endpoint)
+    end
+
+    it 'builds results from sub-checks' do
+      allow(job).to receive(:new_results).with(cm).and_return(results)
+      expect(job).to receive(:check_child_zip_part_attributes).with(zmv1, AuditResults).and_return(true)
+      expect(job).to receive(:check_child_zip_part_attributes).with(zmv2, AuditResults).and_return(false)
+      expect(PreservationCatalog::S3::Audit).to receive(:check_aws_replicated_zipped_moab_version).with(zmv1, AuditResults)
+      expect(PreservationCatalog::S3::Audit).not_to receive(:check_aws_replicated_zipped_moab_version).with(zmv2, AuditResults)
+      expect(results).to receive(:report_results)
+      job.perform(cm, endpoint)
+    end
+  end
+end


### PR DESCRIPTION
Convert `MoabReplicationAuditJob` to use `PartReplicationAuditJob`.

Fixes #1077 