### PR TITLE
Update and pin rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'coveralls'
   # Ruby static code analyzer http://rubocop.readthedocs.io/en/latest/
-  gem 'rubocop', '~> 0.58'
+  gem 'rubocop', '~> 0.60.0'
   gem 'rubocop-rspec'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       nokogiri (~> 1.5)
     okcomputer (1.17.3)
     parallel (1.12.1)
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     pg (1.1.3)
     powerpack (0.1.2)
@@ -293,14 +293,14 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.59.2)
+    rubocop (0.60.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
+      unicode-display_width (~> 1.4.0)
     rubocop-rspec (1.30.0)
       rubocop (>= 0.58.0)
     ruby-prof (0.17.0)
@@ -377,7 +377,7 @@ DEPENDENCIES
   resque-lock
   resque-pool
   rspec-rails (~> 3.6)
-  rubocop (~> 0.58)
+  rubocop (~> 0.60.0)
   rubocop-rspec
   ruby-prof
   shoulda-matchers!
@@ -385,4 +385,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -4,7 +4,7 @@
 # represent a specific stored instance on a specific node, but aggregates
 # those instances.
 class PreservedObject < ApplicationRecord
-  PREFIX_RE = /druid:/i
+  PREFIX_RE = /druid:/i.freeze
   belongs_to :preservation_policy
   has_many :complete_moabs, dependent: :restrict_with_exception, autosave: true
   validates :druid,


### PR DESCRIPTION
This is necessary because minor releases add new cops which break the
build. This ensures that minor version bumps are intentional and not the
result of automatic version updates.