### PR TITLE
Moab vers update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
-    moab-versioning (4.2.2)
+    moab-versioning (4.3.0)
       confstruct
       druid-tools (>= 1.0.0)
       json
@@ -388,4 +388,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::API
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from Moab::ObjectNotFoundException, with: :not_found
-  rescue_from InvalidSuriSyntax, with: :bad_request
+  rescue_from Moab::InvalidSuriSyntaxError, with: :bad_request
 
   protected
 
@@ -23,12 +23,5 @@ class ApplicationController < ActionController::API
     msg = '404 Not Found'
     msg = "#{msg}: #{exception.message}" if exception
     render plain: msg, status: :not_found
-  end
-
-  # TODO: get rid of this once https://github.com/sul-dlss/moab-versioning/issues/159 is implemented
-  def refine_invalid_druid_error!(err)
-    # make a specific moab-versioning StandardError into something more easily manageable by ApplicationController...
-    raise InvalidSuriSyntax, err.message if err.message.include?('Identifier has invalid suri syntax')
-    raise err # re-raise what we got if it was something else
   end
 end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -80,7 +80,5 @@ class ObjectsController < ApplicationController
 
   def retrieve_file_group(druid)
     Moab::StorageServices.retrieve_file_group('content', druid)
-  rescue StandardError => e
-    refine_invalid_druid_error!(e)
   end
 end

--- a/app/errors/invalid_suri_syntax.rb
+++ b/app/errors/invalid_suri_syntax.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-##
-# this allows us to re-raise certain StandardErrors from moab-versioning in a more
-# specifically rescue-able way
-# TODO: move into moab-versioning gem, and remove this class once https://github.com/sul-dlss/moab-versioning/issues/159
-# is implemented
-class InvalidSuriSyntax < StandardError
-end


### PR DESCRIPTION
## Why was this change made?

Removes a kludge introduced in PR #1207.   This will also clean up additional objects_controller endpoints that will be leveraging moab-versioning for information ... specifically the ones about to be written to allow us to retired the sdr-services-app.

Note that the following specs continue to pass, given moab-versioning v4.3.0:
- https://github.com/sul-dlss/preservation_catalog/blob/master/spec/requests/objects_controller_checksums_spec.rb#L173-L177
- https://github.com/sul-dlss/preservation_catalog/blob/master/spec/requests/objects_controller_checksums_spec.rb#L190-L194

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a.