### PR TITLE
WorkflowReporter: loosen regex trapping for non-existent workfl…

### DIFF
--- a/app/services/workflow_reporter.rb
+++ b/app/services/workflow_reporter.rb
@@ -5,7 +5,7 @@ class WorkflowReporter
   PRESERVATIONAUDITWF = 'preservationAuditWF'
   NO_WORKFLOW_HOOKUP = 'no workflow hookup - assume you are in test or dev environment'
   COMPLETED = 'completed'
-  MISSING_WF_REGEX = /^Failed .*#{Settings.workflow_services_url}.*preservationAuditWF.* (HTTP status 404)/.freeze
+  MISSING_WF_REGEX = /Failed .*#{Settings.workflow_services_url}.*preservationAuditWF.* (HTTP status 404)/.freeze
 
   # this method will always return true because of the dor-workflow-service gem
   # see issue sul-dlss/dor-workflow-service#50 for more context


### PR DESCRIPTION
## Why was this change made?

Honeybadger is still catching non-existent WF exceptions for audit workflows (https://app.honeybadger.io/projects/54415/faults/55926196).  This loosens the regex to hopefully catch all of them.

NOTE:
- A better fix: https://github.com/sul-dlss/workflow-server-rails/issues/297 -- throw a unique exception for this problem so trapping for this case isn't so twitchy.
- The best fix: skip ahead and do https://github.com/sul-dlss/preservation_catalog/issues/1249 (report audit errors at prescat endpoint)

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a