### PR TITLE
remove storage_location, since it doesn't appear to be used at all by…

### DIFF
--- a/app/lib/audit/catalog_to_moab.rb
+++ b/app/lib/audit/catalog_to_moab.rb
@@ -46,10 +46,6 @@ module Audit
 
     private
 
-    def storage_location
-      complete_moab.moab_storage_root.storage_location
-    end
-
     def online_moab_found?
       return true if moab
       false


### PR DESCRIPTION
touchup to @mjgiarlo's #1263, fully removing `CatalogToMoab#storage_location`, which doesn't appear to be used anymore.