### PR TITLE
make feature-worker-count a required check

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -126,4 +126,4 @@ OkComputer::Registry.register "feature-version-audit-window-check", VersionAudit
 
 # TODO: do we want anything about s3 credentials here?
 
-OkComputer.make_optional %w[feature-version-audit-window-check external-workflow-services-url feature-zip_storage_dir feature-resque-down]
+OkComputer.make_optional %w[feature-version-audit-window-check external-workflow-services-url feature-zip_storage_dir]


### PR DESCRIPTION
not 100% sure this is the right thing to do, but for your consideration...

## Why was this change made?

because it seems like nagios should alert us when the worker count isn't as expected

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

N/A

closes #1231
