### PR TITLE
Use correct part audit class (enum implementation)

### DIFF
--- a/app/jobs/part_replication_audit_job.rb
+++ b/app/jobs/part_replication_audit_job.rb
@@ -15,7 +15,7 @@ class PartReplicationAuditJob < ApplicationJob
     results = new_results(complete_moab)
     complete_moab.zipped_moab_versions.where(zip_endpoint: zip_endpoint).each do |zmv|
       next unless check_child_zip_part_attributes(zmv, results)
-      PreservationCatalog::S3::Audit.check_replicated_zipped_moab_version(zmv, results)
+      zip_endpoint.audit_class.check_replicated_zipped_moab_version(zmv, results)
     end
     results.report_results(logger)
   end

--- a/app/jobs/part_replication_audit_job.rb
+++ b/app/jobs/part_replication_audit_job.rb
@@ -15,7 +15,7 @@ class PartReplicationAuditJob < ApplicationJob
     results = new_results(complete_moab)
     complete_moab.zipped_moab_versions.where(zip_endpoint: zip_endpoint).each do |zmv|
       next unless check_child_zip_part_attributes(zmv, results)
-      PreservationCatalog::S3::Audit.check_aws_replicated_zipped_moab_version(zmv, results)
+      PreservationCatalog::S3::Audit.check_replicated_zipped_moab_version(zmv, results)
     end
     results.report_results(logger)
   end

--- a/app/lib/preservation_catalog/ibm/audit.rb
+++ b/app/lib/preservation_catalog/ibm/audit.rb
@@ -2,7 +2,7 @@
 
 module PreservationCatalog
   module Ibm
-    # Methods for auditing checking the state of a ZippedMoabVersion on an IBM S3 compatible endpoint.  Requires AWS credentials are
+    # Methods for auditing checking the state of a ZippedMoabVersion on an IBM S3 compatible endpoint.  Requires IBM credentials are
     # available in the environment.  At the time of this comment, ONLY running queue workers will have proper creds loaded.
     class Audit
       delegate :bucket, :bucket_name, to: ::PreservationCatalog::Ibm
@@ -17,7 +17,7 @@ module PreservationCatalog
       end
 
       # convenience method for instantiating the audit class and running the check in one call
-      def self.check_ibm_replicated_zipped_moab_version(zmv, results)
+      def self.check_replicated_zipped_moab_version(zmv, results)
         new(zmv, results).check_ibm_replicated_zipped_moab_version
       end
 

--- a/app/lib/preservation_catalog/s3/audit.rb
+++ b/app/lib/preservation_catalog/s3/audit.rb
@@ -17,7 +17,7 @@ module PreservationCatalog
       end
 
       # convenience method for instantiating the audit class and running the check in one call
-      def self.check_aws_replicated_zipped_moab_version(zmv, results)
+      def self.check_replicated_zipped_moab_version(zmv, results)
         new(zmv, results).check_aws_replicated_zipped_moab_version
       end
 

--- a/app/models/zip_endpoint.rb
+++ b/app/models/zip_endpoint.rb
@@ -14,10 +14,15 @@ class ZipEndpoint < ApplicationRecord
     S3EastDeliveryJob => 2,
     IbmSouthDeliveryJob => 3
   }
+  enum audit_class: {
+    PreservationCatalog::S3::Audit => 1,
+    PreservationCatalog::Ibm::Audit => 2
+  }
 
   validates :endpoint_name, presence: true, uniqueness: true
   # TODO: after switching to string, validate that input resolves to class which #is_a class of the right type?
   validates :delivery_class, presence: true
