### PR TITLE
1202 api endpoint for checksums jm touchup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::API
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from Moab::ObjectNotFoundException, with: :not_found
-  rescue_from InvalidSuriSyntax, with: :internal_server_error
+  rescue_from InvalidSuriSyntax, with: :bad_request
 
   protected
 
@@ -13,12 +13,12 @@ class ApplicationController < ActionController::API
     id&.split(':', 2)&.last
   end
 
-  def not_found
-    render plain: '404 Not Found', status: :not_found
+  def bad_request
+    render plain: '400 bad request', status: :bad_request
   end
 
-  def internal_server_error
-    render plain: '500 Internal Server Error', status: :internal_server_error
+  def not_found
+    render plain: '404 Not Found', status: :not_found
   end
 
   def refine_invalid_druid_error!(err)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,27 @@
 class ApplicationController < ActionController::API
   include ActionController::MimeResponds
 
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+  rescue_from Moab::ObjectNotFoundException, with: :not_found
+  rescue_from InvalidSuriSyntax, with: :internal_server_error
+
   protected
 
   def strip_druid(id)
     id&.split(':', 2)&.last
+  end
+
+  def not_found
+    render plain: '404 Not Found', status: :not_found
+  end
+
+  def internal_server_error
+    render plain: '500 Internal Server Error', status: :internal_server_error
+  end
+
+  def refine_invalid_druid_error!(err)
+    # make a specific moab-versioning StandardError into something more easily manageable by ApplicationController...
+    raise InvalidSuriSyntax, err.message if err.message.include?('Identifier has invalid suri syntax')
+    raise # ...but just re-raise what we got if it was something else
   end
 end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -9,14 +9,14 @@ class ObjectsController < ApplicationController
   # return the PreservedObject model for the druid (supplied with druid: prefix)
   # GET /objects/:druid
   def show
-    object = PreservedObject.find_by!(druid: strip_druid(params[:id]))
+    object = PreservedObject.find_by!(druid: druid)
     render json: object.to_json
   end
 
   # return the checksums and filesize for a single druid (supplied with druid: prefix)
   # GET /objects/:druid/checksum
   def checksum
-    render json: checksum_for_object(params[:id]).to_json
+    render json: checksum_for_object(druid).to_json
   end
 
   # return the checksums and filesize for a list of druid (supplied with druid: prefix)
@@ -40,6 +40,15 @@ class ObjectsController < ApplicationController
 
   private
 
+  def druid
+    strip_druid(params[:id])
+  end
+
+  def druids
+    return [] unless params[:druids].present?
+    params[:druids].map { |druid| strip_druid(druid) }.sort.uniq # normalize, then sort, then de-dupe
+  end
+
   def json_checksum_list
     druids.map { |druid| { "#{druid}": checksum_for_object(druid) } }.to_json
   end
@@ -52,11 +61,6 @@ class ObjectsController < ApplicationController
         end
       end
     end
-  end
-
-  def druids
-    return [] unless params[:druids].present?
-    params[:druids].map { |druid| strip_druid(druid) }.sort.uniq # normalize, then sort, then de-dupe
   end
 
   def checksum_for_object(druid)

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -9,22 +9,14 @@ class ObjectsController < ApplicationController
   # return the PreservedObject model for the druid (supplied with druid: prefix)
   # GET /objects/:druid
   def show
-    object = PreservedObject.find_by(druid: strip_druid(params[:id]))
-    if object
-      render json: object.to_json
-    else
-      render status: 404, json: 'Object not found'
-    end
+    object = PreservedObject.find_by!(druid: strip_druid(params[:id]))
+    render json: object.to_json
   end
 
   # return the checksums and filesize for a single druid (supplied with druid: prefix)
   # GET /objects/:druid/checksum
   def checksum
     render json: checksum_for_object(params[:id]).to_json
-  rescue Moab::ObjectNotFoundException => e
-    render status: 404, json: e.message
-  rescue StandardError => e
-    render status: 500, json: e.message
   end
 
   # return the checksums and filesize for a list of druid (supplied with druid: prefix)
