### PR TITLE
add objects/content_diff endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,6 +83,7 @@ RSpec/NestedGroups:
   Exclude:
     - 'spec/lib/audit/catalog_to_moab_spec.rb'
     - 'spec/lib/audit/moab_to_catalog_spec.rb'
+    - 'spec/requests/objects_controller_content_diff_spec.rb'
     - 'spec/requests/objects_controller_file_spec.rb'
     - 'spec/services/checksum_validator_spec.rb'
     - 'spec/services/preserved_object_handler_*.rb'

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -47,7 +47,7 @@ class ObjectsController < ApplicationController
   # note: this is deliberately allowed to be a POST to allow for a large number of druids to be passed in
   # GET OR POST /objects/checksums?druids[]=druid1&druids[]=druid2&druids[]=druid3
   def checksums
-    unless druids.present?
+    unless normalized_druids.present?
       render(plain: "400 bad request - druids param must be populated", status: :bad_request)
       return
     end
@@ -91,7 +91,7 @@ class ObjectsController < ApplicationController
     strip_druid(params[:id])
   end
 
-  def druids
+  def normalized_druids
     return [] unless params[:druids].present?
     params[:druids].map { |druid| strip_druid(druid) }.sort.uniq # normalize, then sort, then de-dupe
   end
@@ -105,12 +105,12 @@ class ObjectsController < ApplicationController
   end
 
   def json_checksum_list
-    druids.map { |druid| { returned_druid(druid) => content_files_checksums(druid) } }.to_json
+    normalized_druids.map { |druid| { returned_druid(druid) => content_files_checksums(druid) } }.to_json
   end
 
   def csv_checksum_list
     CSV.generate do |csv|
-      druids.each do |druid|
+      normalized_druids.each do |druid|
         content_files_checksums(druid).each do |checksum|
           csv << [returned_druid(druid), checksum[:filename], checksum[:md5], checksum[:sha1], checksum[:sha256], checksum[:filesize]]
         end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -14,6 +14,10 @@ class ObjectsController < ApplicationController
 
   # return a specific file from the Moab
   # GET /objects/:druid/file?category=manifest&filepath=signatureCatalog.xml
+  # useful params:
+  # - category (content|manifest|metadata)
+  # - filepath path of file, relative to category directory
+  # - version (positive integer (as a string)) version of Moab
   def file
     if params[:version] && !params[:version].match?(/^[1-9]\d*$/)
       render(plain: "400 Bad Request: version parameter must be positive integer", status: :bad_request)
@@ -57,6 +61,19 @@ class ObjectsController < ApplicationController
       end
       format.any { render status: :not_acceptable, plain: 'Format not acceptable' }
     end
+  end
+
+  # Retrieves an XML file representing [Moab::FileInventoryDifference]
+  #   from comparison of passed contentMetadata.xml with latest (or specified) version in Moab,
+  #   for all files (default) or a specified subset (shelve|preserve|publish)
+  #
+  # body of request: contentMetadata.xml we wish to compare against a version already in the Moab
+  # useful params:
+  # - subset (default: 'all') which subset of files to compare (all|shelve|preserve|publish)
+  # - version (positive integer (as a string)) version of Moab to be compared against (defaults to latest version)
+  def content_diff
+    #(current_content_md:, subset: 'all', version: nil)
+    # code
   end
 
   private

--- a/app/services/moab_storage_service.rb
+++ b/app/services/moab_storage_service.rb
@@ -2,8 +2,23 @@
 
 # Responsibility: interactions with Moab storage to support read-only access for ReST API calls
 class MoabStorageService
+  # @return an XML file representing [Moab::FileInventoryDifference]
+  #   from comparison of passed contentMetadata.xml with latest (or specified) version in Moab,
+  #   for all files (default) or a specified subset (shelve|preserve|publish)
+  # @raise ArgumentError or Moab::MoabRuntimeError as appropriate
+  # @param [String] druid
+  # @param [String] contentMetadata.xml to be compared against a version already in the Moab
+  # @param [String] subset (default: 'all') which subset of files to compare (all|shelve|preserve|publish)
+  # @param [Integer, nil] version of Moab to be compared against (defaults to latest version)
+  def self.content_diff(druid, content_md, subset='all', version=nil)
+    raise(ArgumentError, "No contentMetadata provided to MoabStorageService.content_diff for druid #{druid}") if content_md.blank?
+    err_msg = "subset arg must be 'all', 'shelve', 'preserve', or 'publish' (MoabStorageService.content_diff for druid #{druid})"
+    raise(ArgumentError, err_msg) unless ['all', 'shelve', 'preserve', 'publish'].include?(subset)
+    Stanford::StorageServices.compare_cm_to_version(content_md, druid, subset, version)
+  end
+
   # @return [Pathname] Pathname object containing the full path for the specified file
