### PR TITLE
Rescue the missing workflow exception to autocreate `preservationAuditWF`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.2)
-    dor-workflow-client (3.11.1)
+    dor-workflow-client (3.13.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)

--- a/app/services/workflow_reporter.rb
+++ b/app/services/workflow_reporter.rb
@@ -5,7 +5,6 @@ class WorkflowReporter
   PRESERVATIONAUDITWF = 'preservationAuditWF'
   NO_WORKFLOW_HOOKUP = 'no workflow hookup - assume you are in test or dev environment'
   COMPLETED = 'completed'
-  MISSING_WF_REGEX = /Failed .*#{Settings.workflow_services_url}.*preservationAuditWF.* \(HTTP status 404\)/.freeze
 
   # this method will always return true because of the dor-workflow-service gem
   # see issue sul-dlss/dor-workflow-service#50 for more context
@@ -18,9 +17,7 @@ class WorkflowReporter
     else
       Rails.logger.warn(NO_WORKFLOW_HOOKUP)
     end
-  rescue Dor::WorkflowException => e
-    raise unless e.message.match?(MISSING_WF_REGEX)
-
+  rescue Dor::MissingWorkflowException
     create_wf(druid, version)
     report_error(druid, version, process_name, error_message)
   end
@@ -34,9 +31,7 @@ class WorkflowReporter
     else
       Rails.logger.warn(NO_WORKFLOW_HOOKUP)
     end
-  rescue Dor::WorkflowException => e
-    raise unless e.message.match?(MISSING_WF_REGEX)
-
+  rescue Dor::MissingWorkflowException
     create_wf(druid, version)
     report_completed(druid, version, process_name)
   end

--- a/spec/services/workflow_reporter_spec.rb
+++ b/spec/services/workflow_reporter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe WorkflowReporter do
         call_count = 0
         allow(stub_wf_client).to receive(:update_error_status) do
           call_count += 1
-          call_count == 1 ? raise(Dor::WorkflowException, err_msg) : nil
+          call_count == 1 ? raise(Dor::MissingWorkflowException, err_msg) : nil
         end
       end
 
@@ -80,7 +80,7 @@ RSpec.describe WorkflowReporter do
         call_count = 0
         allow(stub_wf_client).to receive(:update_status) do
           call_count += 1
-          call_count == 1 ? raise(Dor::WorkflowException, err_msg) : nil
+          call_count == 1 ? raise(Dor::MissingWorkflowException, err_msg) : nil
         end
       end
 


### PR DESCRIPTION
Fixes dor-workflow-client#139

## Why was this change made?

This keys off the class of the exception raised by dor-workflow-client instead of comparing the exception message to a regex. We only care about exceptions related to missing workflows. As of dor-workflow-client 3.13.0, a new custom exception class is raised when there is a missing workflow.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

no