### PR TITLE
Stop using deprecated workflow methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 # general Ruby/Rails gems
 gem 'aws-sdk-s3', '~> 1.17'
 gem 'config' # Settings to manage configs on different instances
-gem 'dor-workflow-client', '~> 3.3' # audit errors are reported to the workflow service
+gem 'dor-workflow-client', '~> 3.8' # audit errors are reported to the workflow service
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'jbuilder', '~> 2.5' # Build JSON APIs with ease.
 gem 'okcomputer' # ReST endpoint with upness status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,7 +361,7 @@ DEPENDENCIES
   config
   coveralls
   dlss-capistrano
-  dor-workflow-client (~> 3.3)
+  dor-workflow-client (~> 3.8)
   druid-tools
   factory_bot_rails (~> 4.0)
   hirb

--- a/app/services/workflow_reporter.rb
+++ b/app/services/workflow_reporter.rb
@@ -2,7 +2,6 @@
 
 # send errors to preservationAuditWF workflow for an object via ReST calls.
 class WorkflowReporter
-  DOR = 'dor'
   PRESERVATIONAUDITWF = 'preservationAuditWF'
   NO_WORKFLOW_HOOKUP = 'no workflow hookup - assume you are in test or dev environment'
   COMPLETED = 'completed'
@@ -11,7 +10,10 @@ class WorkflowReporter
   # see issue sul-dlss/dor-workflow-service#50 for more context
   def self.report_error(druid, process_name, error_message)
     if Settings.workflow_services_url.present?
-      workflow_client.update_workflow_error_status(DOR, "druid:#{druid}", PRESERVATIONAUDITWF, process_name, error_message)
+      workflow_client.update_error_status(druid: "druid:#{druid}",
+                                          workflow: PRESERVATIONAUDITWF,
+                                          process: process_name,
+                                          error_msg: error_message)
     else
       Rails.logger.warn(NO_WORKFLOW_HOOKUP)
     end
@@ -19,7 +21,10 @@ class WorkflowReporter
 
   def self.report_completed(druid, process_name)
     if Settings.workflow_services_url.present?
-      workflow_client.update_workflow_status(DOR, "druid:#{druid}", PRESERVATIONAUDITWF, process_name, COMPLETED)
+      workflow_client.update_status(druid: "druid:#{druid}",
+                                    workflow: PRESERVATIONAUDITWF,
+                                    process: process_name,
+                                    status: COMPLETED)
     else
       Rails.logger.warn(NO_WORKFLOW_HOOKUP)
     end

--- a/spec/services/workflow_reporter_spec.rb
+++ b/spec/services/workflow_reporter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe WorkflowReporter do
       allow(Dor::Workflow::Client).to receive(:new).and_return(stub_client)
     end
 
-    let(:stub_client) { instance_double(Dor::Workflow::Client, update_workflow_error_status: true) }
+    let(:stub_client) { instance_double(Dor::Workflow::Client, update_error_status: true) }
 
     let(:process_name) { 'moab-valid' }
 
@@ -19,7 +19,11 @@ RSpec.describe WorkflowReporter do
       # because we always get true the from the dor-workflow-service gem
       # see issue sul-dlss/dor-workflow-client#50 for more context
       expect(described_class.report_error(druid, process_name, result)).to be true
-      expect(stub_client).to have_received(:update_workflow_error_status).with('dor', "druid:#{druid}", 'preservationAuditWF', process_name, result)
+      expect(stub_client).to have_received(:update_error_status)
+        .with(druid: "druid:#{druid}",
+              workflow: 'preservationAuditWF',
+              process: process_name,
+              error_msg: result)
     end
   end
 
@@ -28,12 +32,16 @@ RSpec.describe WorkflowReporter do
       allow(Dor::Workflow::Client).to receive(:new).and_return(stub_client)
     end
 
-    let(:stub_client) { instance_double(Dor::Workflow::Client, update_workflow_status: true) }
+    let(:stub_client) { instance_double(Dor::Workflow::Client, update_status: true) }
     let(:process_name) { 'preservation-audit' }
 
     it 'returns true' do
       expect(described_class.report_completed(druid, process_name)).to be true
-      expect(stub_client).to have_received(:update_workflow_status).with('dor', "druid:#{druid}", 'preservationAuditWF', process_name, 'completed')
+      expect(stub_client).to have_received(:update_status)
+        .with(druid: "druid:#{druid}",
+              workflow: 'preservationAuditWF',
+              process: process_name,
+              status: 'completed')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?
The code was calling methods that had been deprecated.


## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
n/a