-  #  raises ArgumentError or Moab::MoabRuntimeError as appropriate
+  # @raise ArgumentError or Moab::MoabRuntimeError as appropriate
   # @param [String] druid
   # @param [String] category category of desired file ('content', 'metadata', or 'manifest')
   # @param [String] filename name of the file (path relative to base directory)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     member do
       get 'checksum'
       get 'file', format: false # no need to add extension to url
+      post 'content_diff'
     end
     collection do
       match 'checksums', via: %i[get post]

--- a/spec/requests/objects_controller_checksums_spec.rb
+++ b/spec/requests/objects_controller_checksums_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe ObjectsController, type: :request do
   let(:prefixed_druid2) { 'druid:bz514sm9647' }
   let(:bare_druid) { 'bj102hs9687' }
   let(:bare_druid2) { 'bz514sm9647' }
-  let(:pres_obj) { create(:preserved_object) }
 
   describe 'GET #checksum' do
     context 'when object found' do

--- a/spec/requests/objects_controller_content_diff_spec.rb
+++ b/spec/requests/objects_controller_content_diff_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ObjectsController, type: :request do
+  let(:prefixed_druid) { 'druid:bj102hs9687' }
+  let(:bare_druid) { 'bj102hs9687' }
+  let(:content_md) { '<contentMetadata>yer stuff here</contentMetadata>' }
+
+  describe 'POST #content_diff' do
+    context 'when object exists' do
+      context 'when druid is prefixed' do
+        it 'returns the Moab::FileInventoryDifference as xml' do
+          post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md }
+          expect(response).to have_http_status(:ok)
+          result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
+          expect(result.object_id).to eq 'bj102hs9687'
+          expect(result.basis).to eq 'v3-contentMetadata-all'
+        end
+      end
+
+      context 'when druid is bare' do
+        it 'returns the Moab::FileInventoryDifference as xml' do
+          post content_diff_object_url(id: bare_druid), params: { content_metadata: content_md }
+          expect(response).to have_http_status(:ok)
+          result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
+          expect(result.object_id).to eq 'bj102hs9687'
+          expect(result.basis).to eq 'v3-contentMetadata-all'
+        end
+      end
+
+      context 'when version specified' do
+        it 'returns correct Moab::FileInventoryDifference data' do
+          post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md, version: '1' }
+          expect(response).to have_http_status(:ok)
+          result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
+          expect(result.object_id).to eq 'bj102hs9687'
+          expect(result.basis).to eq 'v1-contentMetadata-all'
+        end
+
+        context 'when version is too high' do
+          it 'returns 500 response code with details' do
+            post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md, version: '666' }
+            expect(response).to have_http_status(:internal_server_error)
+            expect(response.body).to eq '500 Unable to get content diff: Version ID 666 does not exist'
+          end
+        end
+
+        context 'when version param is not digits only' do
+          it 'returns 400 response code with details' do
+            post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md, version: 'v3' }
+            expect(response).to have_http_status(:bad_request)
+            expect(response.body).to eq '400 Bad Request: version parameter must be positive integer'
+          end
+        end
+      end
+
+      context 'when ArgumentError from MoabStorageService' do
+        it 'returns 400 response code with details' do
+          post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md, subset: 'unrecognized' }
+          expect(response).to have_http_status(:bad_request)
+          m = "400 Bad Request: subset arg must be 'all', 'shelve', 'preserve', or 'publish' (MoabStorageService.content_diff for druid bj102hs9687)"
+          expect(response.body).to eq m
+        end
+      end
+
+      context 'when MoabRuntimeError from MoabStorageService' do
+        it 'returns 500 response code; body has additional information' do
+          emsg = 'my error'
+          allow(Stanford::StorageServices).to receive(:compare_cm_to_version)
+            .with(content_md, bare_druid, 'all', nil)
+            .and_raise(Moab::MoabRuntimeError, emsg)
+          post content_diff_object_url(id: bare_druid), params: { content_metadata: content_md }
+          expect(response).to have_http_status(:internal_server_error)
+          expect(response.body).to eq '500 Unable to get content diff: my error'
+        end
+      end
+    end
+
+    context 'when object does not exist' do
+      it 'returns an empty Moab::FileInventoryDifference as xml' do
+        post content_diff_object_url(id: 'druid:xx123yy9999'), params: { content_metadata: content_md }
+        expect(response).to have_http_status(:ok)
+        result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
+        expect(result.object_id).to eq 'xx123yy9999'
+        expect(result.difference_count).to eq '0'
+      end
+    end
+
+    context 'when no id param' do
+      context 'when id param is empty' do
+        it "will raise RoutingError" do
+          expect do
+            post content_diff_object_url(id: '')
+          end.to raise_error(ActionController::RoutingError)
+        end
+      end
+
+      context "when id param missing" do
+        it 'Rails will raise error and do the right thing' do
+          expect do
+            post content_diff_object_url({})
+          end.to raise_error(ActionController::UrlGenerationError)
+        end
+      end
+    end
+
+    context 'when druid invalid' do
+      it 'returns 500 response code with "Identifier has invalid suri syntax"' do
+        post content_diff_object_url(id: 'foobar'), params: { content_metadata: content_md, subset: 'all' }
+        expect(response).to have_http_status(:internal_server_error)
+        expect(response.body).to eq '500 Unable to get content diff: Identifier has invalid suri syntax: foobar'
+      end
+    end
+  end
+end

