### PR TITLE
update prescat to use new workflow-client methods

### DIFF
--- a/app/services/workflow_reporter.rb
+++ b/app/services/workflow_reporter.rb
@@ -2,7 +2,6 @@
 
 # send errors to preservationAuditWF workflow for an object via ReST calls.
 class WorkflowReporter
-  DOR = 'dor'
   PRESERVATIONAUDITWF = 'preservationAuditWF'
   NO_WORKFLOW_HOOKUP = 'no workflow hookup - assume you are in test or dev environment'
   COMPLETED = 'completed'
@@ -11,7 +10,7 @@ class WorkflowReporter
   # see issue sul-dlss/dor-workflow-service#50 for more context
   def self.report_error(druid, process_name, error_message)
     if Settings.workflow_services_url.present?
-      workflow_client.update_workflow_error_status(DOR, "druid:#{druid}", PRESERVATIONAUDITWF, process_name, error_message)
+      workflow_client.update_error_status("druid:#{druid}", PRESERVATIONAUDITWF, process_name, error_message)
     else
       Rails.logger.warn(NO_WORKFLOW_HOOKUP)
     end
@@ -19,7 +18,7 @@ class WorkflowReporter
 
   def self.report_completed(druid, process_name)
     if Settings.workflow_services_url.present?
-      workflow_client.update_workflow_status(DOR, "druid:#{druid}", PRESERVATIONAUDITWF, process_name, COMPLETED)
+      workflow_client.update_status("druid:#{druid}", PRESERVATIONAUDITWF, process_name, COMPLETED)
     else
       Rails.logger.warn(NO_WORKFLOW_HOOKUP)
     end

--- a/spec/services/workflow_reporter_spec.rb
+++ b/spec/services/workflow_reporter_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe WorkflowReporter do
       allow(Dor::Workflow::Client).to receive(:new).and_return(stub_client)
     end
 
-    let(:stub_client) { instance_double(Dor::Workflow::Client, update_workflow_error_status: true) }
-
+    let(:stub_client) { instance_double(Dor::Workflow::Client, update_error_status: true) }
     let(:process_name) { 'moab-valid' }
 
     it 'returns true' do
@@ -19,7 +18,7 @@ RSpec.describe WorkflowReporter do
       # because we always get true the from the dor-workflow-service gem
       # see issue sul-dlss/dor-workflow-client#50 for more context
       expect(described_class.report_error(druid, process_name, result)).to be true
-      expect(stub_client).to have_received(:update_workflow_error_status).with('dor', "druid:#{druid}", 'preservationAuditWF', process_name, result)
+      expect(stub_client).to have_received(:update_error_status).with("druid:#{druid}", 'preservationAuditWF', process_name, result)
     end
   end
 
@@ -28,12 +27,12 @@ RSpec.describe WorkflowReporter do
       allow(Dor::Workflow::Client).to receive(:new).and_return(stub_client)
     end
 
-    let(:stub_client) { instance_double(Dor::Workflow::Client, update_workflow_status: true) }
+    let(:stub_client) { instance_double(Dor::Workflow::Client, update_status: true) }
     let(:process_name) { 'preservation-audit' }
 
     it 'returns true' do
       expect(described_class.report_completed(druid, process_name)).to be true
-      expect(stub_client).to have_received(:update_workflow_status).with('dor', "druid:#{druid}", 'preservationAuditWF', process_name, 'completed')
+      expect(stub_client).to have_received(:update_status).with("druid:#{druid}", 'preservationAuditWF', process_name, 'completed')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

The workflow server is no longer using the repo arg;  this uses non-deprecated methods in workflow-client.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a