@@ -48,18 +40,22 @@ class ObjectsController < ApplicationController
       end
       format.any  { render status: 406, plain: 'Format not acceptable' }
     end
-  rescue Moab::ObjectNotFoundException => e
-    render status: 404, json: e.message
-  rescue StandardError => e
+  rescue NoMethodError => e
     render status: 500, json: e.message
   end
 
   private
 
   def checksum_for_object(druid)
-    content_group = Moab::StorageServices.retrieve_file_group('content', druid)
+    content_group = retrieve_file_group(druid)
     content_group.path_hash.map do |file, signature|
       { filename: file, md5: signature.md5, sha1: signature.sha1, sha256: signature.sha256, filesize: signature.size }
     end
+  end
+
+  def retrieve_file_group(druid)
+    Moab::StorageServices.retrieve_file_group('content', druid)
+  rescue StandardError => e
+    refine_invalid_druid_error!(e)
   end
 end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -9,8 +9,7 @@ class ObjectsController < ApplicationController
   # return the PreservedObject model for the druid (supplied with druid: prefix)
   # GET /objects/:druid
   def show
-    object = PreservedObject.find_by!(druid: druid)
-    render json: object.to_json
+    render json: PreservedObject.find_by!(druid: druid).to_json
   end
 
   # return the checksums and filesize for a single druid (supplied with druid: prefix)

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -42,7 +42,7 @@ class ObjectsController < ApplicationController
         end
         render plain: results
       end
-      format.any  { render status: 406, plain: 'Format not acceptable' }
+      format.any  { render status: :not_acceptable, plain: 'Format not acceptable' }
     end
   end
 

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -22,7 +22,11 @@ class ObjectsController < ApplicationController
   # return the checksums and filesize for a list of druid (supplied with druid: prefix)
   # GET /objects/checksums?druids=druida,druidb,druidc
   def checksums
-    druids = params[:druids]
+    unless druids.present?
+      render(plain: '400 bad request', status: :bad_request)
+      return
+    end
+
     respond_to do |format|
       format.json do
         results = druids.map { |druid| { "#{druid}": checksum_for_object(druid) } }
@@ -40,11 +44,13 @@ class ObjectsController < ApplicationController
       end
       format.any  { render status: 406, plain: 'Format not acceptable' }
     end
-  rescue NoMethodError => e
-    render status: 500, json: e.message
   end
 
   private
+
+  def druids
+    params[:druids]
+  end
 
   def checksum_for_object(druid)
     content_group = retrieve_file_group(druid)

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -55,7 +55,8 @@ class ObjectsController < ApplicationController
   end
 
   def druids
-    params[:druids]
+    return [] unless params[:druids].present?
+    params[:druids].map { |druid| strip_druid(druid) }.sort.uniq # normalize, then sort, then de-dupe
   end
 
   def checksum_for_object(druid)

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -29,24 +29,30 @@ class ObjectsController < ApplicationController
 
     respond_to do |format|
       format.json do
-        results = druids.map { |druid| { "#{druid}": checksum_for_object(druid) } }
-        render json: results.to_json
+        render json: json_checksum_list
       end
       format.csv do
-        results = CSV.generate do |csv|
-          druids.each do |druid|
-            checksum_for_object(druid).each do |checksum|
-              csv << [druid, checksum[:filename], checksum[:md5], checksum[:sha1], checksum[:sha256], checksum[:filesize]]
-            end
-          end
-        end
-        render plain: results
+        render plain: csv_checksum_list
       end
       format.any  { render status: :not_acceptable, plain: 'Format not acceptable' }
     end
   end
 
   private
+
+  def json_checksum_list
+    druids.map { |druid| { "#{druid}": checksum_for_object(druid) } }.to_json
+  end
+
+  def csv_checksum_list
+    CSV.generate do |csv|
+      druids.each do |druid|
+        checksum_for_object(druid).each do |checksum|
+          csv << [druid, checksum[:filename], checksum[:md5], checksum[:sha1], checksum[:sha256], checksum[:filesize]]
+        end
+      end
+    end
+  end
 
   def druids
     params[:druids]

