### PR TITLE
Remove an unused initialization argument from `Audit::CatalogToMoab`

### DIFF
--- a/app/jobs/catalog_to_moab_job.rb
+++ b/app/jobs/catalog_to_moab_job.rb
@@ -10,9 +10,8 @@ class CatalogToMoabJob < ApplicationJob
   end
 
   # @param [CompleteMoab] complete_moab object to C2M check
-  # @param [String] storage_dir
   # @see Audit::CatalogToMoab#initialize
-  def perform(complete_moab, storage_dir)
-    Audit::CatalogToMoab.new(complete_moab, storage_dir).check_catalog_version
+  def perform(complete_moab)
+    Audit::CatalogToMoab.new(complete_moab).check_catalog_version
   end
 end

--- a/app/lib/audit/catalog_to_moab.rb
+++ b/app/lib/audit/catalog_to_moab.rb
@@ -4,11 +4,10 @@ module Audit
   # Catalog to Moab existence check code
   class CatalogToMoab
     include ::MoabValidationHandler
-    attr_reader :complete_moab, :storage_dir, :druid, :results
+    attr_reader :complete_moab, :druid, :results
 
-    def initialize(complete_moab, storage_dir)
+    def initialize(complete_moab)
       @complete_moab = complete_moab
-      @storage_dir = storage_dir
       @druid = complete_moab.preserved_object.druid
       @results = AuditResults.new(druid, nil, complete_moab.moab_storage_root)
     end
@@ -45,9 +44,11 @@ module Audit
       compare_version_and_take_action
     end
 
-    alias storage_location storage_dir
-
     private
+
+    def storage_location
+      complete_moab.moab_storage_root.storage_location
+    end
 
     def online_moab_found?
       return true if moab

--- a/app/models/moab_storage_root.rb
+++ b/app/models/moab_storage_root.rb
@@ -19,7 +19,7 @@ class MoabStorageRoot < ApplicationRecord
   # Use a queue to check all associated CompleteMoab objects for C2M
   def c2m_check!(last_checked_b4_date = Time.current)
     complete_moabs.least_recent_version_audit(last_checked_b4_date).find_each do |cm|
-      CatalogToMoabJob.perform_later(cm, storage_location)
+      CatalogToMoabJob.perform_later(cm)
     end
   end
 

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -35,25 +35,26 @@ describe ApplicationJob, type: :job do
 
   context 'a subclass that has an ActiveRecord parameter with message(s) queued' do
     let(:cm) { create :complete_moab }
+    let(:cm2) { create :complete_moab }
 
     before do
       allow(CatalogToMoabJob).to receive(:perform_later).and_call_original # undo rails_helper block
-      CatalogToMoabJob.perform_later(cm, 'foo')
+      CatalogToMoabJob.perform_later(cm)
     end
 
     it 'does not add duplicate messages' do
-      expect { CatalogToMoabJob.perform_later(cm, 'foo') }
+      expect { CatalogToMoabJob.perform_later(cm) }
         .not_to change { Resque.info[:pending] }.from(1)
 
       # Change complete_moab
       cm.size = 1000
 
-      expect { CatalogToMoabJob.perform_later(cm, 'foo') }
+      expect { CatalogToMoabJob.perform_later(cm) }
         .not_to change { Resque.info[:pending] }.from(1)
     end
 
     it 'but adds novel messages' do
-      expect { CatalogToMoabJob.perform_later(cm, 'bar') }
+      expect { CatalogToMoabJob.perform_later(cm2) }
         .to change { Resque.info[:pending] }.from(1).to(2)
     end
   end

--- a/spec/jobs/catalog_to_moab_job_spec.rb
+++ b/spec/jobs/catalog_to_moab_job_spec.rb
@@ -5,15 +5,14 @@ require 'rails_helper'
 describe CatalogToMoabJob, type: :job do
   let(:job) { described_class.new(cm) }
   let(:cm) { create :complete_moab }
-  let(:storage_dir) { 'foobar' }
 
   describe '#perform' do
     let(:validator) { instance_double(Audit::CatalogToMoab) }
 
     it 'calls Audit::CatalogToMoab#check_catalog_version' do
       expect(validator).to receive(:check_catalog_version)
