### PR TITLE
add info to some objects_controller error messages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,18 +13,22 @@ class ApplicationController < ActionController::API
     id&.split(':', 2)&.last
   end
 
-  def bad_request
-    render plain: '400 bad request', status: :bad_request
+  def bad_request(exception)
+    msg = '400 bad request'
+    msg = "#{msg}: #{exception.message}" if exception
+    render plain: msg, status: :bad_request
   end
 
-  def not_found
-    render plain: '404 Not Found', status: :not_found
+  def not_found(exception)
+    msg = '404 Not Found'
+    msg = "#{msg}: #{exception.message}" if exception
+    render plain: msg, status: :not_found
   end
 
   # TODO: get rid of this once https://github.com/sul-dlss/moab-versioning/issues/159 is implemented
   def refine_invalid_druid_error!(err)
     # make a specific moab-versioning StandardError into something more easily manageable by ApplicationController...
     raise InvalidSuriSyntax, err.message if err.message.include?('Identifier has invalid suri syntax')
-    raise # ...but just re-raise what we got if it was something else
+    raise err # re-raise what we got if it was something else
   end
 end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -20,10 +20,10 @@ class ObjectsController < ApplicationController
 
   # return the checksums and filesize for a list of druid (supplied with druid: prefix)
   # note: this is deliberately allowed to be a POST to allow for a large number of druids to be passed in
-  # GET OR POST /objects/checksums?druids[]=druida&druids[]=druidb&druids[]=druidc
+  # GET OR POST /objects/checksums?druids[]=druid1&druids[]=druid2&druids[]=druid3
   def checksums
     unless druids.present?
-      render(plain: '400 bad request', status: :bad_request)
+      render(plain: "400 bad request - druids param must be populated", status: :bad_request)
       return
     end
 

--- a/spec/requests/objects_controller_checksums_spec.rb
+++ b/spec/requests/objects_controller_checksums_spec.rb
@@ -161,12 +161,36 @@ RSpec.describe ObjectsController, type: :request do
         post checksums_objects_url, params: { druids: [prefixed_druid, 'druid:xx123yy9999'], format: :json }
         expect(response).to have_http_status(:not_found)
       end
+
+      it 'body has additional information from the exception if available' do
+        post checksums_objects_url, params: { druids: [prefixed_druid, 'druid:xx123yy9999'], format: :json }
+        expect(response.body).to eq '404 Not Found: No storage object found for xx123yy9999'
+      end
+    end
+
+    context 'when no druids param provided' do
+      context 'when druids param is empty' do
+        it 'body has additional information from the exception if available' do
+          post checksums_objects_url, params: { druids: [], format: :json }
+          expect(response).to have_http_status(:bad_request)
+          expect(response.body).to eq '400 bad request: Identifier has invalid suri syntax:  nil or empty'
+        end
+      end
+
+      context "when no druids param" do
+        it 'body has additional information from the exception if available' do
+          post checksums_objects_url, params: { format: :json }
+          expect(response).to have_http_status(:bad_request)
+          expect(response.body).to eq '400 bad request - druids param must be populated'
+        end
+      end
     end
 
     context 'when bad parameter passed in' do
       it 'returns a 400 response code with a bad druid passed in' do
-        post checksums_objects_url, params: { druids: [prefixed_druid, 'not a druid'], format: :json }
+        post checksums_objects_url, params: { druids: [prefixed_druid, 'foobar'], format: :json }
         expect(response).to have_http_status(:bad_request)
+        expect(response.body).to eq '400 bad request: Identifier has invalid suri syntax: foobar'
       end
 
       it 'returns a 406 response code when an unsupported response format is provided' do

--- a/spec/requests/objects_controller_object_spec.rb
+++ b/spec/requests/objects_controller_object_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe ObjectsController, type: :request do
         get object_url 'druid:garbage', format: :json
         expect(response).to have_http_status(:not_found)
       end
+
+      it 'returns useful info in the body' do
+        get object_url 'druid:garbage', format: :json
+        expect(response.body).to eq "404 Not Found: Couldn't find PreservedObject"
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,16 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = "doc"
+  end
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin
@@ -57,16 +67,6 @@ RSpec.configure do |config|
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running


### PR DESCRIPTION
## Why was this change made?

To provide better information to us (via Honeybadger) and consumers of the API when exceptions occur.  Related to #1229, in that it gives more information about why calling checksum report fails due to missing druids.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a