### PR TITLE
Uses global id to construct lock key.

### DIFF
--- a/app/jobs/druid_version_job_base.rb
+++ b/app/jobs/druid_version_job_base.rb
@@ -11,7 +11,7 @@ class DruidVersionJobBase < ApplicationJob
 
   # Does queue locking on ONLY druid and version (as first and second parameters)
   def lock(*args)
-    "lock:#{name}-#{args.slice(0..1)}"
+    "lock:#{self.class.name}-#{args.slice(0..1)}"
   end
 
   # A Job subclass must implement this method:

--- a/app/jobs/plexer_job.rb
+++ b/app/jobs/plexer_job.rb
@@ -18,7 +18,9 @@
 class PlexerJob < ZipPartJobBase
   queue_as :zips_made
 
-  before_enqueue { |job| job.zip_info_check!(job.arguments.fourth) }
+  before_enqueue do |job|
+    job.zip_info_check!(job.arguments.fourth)
+  end
 
   # @param [String] druid
   # @param [Integer] version

--- a/app/jobs/zip_part_job_base.rb
+++ b/app/jobs/zip_part_job_base.rb
@@ -11,7 +11,7 @@ class ZipPartJobBase < DruidVersionJobBase
 
   # Does queue locking on ONLY druid, version and part (as first 3 parameters)
   def lock(*args)
-    "lock:#{name}-#{args.slice(0..2)}"
+    "lock:#{self.class.name}-#{args.slice(0..2)}"
   end
 
   # A Job subclass must implement this method:

--- a/spec/jobs/plexer_job_spec.rb
+++ b/spec/jobs/plexer_job_spec.rb
@@ -25,9 +25,12 @@ describe PlexerJob, type: :job do
     expect(job).to be_an(ZipPartJobBase)
   end
 
-  it 'raises without enqueueing if metadata is incomplete' do
+  it 'raises without enqueueing if size metadata is incomplete' do
     expect { described_class.perform_later(druid, version, 'part_key', metadata.merge(size: nil)) }
       .to raise_error(ArgumentError, /size/)
+  end
+
+  it 'raises without enqueueing if zip_cmd metadata is incomplete' do
     expect { described_class.perform_later(druid, version, 'part_key', metadata.reject { |x| x == :zip_cmd }) }
       .to raise_error(ArgumentError, /zip_cmd/)
   end


### PR DESCRIPTION
refs #1087

## Why was this change made?
To eliminate one possibility for why locks are not being deleted from Redis, viz., objects are changing between a lock being created and the lock being deleted, resulting in the lock key also changing and therefore not being found to delete.

Note that this is at least one logical possibility for the problem. We won't know for sure until this is actually run in prod.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