--- a/spec/requests/objects_controller_file_spec.rb
+++ b/spec/requests/objects_controller_file_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe ObjectsController, type: :request do
   let(:prefixed_druid) { 'druid:bj102hs9687' }
   let(:bare_druid) { 'bj102hs9687' }
-  let(:pres_obj) { create(:preserved_object) }
 
   describe 'GET #file' do
     context 'when object exists' do

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -3,17 +3,39 @@
 require 'rails_helper'
 
 RSpec.describe 'routes', type: :routing do
+  let(:id) { 'druid:ab123cd4567' }
+
+  describe 'objects/:id' do
+    it 'object_path' do
+      expect(get: object_path(id: id)).to route_to(controller: 'objects', action: 'show', id: id)
+    end
+  end
+
   describe 'objects/:id/file' do
     it 'file_object_path' do
-      druid = 'druid:ab123cd4567'
-      expect(get: file_object_path(id: druid)).to route_to(controller: 'objects', action: 'file', id: druid)
+      expect(get: file_object_path(id: id)).to route_to(controller: 'objects', action: 'file', id: id)
     end
   end
 
   describe 'objects/:id/checksum' do
     it 'checksum_object_path' do
-      druid = 'druid:ab123cd4567'
-      expect(get: checksum_object_path(id: druid)).to route_to(controller: 'objects', action: 'checksum', id: druid)
+      expect(get: checksum_object_path(id: id)).to route_to(controller: 'objects', action: 'checksum', id: id)
+    end
+  end
+
+  describe 'objects/checksums' do
+    it 'GET checksums_objects_path' do
+      expect(get: checksums_objects_path).to route_to(controller: 'objects', action: 'checksums')
+    end
+
+    it 'POST checksums_objects_path' do
+      expect(post: checksums_objects_path).to route_to(controller: 'objects', action: 'checksums')
+    end
+  end
+
+  describe 'objects/:id/content_diff' do
+    it 'content_diff_object_path' do
+      expect(post: content_diff_object_path(id: id)).to route_to(controller: 'objects', action: 'content_diff', id: id)
     end
   end
 end

--- a/spec/services/moab_storage_service_spec.rb
+++ b/spec/services/moab_storage_service_spec.rb
@@ -5,6 +5,128 @@ require 'rails_helper'
 RSpec.describe MoabStorageService do
   let(:druid) { 'jj925bx9565' }
 
