### PR TITLE
create audit workflow if it doesn't exist

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -154,9 +154,9 @@ class AuditResults
       log_result(r, logger)
       if r.key?(INVALID_MOAB)
         msg = "#{workflows_msg_prefix} || #{r.values.first}"
-        WorkflowReporter.report_error(druid, 'moab-valid', msg)
+        WorkflowReporter.report_error(druid, actual_version, 'moab-valid', msg)
       elsif status_changed_to_ok?(r)
-        WorkflowReporter.report_completed(druid, 'preservation-audit')
+        WorkflowReporter.report_completed(druid, actual_version, 'preservation-audit')
       elsif WORKFLOW_REPORT_CODES.include?(r.keys.first)
         candidate_workflow_results << r
       end
@@ -187,7 +187,7 @@ class AuditResults
   def report_errors_to_workflows(candidate_workflow_results)
     return if candidate_workflow_results.empty?
     msg = "#{workflows_msg_prefix} #{candidate_workflow_results.map(&:values).flatten.join(' && ')}"
-    WorkflowReporter.report_error(druid, 'preservation-audit', msg)
+    WorkflowReporter.report_error(druid, actual_version, 'preservation-audit', msg)
   end
 
   def log_result(result, logger)

--- a/app/services/workflow_reporter.rb
+++ b/app/services/workflow_reporter.rb
@@ -5,10 +5,11 @@ class WorkflowReporter
   PRESERVATIONAUDITWF = 'preservationAuditWF'
   NO_WORKFLOW_HOOKUP = 'no workflow hookup - assume you are in test or dev environment'
   COMPLETED = 'completed'
+  MISSING_WF_REGEX = /^Failed .*#{Settings.workflow_services_url}.*preservationAuditWF.* (HTTP status 404)/.freeze
 
   # this method will always return true because of the dor-workflow-service gem
   # see issue sul-dlss/dor-workflow-service#50 for more context