--- a/app/errors/invalid_suri_syntax.rb
+++ b/app/errors/invalid_suri_syntax.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+##
+# this allows us to re-raise certain StandardErrors from moab-versioning in a more
+# specifically rescue-able way
+class InvalidSuriSyntax < StandardError
+end

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe ObjectsController, type: :request do
         expect(response).to have_http_status(:not_acceptable)
       end
 
-      it 'returns a 500 response code with no druid parameters passed in' do
+      it 'returns a 400 response code with no druid parameters passed in' do
         get checksums_objects_url, params: { format: :json }
-        expect(response).to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe ObjectsController, type: :request do
                 md5: '42e9d4c0a766f837e5a2f5610d9f258e',
                 sha1: '5bfc6052b0e458e0aa703a0a6853bb9c112e0695',
                 sha256: '1530df24086afefd71bf7e5b7e85bb350b6972c838bf6c87ddd5c556b800c802',
-                filesize: 167_784 }] },
+                filesize: 167_784 }] }
         ]
         expect(response).to have_http_status(:ok)
         expect(response.body).to eq(expected_response.to_json)

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe ObjectsController, type: :request do
     end
 
     context 'when bad parameter passed in' do
-      it 'returns a 500 response code' do
+      it 'returns a 400 response code' do
         get checksum_object_url 'not a druid', format: :json
-        expect(response).to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
@@ -110,9 +110,9 @@ RSpec.describe ObjectsController, type: :request do
     end
 
     context 'when bad parameter passed in' do
-      it 'returns a 500 response code with a bad druid passed in' do
+      it 'returns a 400 response code with a bad druid passed in' do
         get checksums_objects_url, params: { druids: [prefixed_druid, 'not a druid'], format: :json }
-        expect(response).to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:bad_request)
       end
 
       it 'returns a 406 response code when an unsupported response format is provided' do

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -10,8 +10,14 @@ RSpec.describe ObjectsController, type: :request do
 
   describe 'GET #show' do
     context 'when object found' do
-      it 'response contains the object' do
+      it 'response contains the object when given prefixed druid' do
         get object_url "druid:#{pres_obj.druid}", format: :json
+        expect(response.body).to include(pres_obj.to_json)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'response contains the object when given bare druid' do
+        get object_url pres_obj.druid, format: :json
         expect(response.body).to include(pres_obj.to_json)
         expect(response).to have_http_status(:ok)
       end

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ObjectsController, type: :request do
   let(:prefixed_druid) { 'druid:bj102hs9687' }
   let(:prefixed_druid2) { 'druid:bz514sm9647' }
   let(:bare_druid) { 'bj102hs9687' }
+  let(:bare_druid2) { 'bz514sm9647' }
   let(:pres_obj) { create(:preserved_object) }
 
   describe 'GET #show' do
@@ -26,8 +27,26 @@ RSpec.describe ObjectsController, type: :request do
 
   describe 'GET #checksum' do
     context 'when object found' do
-      it 'response contains the object checksum' do
+      it 'response contains the object checksum when given a prefixed druid' do
         get checksum_object_url prefixed_druid, format: :json