+  validates :audit_class, presence: true
 
   # for the given druid, which zip endpoints should have archive copies, as per the preservation_policy?
   scope :targets, lambda { |druid|
@@ -54,6 +59,7 @@ class ZipEndpoint < ApplicationRecord
         zip_endpoint.storage_location = endpoint_config.storage_location
         zip_endpoint.preservation_policies = preservation_policies
         zip_endpoint.delivery_class = delivery_classes[endpoint_config.delivery_class.constantize]
+        zip_endpoint.audit_class = audit_classes[endpoint_config.audit_class.constantize]
       end
     end
   end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -17,6 +17,7 @@ zip_endpoints:
     endpoint_node: 'localhost'
     storage_location: 'bucket_name'
     delivery_class: 'S3WestDeliveryJob'
+    audit_class: 'PreservationCatalog::S3::Audit'
 workflow_services_url: 'https://sul-lyberservices-test.stanford.edu/workflow/'
 resque_dashboard_hostnames:
   - 'localhost'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -18,7 +18,9 @@ zip_endpoints:
     endpoint_node: 'localhost'
     storage_location: 'bucket_name'
     delivery_class: 'S3WestDeliveryJob'
+    audit_class: 'PreservationCatalog::S3::Audit'
   ibm_us_south:
     endpoint_node: 'https://s3.us-south.cloud-object-storage.appdomain.cloud'
     storage_location: 'storage_location'
     delivery_class: 'IbmSouthDeliveryJob'
+    audit_class: 'PreservationCatalog::Ibm::Audit'

--- a/db/migrate/20190921025847_add_audit_class_to_zip_endpoints.rb
+++ b/db/migrate/20190921025847_add_audit_class_to_zip_endpoints.rb
@@ -1,0 +1,21 @@
+class AddAuditClassToZipEndpoints < ActiveRecord::Migration[5.1]
+  def up
+    add_column :zip_endpoints, :audit_class, :integer
+
+    execute <<-SQL
+      UPDATE zip_endpoints
+      SET audit_class = 1
+      WHERE delivery_class in (1, 2);
+
+      UPDATE zip_endpoints
+      SET audit_class = 2
+      WHERE delivery_class = 3;
+    SQL
+
+    change_column :zip_endpoints, :audit_class, :integer, null: false
+  end
+
+  def down
+    remove_column :zip_endpoints, :audit_class
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181010203927) do
+ActiveRecord::Schema.define(version: 20190921025847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 20181010203927) do
     t.string "storage_location"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "audit_class", null: false
     t.index ["endpoint_name"], name: "index_zip_endpoints_on_endpoint_name", unique: true
   end
 

--- a/spec/factories/zip_endpoints.rb
+++ b/spec/factories/zip_endpoints.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     sequence(:endpoint_node) { |n| "us-west-#{format('%02d', n)}" }
     storage_location { 'bucket_name' }
     delivery_class { 1 }
+    audit_class { 1 }
     preservation_policies { [PreservationPolicy.default_policy] }
   end
 end

--- a/spec/jobs/part_replication_audit_job_spec.rb
+++ b/spec/jobs/part_replication_audit_job_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 describe PartReplicationAuditJob, type: :job do
   let(:cm) { create(:complete_moab, version: 2) }
   let(:job) { described_class.new(cm, endpoint) }
-  let(:endpoint) { cm.zipped_moab_versions.first.zip_endpoint }
+  let(:endpoints) { cm.zipped_moab_versions.map(&:zip_endpoint).uniq }
+  let(:endpoint) { endpoints.first }
+  let(:endpoint2) { endpoints.second }
   let(:logger) { instance_double(Logger) }
 
   before do
@@ -29,7 +31,11 @@ describe PartReplicationAuditJob, type: :job do
   describe '#perform' do
     let(:zmv1) { cm.zipped_moab_versions.where(zip_endpoint: endpoint).first }
     let(:zmv2) { cm.zipped_moab_versions.where(zip_endpoint: endpoint).second }
+    let(:zmv3) { cm.zipped_moab_versions.where(zip_endpoint: endpoint2).first }
+    let(:zmv4) { cm.zipped_moab_versions.where(zip_endpoint: endpoint2).second }
     let(:results) { job.send(:new_results, cm) }
