### PR TITLE
Change cleanup logic of sdr-transfers

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,7 +22,7 @@ end
 every :hour, roles: [:cache_cleaner] do
   set :output, standard: '/var/log/preservation_catalog/zip_cache_cleanup.log'
   command <<-'END_OF_COMMAND'
-    find /sdr-transfers -mindepth 5 -type f -name "*.zip" -mtime +1 -exec bash -c 'TARGET="{}"; rm -v ${TARGET%ip}*' \;
+    find /sdr-transfers -mindepth 5 -type f -name "*.md5" -mtime +1 -exec bash -c 'TARGET="{}"; rm -v ${TARGET%md5}*' \;
   END_OF_COMMAND
 end
 


### PR DESCRIPTION
Problem: We have large zip files that may be old(ish), awaiting md5 creation and shipping to the cloud. By basing our deletion criteria on the age of the zip, rather than the age of md5 sidecar files, we increase the risk that we'll delete zips that are either awaiting md5 creation or are still in the process of being transferred to endpoints. This is especially true for Moabs with > 100 zip parts.
Solution: Look at the creation time of MD5 sidecar files instead; if an md5 sidecar has existed for > 1 day, chances are better that the associated zip file has been successfully uploaded.