+        expected_response = [
+          { filename: 'eric-smith-dissertation.pdf',
+            md5: 'aead2f6f734355c59af2d5b2689e4fb3',
+            sha1: '22dc6464e25dc9a7d600b1de6e3848bf63970595',
+            sha256: 'e49957d53fb2a46e3652f4d399bd14d019600cf496b98d11ebcdf2d10a8ffd2f',
+            filesize: 1_000_217 },
+          { filename: 'eric-smith-dissertation-augmented.pdf',
+            md5: '93802f1a639bc9215c6336ff5575ee22',
+            sha1: '32f7129a81830004f0360424525f066972865221',
+            sha256: 'a67276820853ddd839ba614133f1acd7330ece13f1082315d40219bed10009de',
+            filesize: 905_566 }
+        ]
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq(expected_response.to_json)
+      end
+
+      it 'response contains the object checksum when given a bare druid' do
+        get checksum_object_url bare_druid, format: :json
         expected_response = [
           { filename: 'eric-smith-dissertation.pdf',
             md5: 'aead2f6f734355c59af2d5b2689e4fb3',
@@ -62,10 +81,10 @@ RSpec.describe ObjectsController, type: :request do
 
   describe 'GET #checksums' do
     context 'when objects found' do
-      it 'json response contains multiple object checksums' do
-        get checksums_objects_url, params: { druids: [prefixed_druid, prefixed_druid2], format: :json }
+      it 'json response contains one checksum for each unique, normalized druid (in alpha order by druid)' do
+        get checksums_objects_url, params: { druids: [prefixed_druid, prefixed_druid2, bare_druid], format: :json }
         expected_response = [
-          { "#{prefixed_druid}":
+          { "#{bare_druid}":
             [{ filename: 'eric-smith-dissertation.pdf',
                md5: 'aead2f6f734355c59af2d5b2689e4fb3',
                sha1: '22dc6464e25dc9a7d600b1de6e3848bf63970595',
@@ -76,25 +95,25 @@ RSpec.describe ObjectsController, type: :request do
                sha1: '32f7129a81830004f0360424525f066972865221',
                sha256: 'a67276820853ddd839ba614133f1acd7330ece13f1082315d40219bed10009de',
                filesize: 905_566 }] },
-          { "#{prefixed_druid2}":
+          { "#{bare_druid2}":
             [{  filename: 'SC1258_FUR_032a.jpg',
                 md5: '42e9d4c0a766f837e5a2f5610d9f258e',
                 sha1: '5bfc6052b0e458e0aa703a0a6853bb9c112e0695',
                 sha256: '1530df24086afefd71bf7e5b7e85bb350b6972c838bf6c87ddd5c556b800c802',
-                filesize: 167_784 }] }
+                filesize: 167_784 }] },
         ]
         expect(response).to have_http_status(:ok)
         expect(response.body).to eq(expected_response.to_json)
       end
 
-      it 'csv response contains multiple object checksums' do
+      it 'csv response contains multiple object checksums, but still normalizes and de-dupes druids, and alpha sorts by normalized druid' do
         get checksums_objects_url, params: { druids: [prefixed_druid, prefixed_druid2], format: :csv }
         expected_response = CSV.generate do |csv|
-          csv << [prefixed_druid, 'eric-smith-dissertation.pdf', 'aead2f6f734355c59af2d5b2689e4fb3',
+          csv << [bare_druid, 'eric-smith-dissertation.pdf', 'aead2f6f734355c59af2d5b2689e4fb3',
                   '22dc6464e25dc9a7d600b1de6e3848bf63970595', 'e49957d53fb2a46e3652f4d399bd14d019600cf496b98d11ebcdf2d10a8ffd2f', '1000217']
-          csv << [prefixed_druid, 'eric-smith-dissertation-augmented.pdf', '93802f1a639bc9215c6336ff5575ee22',
+          csv << [bare_druid, 'eric-smith-dissertation-augmented.pdf', '93802f1a639bc9215c6336ff5575ee22',
                   '32f7129a81830004f0360424525f066972865221', 'a67276820853ddd839ba614133f1acd7330ece13f1082315d40219bed10009de', '905566']
-          csv << [prefixed_druid2, 'SC1258_FUR_032a.jpg', '42e9d4c0a766f837e5a2f5610d9f258e',
+          csv << [bare_druid2, 'SC1258_FUR_032a.jpg', '42e9d4c0a766f837e5a2f5610d9f258e',
                   '5bfc6052b0e458e0aa703a0a6853bb9c112e0695', '1530df24086afefd71bf7e5b7e85bb350b6972c838bf6c87ddd5c556b800c802', '167784']
         end
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION
a few touchups:
* some decomposition and refactoring in `ApplicationController` and `ObjectsController` to make things slightly more idiomatic to rails, and slightly more readable/reusable (hopefully).
* conversion of what were `500` errors to `400`s (since the error cases are ones where clients are providing bad input, e.g. malformed or missing druid param values).
* more uniform normalization of druid input
  * more thorough testing of said normalization