-      expect(Audit::CatalogToMoab).to receive(:new).with(cm, storage_dir).and_return(validator)
-      job.perform(cm, storage_dir)
+      expect(Audit::CatalogToMoab).to receive(:new).with(cm).and_return(validator)
+      job.perform(cm)
     end
   end
 end

--- a/spec/lib/audit/catalog_to_moab_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Audit::CatalogToMoab do
       c2m.check_catalog_version
     end
 
-    it 'calls online_moab_found?(druid, storage_location)' do
+    it 'calls online_moab_found?' do
       expect(c2m).to receive(:online_moab_found?)
       c2m.check_catalog_version
     end

--- a/spec/lib/audit/catalog_to_moab_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Audit::CatalogToMoab do
   let(:last_checked_version_b4_date) { (Time.now.utc - 1.day).iso8601 }
-  let(:storage_dir) { 'spec/fixtures/storage_root01/sdr2objects' }
+  let(:storage_location) { 'spec/fixtures/storage_root01/sdr2objects' }
   let(:druid) { 'bj102hs9687' }
-  let(:c2m) { described_class.new(comp_moab, storage_dir) }
+  let(:c2m) { described_class.new(comp_moab) }
   let(:mock_sov) { instance_double(Stanford::StorageObjectValidator) }
   let(:po) { create(:preserved_object_fixture, druid: druid) }
   let(:comp_moab) do
-    MoabStorageRoot.find_by!(storage_location: storage_dir).complete_moabs.find_by!(preserved_object: po)
+    MoabStorageRoot.find_by!(storage_location: storage_location).complete_moabs.find_by!(preserved_object: po)
   end
   let(:logger_double) { instance_double(Logger, info: nil, error: nil, add: nil) }
   let(:results_double) do
@@ -25,7 +25,6 @@ RSpec.describe Audit::CatalogToMoab do
   describe '#initialize' do
     it 'sets attributes' do
       expect(c2m.complete_moab).to eq comp_moab
-      expect(c2m.storage_dir).to eq storage_dir
       expect(c2m.druid).to eq druid
       expect(c2m.results).to be_an_instance_of AuditResults
     end
@@ -39,11 +38,11 @@ RSpec.describe Audit::CatalogToMoab do
   end
 
   describe '#check_catalog_version' do
-    let(:object_dir) { "#{storage_dir}/#{DruidTools::Druid.new(druid).tree.join('/')}" }
+    let(:object_dir) { "#{storage_location}/#{DruidTools::Druid.new(druid).tree.join('/')}" }
 
     before { comp_moab.ok! }
 
-    it 'instantiates Moab::StorageObject from druid and storage_dir' do
+    it 'instantiates Moab::StorageObject from druid and storage_location' do
       expect(Moab::StorageObject).to receive(:new).with(druid, a_string_matching(object_dir)).and_call_original
       c2m.check_catalog_version
     end
@@ -71,7 +70,7 @@ RSpec.describe Audit::CatalogToMoab do
       c2m.check_catalog_version
     end
 
-    it 'calls online_moab_found?(druid, storage_dir)' do
+    it 'calls online_moab_found?(druid, storage_location)' do
       expect(c2m).to receive(:online_moab_found?)
       c2m.check_catalog_version
     end

--- a/spec/models/moab_storage_root_spec.rb
+++ b/spec/models/moab_storage_root_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe MoabStorageRoot, type: :model do
 
     describe '#c2m_check!' do
       it 'calls CatalogToMoabJob for each eligible CompleteMoab' do
-        expect(CatalogToMoabJob).to receive(:perform_later).with(msr.complete_moabs.first, msr.storage_location)
-        expect(CatalogToMoabJob).to receive(:perform_later).with(msr.complete_moabs.second, msr.storage_location)
+        expect(CatalogToMoabJob).to receive(:perform_later).with(msr.complete_moabs.first)
+        expect(CatalogToMoabJob).to receive(:perform_later).with(msr.complete_moabs.second)
         msr.c2m_check!
       end
     end


### PR DESCRIPTION
## Why was this change made?

I am not sure why this argument was there and not used when the storage location can be grabbed from the `CompleteMoab`. Possibly used to be used for dependency injection or testing? Instead, grab the storage location from the `CompleteMoab` since we no longer appear to be using this arg which is mostly getting in the way.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

no