### PR TITLE
Add okcomputer check to count number of workers

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -83,18 +83,12 @@ end
 # check for the right number of workers
 class WorkerCountCheck < OkComputer::Check
   def check
-    if Resque.workers.first.to_s.include?('stage')
-      if Resque.workers.count == 117
-        mark_message '117 workers are up.'
-      else
-        mark_failure
-        mark_message 'Not all 117 workers are up!'
-      end
-    elsif Resque.workers.count == 180
-      mark_message '180 workers are up.'
+    count = Settings.total_worker_count
+    if Resque.workers.count == count
+      mark_message "#{count} workers are up."
     else
       mark_failure
-      mark_message 'Not all 180 workers are up!'
+      mark_message "Not all #{count} workers are up!"
     end
   end
   OkComputer::Registry.register 'feature-worker-count', WorkerCountCheck.new

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -80,6 +80,26 @@ Resque::Failure.queues.each do |queue|
                                 OkComputer::SizeThresholdCheck.new(queue, 20) { Resque::Failure.count(queue) }
 end
 
+# check for the right number of workers
+class WorkerCountCheck < OkComputer::Check
+  def check
+    if Resque.workers.first.to_s.include?('stage')
+      if Resque.workers.count == 117
+        mark_message '117 workers are up.'
+      else
+        mark_failure
+        mark_message 'Not all 117 workers are up!'
+      end
+    elsif Resque.workers.count == 180
+      mark_message '180 workers are up.'
+    else
+      mark_failure
+      mark_message 'Not all 180 workers are up!'
+    end
+  end
+  OkComputer::Registry.register 'feature-worker-count', WorkerCountCheck.new
+end
+
 # ------------------------------------------------------------------------------
 
 # NON-CRUCIAL (Optional) checks, avail at /status/<name-of-check>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,3 +43,5 @@ resque_dashboard_hostnames: # tells the router where to mount the resque dashboa
 # instance specific configs.
 replication:
   audit_should_backfill: false
+
+total_worker_count: 117 # for okcomputer endpoint


### PR DESCRIPTION
## Why was this change made?

Our monitor didn't pick up on audit workers being down earlier this week. This check detects the currently configured number of workers in stage and prod, and though it hard codes that number, it's something.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

No, since this adds a check on behavior we already assume.