### PR TITLE
Create missing preservationAuditWF

### DIFF
--- a/app/services/workflow_reporter.rb
+++ b/app/services/workflow_reporter.rb
@@ -5,7 +5,7 @@ class WorkflowReporter
   PRESERVATIONAUDITWF = 'preservationAuditWF'
   NO_WORKFLOW_HOOKUP = 'no workflow hookup - assume you are in test or dev environment'
   COMPLETED = 'completed'
-  MISSING_WF_REGEX = /Failed .*#{Settings.workflow_services_url}.*preservationAuditWF.* (HTTP status 404)/.freeze
+  MISSING_WF_REGEX = /Failed .*#{Settings.workflow_services_url}.*preservationAuditWF.* \(HTTP status 404\)/.freeze
 
   # this method will always return true because of the dor-workflow-service gem
   # see issue sul-dlss/dor-workflow-service#50 for more context
@@ -38,7 +38,7 @@ class WorkflowReporter
     raise unless e.message.match?(MISSING_WF_REGEX)
 
     create_wf(druid, version)
-    report_completed(druid, process_name, error_message)
+    report_completed(druid, version, process_name)
   end
 
   def self.create_wf(druid, version)


### PR DESCRIPTION
Fixes #1258

## Why was this change made?

The implementation was never matching the exception message due to unescaped parentheses in the regex. Fix that, and change the test to make it fail without the `WorkflowReporter::MISSING_WF_REGEX` change.

Also, fix another bug where the second call to `WorkflowReporter.report_completed` was 1) not sending the `version` argument, and 2) sending an undefined `error_message` argument (copy-pasta). I suspect this bug was being hidden by the funky test setup.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

no