### PR TITLE
Update schedule.rb to increase cache_cleaner mtime

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,7 +22,7 @@ end
 every :hour, roles: [:cache_cleaner] do
   set :output, standard: '/var/log/preservation_catalog/zip_cache_cleanup.log'
   command <<-'END_OF_COMMAND'
-    find /sdr-transfers -mindepth 5 -type f -name "*.md5" -mtime +1 -exec bash -c 'TARGET="{}"; rm -v ${TARGET%md5}*' \;
+    find /sdr-transfers -mindepth 5 -type f -name "*.md5" -mtime +2 -exec bash -c 'TARGET="{}"; rm -v ${TARGET%md5}*' \;
   END_OF_COMMAND
 end
 


### PR DESCRIPTION
We've seen an issue where very large archives (typically > 200GB) don't finish zipping *and* transferring within 24 hours, resulting in some zip parts being deleted from disk before transfer completes. This leads to incorrect zip_parts being reported for the final .zip file transfer, and may result in an overall failed transfer (expected zip_part not found on disk). 

By increasing mtime to 48hrs we decrease the likelihood of this happening, at the risk of running out of transfer space overall.