+  describe '.content_diff' do
+    let(:subset) { 'all' }
+    let(:version) { nil }
+    let(:content_md) { '<contentMetadata>yer stuff here</contentMetadata>' }
+    let(:result) { Stanford::StorageServices.compare_cm_to_version(content_md, druid, 'all', 1) }
+
+    it 'calls Stanford::StorageServices.compare_cm_to_version' do
+      allow(Stanford::StorageServices).to receive(:compare_cm_to_version).with(content_md, druid, 'all', version).and_return(result)
+      expect(described_class.content_diff(druid, content_md)).to eq result
+      expect(Stanford::StorageServices).to have_received(:compare_cm_to_version).with(content_md, druid, 'all', nil)
+    end
+
+    context 'when moab-versioning gem raises error' do
+      it 'passes along error' do
+        emsg = 'my error'
+        allow(Stanford::StorageServices).to receive(:compare_cm_to_version)
+          .with(content_md, druid, 'all', version)
+          .and_raise(Moab::InvalidMetadataException, emsg)
+        expect { described_class.content_diff(druid, content_md) }.to raise_error(Moab::InvalidMetadataException, emsg)
+      end
+    end
+
+    context 'content_md param' do
+      let(:err_msg) { "No contentMetadata provided to MoabStorageService.content_diff for druid jj925bx9565" }
+
+      context 'when missing' do
+        it 'raises ArgumentError' do
+          expect { described_class.content_diff(druid, nil) }.to raise_error(ArgumentError, err_msg)
+        end
+      end
+
+      context 'when empty' do
+        it 'raises ArgumentError' do
+          expect { described_class.content_diff(druid, '') }.to raise_error(ArgumentError, err_msg)
+        end
+      end
+    end
+
+    context 'subset param' do
+      let(:err_msg) { "subset arg must be 'all', 'shelve', 'preserve', or 'publish' (MoabStorageService.content_diff for druid jj925bx9565)" }
+
+      before do
+        allow(Stanford::StorageServices).to receive(:compare_cm_to_version).with(content_md, druid, subset, version).and_return(result)
+      end
+
+      context 'when all' do
+        let(:subset) { 'all' }
+
+        it 'returns the requested filepath' do
+          expect(described_class.content_diff(druid, content_md, subset)).to eq result
+        end
+      end
+
+      context 'when shelve' do
+        let(:subset) { 'shelve' }
+
+        it 'returns the requested filepath' do
+          expect(described_class.content_diff(druid, content_md, subset)).to eq result
+        end
+      end
+
+      context 'when preserve' do
+        let(:subset) { 'preserve' }
+
+        it 'returns the requested filepath' do
+          expect(described_class.content_diff(druid, content_md, subset)).to eq result
+        end
+      end
+
+      context 'when publish' do
+        let(:subset) { 'publish' }
+
+        it 'returns the requested filepath' do
+          expect(described_class.content_diff(druid, content_md, subset)).to eq result
+        end
+      end
+
+      context 'when unrecognized value' do
+        let(:subset) { 'unrecognized' }
+
+        it 'raises ArgumentError' do
+          expect { described_class.content_diff(druid, content_md, subset) }.to raise_error(ArgumentError, err_msg)
+        end
+      end
+
+      context 'when explicitly set to nil' do
+        it 'raises ArgumentError' do
+          expect { described_class.content_diff(druid, content_md, nil) }.to raise_error(ArgumentError, err_msg)
+        end
+      end
+    end
+
+    context 'version param' do
+      context 'when specified correctly' do
+        it 'returns the requested FileInventoryDifference' do
+          expect(described_class.content_diff(druid, content_md, subset, 1)).to be_an_instance_of Moab::FileInventoryDifference
+        end
+      end
+
+      context 'when not a positive integer value' do
+        it 'raises Moab::MoabRuntimeError' do
+          err_msg = 'Version ID v3 does not exist'
+          expect { described_class.content_diff(druid, content_md, subset, 'v3') }.to raise_error(Moab::MoabRuntimeError, err_msg)
+        end
+      end
+
+      context 'when too high a version' do
+        it 'raises Moab::MoabRuntimeError' do
+          err_msg = 'Version ID 666 does not exist'
+          expect { described_class.content_diff(druid, content_md, subset, 666) }.to raise_error(Moab::MoabRuntimeError, err_msg)
+        end
+      end
+
+      context 'when missing' do
+        it 'uses the most recent version and returns the requested FileInventoryDifference' do
+          # FIXME: this is not checking for most recent version!
+          expect(described_class.content_diff(druid, content_md)).to be_an_instance_of Moab::FileInventoryDifference
+        end
+      end
+    end
+  end
+
   describe '.filepath' do
     let(:category) { '' }
     let(:fname) { 'foo' }


### PR DESCRIPTION
## Why was this change made?

To replace `cm-inv-diff` endpoint in sdr-services-app.  There will be a `content_diff` method in preservation-client to be used instead of dor-services-app calling sdr-services-app.

Some small refactors added:
- renamed a private method in objects_controller to make the code clearer
- removed unnec lines from request specs
- tweaked a few method comments

Also added more routing specs.  (because I'm compulsive?)

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

issue #1243 exists for documenting endpoints;  it will be part of the work of the last 2 weeks of December - it's a great one for learning more about preservation.