### PR TITLE
Update CV enqueing job in schedule

### DIFF
--- a/app/models/moab_storage_root.rb
+++ b/app/models/moab_storage_root.rb
@@ -11,7 +11,7 @@ class MoabStorageRoot < ApplicationRecord
   def validate_expired_checksums!
     cms = complete_moabs.fixity_check_expired
     Rails.logger.info "MoabStorageRoot #{id} (#{name}), # of complete_moabs to be checksum validated: #{cms.count}"
-    cms.find_each { |cm| ChecksumValidationJob.perform_later(cm) }
+    cms.find_each(&:validate_checksums!)
   end
 
   # Use a queue to check all associated CompleteMoab objects for C2M

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -16,7 +16,7 @@ every :friday, roles: [:queue_populator] do
 end
 every :sunday, at: '1am', roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/cv-err.log'
-  runner 'Audit::Checksum.validate_disk_all_storage_roots'
+  runner 'MoabStorageRoot.find_each(&:validate_expired_checksums!)'
 end
 
 every :hour, roles: [:cache_cleaner] do


### PR DESCRIPTION
`validate_disk_all_storage_roots` doesn't exist.  The README was already updated to reference `validate_expired_checksums!`, but our actual schedule was not. 

And remove some knowledge of internals of CM validation from MSR layer, using the method `validate_checksums!` instead of knowing what job should be invoked (and with what args).  The same thing is accomplished, but the OO interface is better.

Fixes #1116 