+    let(:audit_class) { endpoint.audit_class }
+    let(:audit_class2) { endpoint2.audit_class }
 
     it 'only checks parts for one endpoint' do
       other_ep = create(:zip_endpoint)
@@ -40,14 +46,27 @@ describe PartReplicationAuditJob, type: :job do
       job.perform(cm, endpoint)
     end
 
-    it 'builds results from sub-checks' do
+    it 'builds results from sub-checks, only for the given endpoint' do
       allow(job).to receive(:new_results).with(cm).and_return(results)
       allow(job).to receive(:check_child_zip_part_attributes).with(zmv2, AuditResults)
       expect(job).to receive(:check_child_zip_part_attributes).with(zmv1, AuditResults).and_return(true)
-      expect(PreservationCatalog::S3::Audit).to receive(:check_replicated_zipped_moab_version).with(zmv1, AuditResults)
-      expect(PreservationCatalog::S3::Audit).not_to receive(:check_replicated_zipped_moab_version).with(zmv2, AuditResults)
+      expect(audit_class).to receive(:check_replicated_zipped_moab_version).with(zmv1, AuditResults)
+      expect(audit_class).not_to receive(:check_replicated_zipped_moab_version).with(zmv2, AuditResults)
+      expect(audit_class2).not_to receive(:check_replicated_zipped_moab_version)
       expect(results).to receive(:report_results)
       job.perform(cm, endpoint)
+    end
+
+    it 'checks the other endpoint when requested' do
+      allow(job).to receive(:new_results).with(cm).and_return(results)
+      allow(job).to receive(:check_child_zip_part_attributes).with(zmv3, results).and_return(true)
+      allow(job).to receive(:check_child_zip_part_attributes).with(zmv4, results).and_return(true)
+      expect(audit_class).not_to receive(:check_replicated_zipped_moab_version)
+      expect(audit_class2).not_to receive(:check_replicated_zipped_moab_version).with(zmv1, AuditResults)
+      expect(audit_class2).not_to receive(:check_replicated_zipped_moab_version).with(zmv2, AuditResults)
+      expect(audit_class2).to receive(:check_replicated_zipped_moab_version).with(zmv3, results)
+      expect(audit_class2).to receive(:check_replicated_zipped_moab_version).with(zmv4, results)
+      job.perform(cm, endpoint2)
     end
   end
 end

--- a/spec/jobs/part_replication_audit_job_spec.rb
+++ b/spec/jobs/part_replication_audit_job_spec.rb
@@ -44,8 +44,8 @@ describe PartReplicationAuditJob, type: :job do
       allow(job).to receive(:new_results).with(cm).and_return(results)
       allow(job).to receive(:check_child_zip_part_attributes).with(zmv2, AuditResults)
       expect(job).to receive(:check_child_zip_part_attributes).with(zmv1, AuditResults).and_return(true)
-      expect(PreservationCatalog::S3::Audit).to receive(:check_aws_replicated_zipped_moab_version).with(zmv1, AuditResults)
-      expect(PreservationCatalog::S3::Audit).not_to receive(:check_aws_replicated_zipped_moab_version).with(zmv2, AuditResults)
+      expect(PreservationCatalog::S3::Audit).to receive(:check_replicated_zipped_moab_version).with(zmv1, AuditResults)
+      expect(PreservationCatalog::S3::Audit).not_to receive(:check_replicated_zipped_moab_version).with(zmv2, AuditResults)
       expect(results).to receive(:report_results)
       job.perform(cm, endpoint)
     end

--- a/spec/lib/preservation_catalog/ibm/audit_spec.rb
+++ b/spec/lib/preservation_catalog/ibm/audit_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
 
       expect(bucket).to receive(:object).with(ok_part.s3_key).and_return(s3_obj)
       expect(s3_obj).to receive(:metadata).and_return('checksum_md5' => ok_part.md5)
-      expect { described_class.check_ibm_replicated_zipped_moab_version(zmv, results) }
+      expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
         .to change { ok_part.reload.last_existence_check }
         .from(nil)
         .and change { ok_part.reload.last_checksum_validation }
