### PR TITLE
Give resque-pool more time to restart

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -43,7 +43,7 @@ before 'deploy:migrate', 'shared_configs:update'
 
 after 'deploy:migrate', 'db_seed'
 
-before 'deploy:migrate', 'resque:pool:stop'
+before 'deploy:starting', 'resque:pool:stop'
 after 'deploy:restart', 'resque:pool:start'
 
 desc 'Run rake db:seed'


### PR DESCRIPTION
Connects to #1122
Now, the first thing cap will do is shut down resque-pool, even before the user chooses which branch, which gives us a chance to check in on the process before the deploy resumes. The start up could be moved ahead at most three steps, if we want.