### PR TITLE
Trap for `Errno::ENOENT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,12 +229,12 @@ In console, start by finding the storage root.
 
 ```ruby
 msr = MoabStorageRoot.find_by!(name: name)
-MoabToCatalog.seed_catalog_for_dir(msr.storage_location)
+Audit::MoabToCatalog.seed_catalog_for_dir(msr.storage_location)
 ```
 
 Or for all roots:
 ```ruby
-MoabStorageRoot.find_each { |msr| MoabToCatalog.seed_catalog_for_dir(msr.storage_location) }
+MoabStorageRoot.find_each { |msr| Audit::MoabToCatalog.seed_catalog_for_dir(msr.storage_location) }
 ```
 
 ## Development
@@ -285,4 +285,3 @@ bundle exec cap prod deploy # for the prod servers
 
 ### Resque Pool
 The Resque Pool admin interface is available at `<hostname>/resque/overview`.
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,5 @@
 version: '3.6'
 
-volumes:
-  redis:
-
 services:
   db:
     image: postgres
@@ -11,7 +8,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=sekret
     volumes:
-      - ./postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
   redis:
     image: redis:3
     command: redis-server
@@ -19,3 +16,7 @@ services:
       - 6379:6379
     volumes:
         - redis:/data
+
+volumes:
+  redis:
+  postgres-data:


### PR DESCRIPTION
Fixes #1184

## Why was this change made?

* Trap for `Errno::ENOENT` on first call to `moab_validation_errors`
* When the trap triggers, add a `MOAB_NOT_FOUND` result and update the status to `online_moab_not_found`

Also includes opportunistic bits:
* Prefer appending arrays of values to iterating and shoveling in `MoabValidationHandler`
* Use docker-mounted volume for postgres-data instead of local folder
  * Prevents permissions errors when starting up containers
  * We do this in our other projects as well. See also: sul-dlss/dor-services-app#436 
* Fix README by adding the needed namespaces.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

Yes, README fixes.