@@ -67,7 +67,7 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
     end
 
     it 'logs the missing parts and sets status to not_found' do
-      described_class.check_ibm_replicated_zipped_moab_version(zmv, results)
+      described_class.check_replicated_zipped_moab_version(zmv, results)
       zmv.zip_parts.each do |part|
         msg = "replicated part not found on #{endpoint_name}: #{part.s3_key} was not found on #{bucket_name}"
         expect(results.result_array).to include(
@@ -102,17 +102,17 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
       end
 
       it "doesn't log checksum mismatches" do
-        described_class.check_ibm_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         expect(results.result_array).not_to include(a_hash_including(AuditResults::ZIP_PART_CHECKSUM_MISMATCH))
       end
 
       it "doesn't log not found errors" do
-        described_class.check_ibm_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         expect(results.result_array).not_to include(a_hash_including(AuditResults::ZIP_PART_NOT_FOUND))
       end
 
       it 'updates existence check timestamps' do
-        expect { described_class.check_ibm_replicated_zipped_moab_version(zmv, results) }
+        expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
           .to change { zmv.zip_parts.first.reload.last_existence_check }
           .from(nil)
           .and change { zmv.zip_parts.second.reload.last_existence_check }
@@ -122,7 +122,7 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
       end
 
       it 'updates checksum validation timestamps' do
-        expect { described_class.check_ibm_replicated_zipped_moab_version(zmv, results) }
+        expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
           .to change { zmv.zip_parts.first.reload.last_checksum_validation }
           .from(nil)
           .and change { zmv.zip_parts.second.reload.last_checksum_validation }
@@ -138,7 +138,7 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
       end
 
       it 'logs the mismatches' do
-        described_class.check_ibm_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         zmv.zip_parts.where(suffix: ['.zip', '.z01']).each do |part|
           msg = "replicated md5 mismatch on #{endpoint_name}: #{part.s3_key} catalog md5 (#{part.md5})"\
             " doesn't match the replicated md5 (#{non_matching_md5}) on #{bucket_name}"
@@ -147,7 +147,7 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
       end
 
       it 'updates existence check timestamps' do
-        expect { described_class.check_ibm_replicated_zipped_moab_version(zmv, results) }
+        expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
           .to change { zmv.zip_parts.first.reload.last_existence_check }
           .from(nil)
           .and change { zmv.zip_parts.second.reload.last_existence_check }
@@ -157,7 +157,7 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
       end
 
       it 'updates validation timestamps' do
-        expect { described_class.check_ibm_replicated_zipped_moab_version(zmv, results) }
+        expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
           .to change { zmv.zip_parts.first.reload.last_checksum_validation }
           .from(nil)
           .and change { zmv.zip_parts.second.reload.last_checksum_validation }
@@ -167,7 +167,7 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
       end
 
       it 'updates status to replicated_checksum_mismatch' do
-        expect { described_class.check_ibm_replicated_zipped_moab_version(zmv, results) }
+        expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
           .to change { zmv.zip_parts.first.reload.status }
           .to('replicated_checksum_mismatch')
           .and change { zmv.zip_parts.second.reload.status }
@@ -210,7 +210,7 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
       end
 
       it 'logs the missing parts' do
-        described_class.check_ibm_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         [zmv.zip_parts.first, zmv.zip_parts.fourth].each do |part|
           msg = "replicated part not found on #{endpoint_name}: #{part.s3_key} was not found on #{bucket_name}"
           expect(results.result_array).to include(a_hash_including(AuditResults::ZIP_PART_NOT_FOUND => msg))
@@ -218,7 +218,7 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
       end
 
       it "doesn't log checksum mismatches" do
-        described_class.check_ibm_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         expect(results.result_array).not_to include(a_hash_including(AuditResults::ZIP_PART_CHECKSUM_MISMATCH))
       end
     end
@@ -229,7 +229,7 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
       end
 
       it 'logs the missing parts' do
-        described_class.check_ibm_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         [zmv.zip_parts.first, zmv.zip_parts.fourth].each do |part|
           msg = "replicated part not found on #{endpoint_name}: #{part.s3_key} was not found on #{bucket_name}"
           expect(results.result_array).to include(a_hash_including(AuditResults::ZIP_PART_NOT_FOUND => msg))
@@ -240,7 +240,7 @@ RSpec.describe PreservationCatalog::Ibm::Audit do
         part = zmv.zip_parts.second
         msg = "replicated md5 mismatch on #{endpoint_name}: #{part.s3_key} catalog md5 (#{part.md5}) "\
           "doesn't match the replicated md5 (#{non_matching_md5}) on #{bucket_name}"
-        described_class.check_ibm_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         expect(results.result_array).to include(a_hash_including(AuditResults::ZIP_PART_CHECKSUM_MISMATCH => msg))
       end
     end

--- a/spec/lib/preservation_catalog/s3/audit_spec.rb
+++ b/spec/lib/preservation_catalog/s3/audit_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe PreservationCatalog::S3::Audit do
 
       expect(bucket).to receive(:object).with(ok_part.s3_key).and_return(s3_obj)
       expect(s3_obj).to receive(:metadata).and_return('checksum_md5' => ok_part.md5)
-      expect { described_class.check_aws_replicated_zipped_moab_version(zmv, results) }
+      expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
         .to change { ok_part.reload.last_existence_check }.from(nil)
         .and change { ok_part.reload.last_checksum_validation }.from(nil)
     end
@@ -65,7 +65,7 @@ RSpec.describe PreservationCatalog::S3::Audit do
     end
 
     it 'logs the missing parts and sets status to not_found' do
-      described_class.check_aws_replicated_zipped_moab_version(zmv, results)
+      described_class.check_replicated_zipped_moab_version(zmv, results)
       zmv.zip_parts.each do |part|
         msg = "replicated part not found on #{endpoint_name}: #{part.s3_key} was not found on #{bucket_name}"
         expect(results.result_array).to include(
@@ -100,24 +100,24 @@ RSpec.describe PreservationCatalog::S3::Audit do
       end
 
       it "doesn't log checksum mismatches" do
-        described_class.check_aws_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         expect(results.result_array).not_to include(a_hash_including(AuditResults::ZIP_PART_CHECKSUM_MISMATCH))
       end
 
       it "doesn't log not found errors" do
-        described_class.check_aws_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         expect(results.result_array).not_to include(a_hash_including(AuditResults::ZIP_PART_NOT_FOUND))
       end
 
       it 'updates existence check timestamps' do
-        expect { described_class.check_aws_replicated_zipped_moab_version(zmv, results) }
+        expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
           .to change { zmv.zip_parts.first.reload.last_existence_check }.from(nil)
           .and change { zmv.zip_parts.second.reload.last_existence_check }.from(nil)
           .and change { zmv.zip_parts.third.reload.last_existence_check }.from(nil)
       end
 
       it 'updates checksum validation timestamps' do
-        expect { described_class.check_aws_replicated_zipped_moab_version(zmv, results) }
+        expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
           .to change { zmv.zip_parts.first.reload.last_checksum_validation }.from(nil)
           .and change { zmv.zip_parts.second.reload.last_checksum_validation }.from(nil)
           .and change { zmv.zip_parts.third.reload.last_checksum_validation }.from(nil)
@@ -130,7 +130,7 @@ RSpec.describe PreservationCatalog::S3::Audit do
       end
 
       it 'logs the mismatches' do
-        described_class.check_aws_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         zmv.zip_parts.where(suffix: ['.zip', '.z01']).each do |part|
           msg = "replicated md5 mismatch on #{endpoint_name}: #{part.s3_key} catalog md5 (#{part.md5})"\
             " doesn't match the replicated md5 (#{non_matching_md5}) on #{bucket_name}"
@@ -139,21 +139,21 @@ RSpec.describe PreservationCatalog::S3::Audit do
       end
 
       it 'updates existence check timestamps' do
-        expect { described_class.check_aws_replicated_zipped_moab_version(zmv, results) }
+        expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
           .to change { zmv.zip_parts.first.reload.last_existence_check }.from(nil)
           .and change { zmv.zip_parts.second.reload.last_existence_check }.from(nil)
           .and change { zmv.zip_parts.third.reload.last_existence_check }.from(nil)
       end
 
       it 'updates validation timestamps' do
-        expect { described_class.check_aws_replicated_zipped_moab_version(zmv, results) }
+        expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
           .to change { zmv.zip_parts.first.reload.last_checksum_validation }.from(nil)
           .and change { zmv.zip_parts.second.reload.last_checksum_validation }.from(nil)
           .and change { zmv.zip_parts.third.reload.last_checksum_validation }.from(nil)
       end
 
       it 'updates status to replicated_checksum_mismatch' do
-        expect { described_class.check_aws_replicated_zipped_moab_version(zmv, results) }
+        expect { described_class.check_replicated_zipped_moab_version(zmv, results) }
           .to change { zmv.zip_parts.first.reload.status }
           .to('replicated_checksum_mismatch')
           .and change { zmv.zip_parts.second.reload.status }
@@ -196,7 +196,7 @@ RSpec.describe PreservationCatalog::S3::Audit do
       end
 
       it 'logs the missing parts' do
-        described_class.check_aws_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         [zmv.zip_parts.first, zmv.zip_parts.fourth].each do |part|
           msg = "replicated part not found on #{endpoint_name}: #{part.s3_key} was not found on #{bucket_name}"
           expect(results.result_array).to include(a_hash_including(AuditResults::ZIP_PART_NOT_FOUND => msg))
@@ -204,7 +204,7 @@ RSpec.describe PreservationCatalog::S3::Audit do
       end
 
       it "doesn't log checksum mismatches" do
-        described_class.check_aws_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         expect(results.result_array).not_to include(a_hash_including(AuditResults::ZIP_PART_CHECKSUM_MISMATCH))
       end
     end
@@ -215,7 +215,7 @@ RSpec.describe PreservationCatalog::S3::Audit do
       end
 
       it 'logs the missing parts' do
-        described_class.check_aws_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         [zmv.zip_parts.first, zmv.zip_parts.fourth].each do |part|
           msg = "replicated part not found on #{endpoint_name}: #{part.s3_key} was not found on #{bucket_name}"
           expect(results.result_array).to include(a_hash_including(AuditResults::ZIP_PART_NOT_FOUND => msg))
@@ -226,7 +226,7 @@ RSpec.describe PreservationCatalog::S3::Audit do
         part = zmv.zip_parts.second
         msg = "replicated md5 mismatch on #{endpoint_name}: #{part.s3_key} catalog md5 (#{part.md5}) "\
           "doesn't match the replicated md5 (#{non_matching_md5}) on #{bucket_name}"
-        described_class.check_aws_replicated_zipped_moab_version(zmv, results)
+        described_class.check_replicated_zipped_moab_version(zmv, results)
         expect(results.result_array).to include(a_hash_including(AuditResults::ZIP_PART_CHECKSUM_MISMATCH => msg))
       end
     end


### PR DESCRIPTION
only one of this and #1220 should be merged

## Why was this change made?

to fix the issue with connecting to the IBM endpoint to audit it, per #1189 

this PR allows the audit job to select the audit class specific to the endpoint type.

i _think_ i slightly prefer the PR without the migration (see #1220), but not as much as i thought i would when i started writing it.

what's here parallels what we did for `delivery_class`.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

no, but if people like this, i will update the DB documentation as needed, either as a follow on commit in this PR, or in a separate PR (would file an issue if doing the latter).