-  def self.report_error(druid, process_name, error_message)
+  def self.report_error(druid, version, process_name, error_message)
     if Settings.workflow_services_url.present?
       workflow_client.update_error_status(druid: "druid:#{druid}",
                                           workflow: PRESERVATIONAUDITWF,
@@ -17,9 +18,14 @@ class WorkflowReporter
     else
       Rails.logger.warn(NO_WORKFLOW_HOOKUP)
     end
+  rescue Dor::WorkflowException => e
+    raise unless e.message.match?(MISSING_WF_REGEX)
+
+    create_wf(druid, version)
+    report_error(druid, version, process_name, error_message)
   end
 
-  def self.report_completed(druid, process_name)
+  def self.report_completed(druid, version, process_name)
     if Settings.workflow_services_url.present?
       workflow_client.update_status(druid: "druid:#{druid}",
                                     workflow: PRESERVATIONAUDITWF,
@@ -28,7 +34,17 @@ class WorkflowReporter
     else
       Rails.logger.warn(NO_WORKFLOW_HOOKUP)
     end
+  rescue Dor::WorkflowException => e
+    raise unless e.message.match?(MISSING_WF_REGEX)
+
+    create_wf(druid, version)
+    report_completed(druid, process_name, error_message)
   end
+
+  def self.create_wf(druid, version)
+    workflow_client.create_workflow_by_name(druid, PRESERVATIONAUDITWF, version: version)
+  end
+  private_class_method :create_wf
 
   def self.workflow_client
     wf_log = Logger.new('log/workflow_service.log', 'weekly')

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -125,18 +125,18 @@ RSpec.describe AuditResults do
 
         it 'details about the failures' do
           err_details = im_audit_results.send(:result_code_msg, result_code, moab_valid_errs)
-          expect(WorkflowReporter).to receive(:report_error).with(druid, 'moab-valid', a_string_matching(Regexp.escape(err_details)))
+          expect(WorkflowReporter).to receive(:report_error).with(druid, actual_version, 'moab-valid', a_string_matching(Regexp.escape(err_details)))
           im_audit_results.report_results
         end
 
         it 'check name' do
-          expect(WorkflowReporter).to receive(:report_error).with(druid, 'moab-valid', a_string_matching(check_name))
+          expect(WorkflowReporter).to receive(:report_error).with(druid, actual_version, 'moab-valid', a_string_matching(check_name))
           im_audit_results.report_results
         end
 
         it 'ms_root name' do
           expected = Regexp.escape("actual location: #{ms_root.name}")
-          expect(WorkflowReporter).to receive(:report_error).with(druid, 'moab-valid', a_string_matching(expected))
+          expect(WorkflowReporter).to receive(:report_error).with(druid, actual_version, 'moab-valid', a_string_matching(expected))
           im_audit_results.report_results
         end
       end
@@ -154,7 +154,7 @@ RSpec.describe AuditResults do
         audit_results.add_result(code, addl_hash)
         wf_err_msg = audit_results.send(:result_code_msg, code, addl_hash)
         expect(WorkflowReporter).to receive(:report_error).with(
-          druid, 'preservation-audit', a_string_matching(wf_err_msg)
+          druid, actual_version, 'preservation-audit', a_string_matching(wf_err_msg)
         )
         audit_results.report_results
       end
@@ -169,17 +169,17 @@ RSpec.describe AuditResults do
         audit_results.add_result(code2, result_msg_args2)
         result_msg2 = audit_results.send(:result_code_msg, code2, result_msg_args2)
         allow(WorkflowReporter).to receive(:report_error).with(
-          druid, 'preservation-audit', instance_of(String)
+          druid, actual_version, 'preservation-audit', instance_of(String)
         )
         audit_results.report_results
         expect(WorkflowReporter).to have_received(:report_error).with(
-          druid, 'preservation-audit', a_string_matching(result_msg1)
+          druid, actual_version, 'preservation-audit', a_string_matching(result_msg1)
         )
         expect(WorkflowReporter).to have_received(:report_error).with(
-          druid, 'preservation-audit', a_string_matching(/ \&\& /)
+          druid, actual_version, 'preservation-audit', a_string_matching(/ \&\& /)
         )
         expect(WorkflowReporter).to have_received(:report_error).with(
-          druid, 'preservation-audit', a_string_matching(result_msg2)
+          druid, actual_version, 'preservation-audit', a_string_matching(result_msg2)
         )
       end
 
@@ -188,7 +188,7 @@ RSpec.describe AuditResults do
         audit_results.add_result(code)
         expected = Regexp.escape("actual location: #{ms_root.name}")
         expect(WorkflowReporter).to receive(:report_error).with(
-          druid, 'preservation-audit', a_string_matching(expected)
+          druid, actual_version, 'preservation-audit', a_string_matching(expected)
         )
         audit_results.report_results
       end
@@ -199,9 +199,9 @@ RSpec.describe AuditResults do
         audit_results.add_result(code)
         unexpected = Regexp.escape("actual location: ")
         expect(WorkflowReporter).not_to receive(:report_error).with(
-          druid, 'preservation-audit', a_string_matching(unexpected)
+          druid, actual_version, 'preservation-audit', a_string_matching(unexpected)
         )
-        expect(WorkflowReporter).to receive(:report_error).with(druid, 'preservation-audit', anything)
+        expect(WorkflowReporter).to receive(:report_error).with(druid, actual_version, 'preservation-audit', anything)
         audit_results.report_results
       end
 
@@ -210,7 +210,7 @@ RSpec.describe AuditResults do
         audit_results.add_result(code)
         expected = "actual version: #{actual_version}"
         expect(WorkflowReporter).to receive(:report_error).with(
-          druid, 'preservation-audit', a_string_matching(expected)
+          druid, actual_version, 'preservation-audit', a_string_matching(expected)
         )
         audit_results.report_results
       end
@@ -221,9 +221,9 @@ RSpec.describe AuditResults do
         audit_results.add_result(code)
         unexpected = Regexp.escape("actual version: ")
         expect(WorkflowReporter).not_to receive(:report_error).with(
-          druid, 'preservation-audit', a_string_matching(unexpected)
+          druid, nil, 'preservation-audit', a_string_matching(unexpected)
         )
-        expect(WorkflowReporter).to receive(:report_error).with(druid, 'preservation-audit', anything)
+        expect(WorkflowReporter).to receive(:report_error).with(druid, nil, 'preservation-audit', anything)
         audit_results.report_results
       end
 
@@ -241,7 +241,7 @@ RSpec.describe AuditResults do
         it 'message sent includes CompleteMoab create date' do
           expected = Regexp.escape("db CompleteMoab (created #{create_date}")
           expect(WorkflowReporter).to receive(:report_error).with(
-            druid, 'preservation-audit', a_string_matching(expected)
+            druid, actual_version, 'preservation-audit', a_string_matching(expected)
           )
           my_audit_results.report_results
         end
@@ -249,7 +249,7 @@ RSpec.describe AuditResults do
         it 'message sent includes CompleteMoab updated date' do
           expected = "db CompleteMoab .* last updated #{update_date}"
           expect(WorkflowReporter).to receive(:report_error).with(
-            druid, 'preservation-audit', a_string_matching(expected)
+            druid, actual_version, 'preservation-audit', a_string_matching(expected)
           )
           my_audit_results.report_results
         end
@@ -261,7 +261,7 @@ RSpec.describe AuditResults do
         result_code = AuditResults::CM_STATUS_CHANGED
         addl_hash = { old_status: 'invalid_checksum', new_status: 'ok' }
         audit_results.add_result(result_code, addl_hash)
-        expect(WorkflowReporter).to receive(:report_completed).with(druid, 'preservation-audit')
+        expect(WorkflowReporter).to receive(:report_completed).with(druid, actual_version, 'preservation-audit')
         audit_results.report_results
       end
     end

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -525,13 +525,13 @@ RSpec.describe ChecksumValidator do
 
     it 'has status changed to OK_STATUS and completes workflow' do
       comp_moab.invalid_moab!
-      expect(WorkflowReporter).to receive(:report_completed).with(druid, 'preservation-audit')
+      expect(WorkflowReporter).to receive(:report_completed).with(druid, nil, 'preservation-audit')
       cv.validate_checksums
     end
 
     it 'has status that does not change and does not complete workflow' do
       comp_moab.ok!
-      expect(WorkflowReporter).not_to receive(:report_completed).with(druid, 'preservation-audit')
+      expect(WorkflowReporter).not_to receive(:report_completed).with(druid, nil, 'preservation-audit')
       cv.validate_checksums
     end
 
@@ -543,7 +543,7 @@ RSpec.describe ChecksumValidator do
 
       it "does not complete workflow" do
         comp_moab.ok!
-        expect(WorkflowReporter).not_to receive(:report_completed).with(druid, 'preservation-audit')
+        expect(WorkflowReporter).not_to receive(:report_completed).with(druid, nil, 'preservation-audit')
         cv.validate_checksums
       end
     end
@@ -558,7 +558,7 @@ RSpec.describe ChecksumValidator do
       end
 
       it 'does not complete workflow' do
-        expect(WorkflowReporter).not_to receive(:report_completed).with(druid, 'preservation-audit')
+        expect(WorkflowReporter).not_to receive(:report_completed).with(druid, nil, 'preservation-audit')
         cv.validate_checksums
       end
     end

--- a/spec/services/workflow_reporter_spec.rb
+++ b/spec/services/workflow_reporter_spec.rb
@@ -4,44 +4,76 @@ require 'rails_helper'
 
 RSpec.describe WorkflowReporter do
   let(:druid) { 'jj925bx9565' }
+  let(:version) { '1' }
+  let(:err_msg) { "Failed to retrieve response #{Settings.workflow_services_url}/preservationAuditWF/something (HTTP status 404)" }
+  let(:wf_server_response_json) { { some: 'json response from wf server' } }
+
+  before do
+    allow(Dor::Workflow::Client).to receive(:new).and_return(stub_wf_client)
+  end
 
   describe '.report_error' do
-    before do
-      allow(Dor::Workflow::Client).to receive(:new).and_return(stub_client)
+    let(:process_name) { 'moab-valid' }
+    let(:audit_result) { 'Invalid moab, validation error...ential version directories.' }
+
+    context 'when workflow already exists' do
+      let(:stub_wf_client) { instance_double(Dor::Workflow::Client, update_error_status: wf_server_response_json) }
+
+      it 'returns json response from wf server (mocked here)' do
+        expect(described_class.report_error(druid, version, process_name, audit_result)).to eq wf_server_response_json
+        expect(stub_wf_client).to have_received(:update_error_status)
+          .with(druid: "druid:#{druid}",
+                workflow: 'preservationAuditWF',
+                process: process_name,
+                error_msg: audit_result)
+      end
     end
 
-    let(:stub_client) { instance_double(Dor::Workflow::Client, update_error_status: true) }
+    context 'when workflow does not exist' do
+      let(:stub_wf_client) { instance_double(Dor::Workflow::Client) }
 
-    let(:process_name) { 'moab-valid' }
-
-    it 'returns true' do
-      result = 'Invalid moab, validation error...ential version directories.'
-      # because we always get true the from the dor-workflow-service gem
-      # see issue sul-dlss/dor-workflow-client#50 for more context
-      expect(described_class.report_error(druid, process_name, result)).to be true
-      expect(stub_client).to have_received(:update_error_status)
-        .with(druid: "druid:#{druid}",
-              workflow: 'preservationAuditWF',
-              process: process_name,
-              error_msg: result)
+      it 'creates workflow and calls report_error again' do
+        # NOTE: funky way to let code raise an error and handle it without rspec failing
+        expect do
+          allow(stub_wf_client).to receive(:update_error_status).and_raise(Dor::WorkflowException, err_msg)
+          allow(described_class).to receive(:create_wf)
+          described_class.report_error(druid, version, process_name, audit_result)
+          expect(described_class).to have_received(:create_wf)
+          expect(described_class).to receive(:report_error).twice
+        end.to raise_error(Dor::WorkflowException, err_msg)
+      end
     end
   end
 
   describe '.report_completed' do
-    before do
-      allow(Dor::Workflow::Client).to receive(:new).and_return(stub_client)
-    end
-
-    let(:stub_client) { instance_double(Dor::Workflow::Client, update_status: true) }
     let(:process_name) { 'preservation-audit' }
 
-    it 'returns true' do
-      expect(described_class.report_completed(druid, process_name)).to be true
-      expect(stub_client).to have_received(:update_status)
-        .with(druid: "druid:#{druid}",
-              workflow: 'preservationAuditWF',
-              process: process_name,
-              status: 'completed')
+    context 'when workflow exists' do
+      let(:stub_wf_client) { instance_double(Dor::Workflow::Client, update_status: wf_server_response_json) }
+
+      it 'returns json response from wf server (mocked here)' do
+        expect(described_class.report_completed(druid, version, process_name)).to eq wf_server_response_json
+        expect(stub_wf_client).to have_received(:update_status)
+          .with(druid: "druid:#{druid}",
+                workflow: 'preservationAuditWF',
+                process: process_name,
+                status: 'completed')
+      end
+    end
+
+    context 'when workflow does not exist' do
+      let(:stub_wf_client) { instance_double(Dor::Workflow::Client) }
+
+      it 'creates workflow and calls report_completed again' do
+        # NOTE: funky way to let code raise an error and handle it without rspec failing
+        expect do
+          allow(stub_wf_client).to receive(:update_status).and_raise(Dor::WorkflowException, err_msg)
+          allow(described_class).to receive(:create_wf)
+          described_class.report_completed(druid, version, process_name)
+          expect(described_class).to have_received(:create_wf)
+          expect(described_class).to receive(:report_completed).twice
+        end.to raise_error(Dor::WorkflowException, err_msg)
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

To stop the "Failed to retrieve resource" errors for non-existent preservationAuditWF, e.g. https://app.honeybadger.io/projects/54415/faults/57642907.

NOTE:  I deployed to stage and tried to test it in situ, but the objects in prescat don't correspond to the objects in dor/argo very well so I gave up.

Closes #1245

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a