### PR TITLE
Uses global id to construct lock key.

### DIFF
--- a/app/jobs/druid_version_job_base.rb
+++ b/app/jobs/druid_version_job_base.rb
@@ -10,7 +10,7 @@ class DruidVersionJobBase < ApplicationJob
   end
 
   # Does queue locking on ONLY druid and version (as first and second parameters)
-  def lock(*args)
+  def self.lock(*args)
     "lock:#{name}-#{args.slice(0..1)}"
   end
 

--- a/app/jobs/zip_part_job_base.rb
+++ b/app/jobs/zip_part_job_base.rb
@@ -10,7 +10,7 @@ class ZipPartJobBase < DruidVersionJobBase
   end
 
   # Does queue locking on ONLY druid, version and part (as first 3 parameters)
-  def lock(*args)
+  def self.lock(*args)
     "lock:#{name}-#{args.slice(0..2)}"
   end
 

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -32,4 +32,29 @@ describe ApplicationJob, type: :job do
         .to change { Resque.info[:pending] }.from(2).to(3)
     end
   end
+
+  context 'a subclass that has an ActiveRecord parameter with message(s) queued' do
+    let(:cm) { create :complete_moab }
+
+    before do
+      allow(CatalogToMoabJob).to receive(:perform_later).and_call_original # undo rails_helper block
+      CatalogToMoabJob.perform_later(cm, 'foo')
+    end
+
+    it 'does not add duplicate messages' do
+      expect { CatalogToMoabJob.perform_later(cm, 'foo') }
+        .not_to change { Resque.info[:pending] }.from(1)
+
+      # Change complete_moab
+      cm.size = 1000
+
+      expect { CatalogToMoabJob.perform_later(cm, 'foo') }
+        .not_to change { Resque.info[:pending] }.from(1)
+    end
+
+    it 'but adds novel messages' do
+      expect { CatalogToMoabJob.perform_later(cm, 'bar') }
+        .to change { Resque.info[:pending] }.from(1).to(2)
+    end
+  end
 end

--- a/spec/jobs/plexer_job_spec.rb
+++ b/spec/jobs/plexer_job_spec.rb
@@ -25,9 +25,12 @@ describe PlexerJob, type: :job do
     expect(job).to be_an(ZipPartJobBase)
   end
 
-  it 'raises without enqueueing if metadata is incomplete' do
+  it 'raises without enqueueing if size metadata is incomplete' do
     expect { described_class.perform_later(druid, version, 'part_key', metadata.merge(size: nil)) }
       .to raise_error(ArgumentError, /size/)
+  end
+
+  it 'raises without enqueueing if zip_cmd metadata is incomplete' do
     expect { described_class.perform_later(druid, version, 'part_key', metadata.reject { |x| x == :zip_cmd }) }
       .to raise_error(ArgumentError, /zip_cmd/)
   end


### PR DESCRIPTION
refs #1087

## Why was this change made?
To eliminate one possibility for why locks are not being deleted from Redis, viz., objects are changing between a lock being created and the lock being deleted, resulting in the lock key also changing and therefore not being found to delete.

Note that this is at least one logical possibility for the problem. We won't know for sure until this is actually run in prod.

This is a replacement for #1254.