### PR TITLE
use MoabStorageService for controllers

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -72,13 +72,9 @@ class ObjectsController < ApplicationController
   end
 
   def checksum_for_object(druid)
-    content_group = retrieve_file_group(druid)
+    content_group = MoabStorageService.retrieve_content_file_group(druid)
     content_group.path_hash.map do |file, signature|
       { filename: file, md5: signature.md5, sha1: signature.sha1, sha256: signature.sha256, filesize: signature.size }
     end
-  end
-
-  def retrieve_file_group(druid)
-    Moab::StorageServices.retrieve_file_group('content', druid)
   end
 end

--- a/app/services/moab_storage_service.rb
+++ b/app/services/moab_storage_service.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Responsibility: interactions with Moab storage to support read-only access for ReST API calls
+class MoabStorageService
+  def self.retrieve_content_file_group(druid)
+    Moab::StorageServices.retrieve_file_group('content', druid)
+  end
+end

--- a/spec/services/moab_storage_service_spec.rb
+++ b/spec/services/moab_storage_service_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MoabStorageService do
+  let(:druid) { 'jj925bx9565' }
+
+  describe '.retrieve_content_file_group' do
+    it 'calls Moab::StorageServices.retrieve_file_group for "content"' do
+      allow(Moab::StorageServices).to receive(:retrieve_file_group).with('content', druid)
+      described_class.retrieve_content_file_group(druid)
+      expect(Moab::StorageServices).to have_received(:retrieve_file_group).with('content', druid)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Additional API endpoints are coming in order to replace the sdr-services-app.  The MoabStorageService class introduced here will contain the code used by the objects_controller to get information about existing Moabs.   

It is possible that some of the audit job functionality could also utilize this new class for its moab lookups, but right now I am concerned only with the API endpoints.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a
