### PR TITLE
Add /v1-scoped routes and redirect old URLs to new ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,11 +288,14 @@ bundle exec cap prod deploy # for the prod servers
 The Resque Pool admin interface is available at `<hostname>/resque/overview`.
 
 ## API
-### `GET /objects/:druid`
+
+### V1
+
+#### `GET /v1/objects/:druid`
 Return the PreservedObject model for the object.
 
 ```
-curl https://preservation-catalog-prod-01.stanford.edu/objects/druid:bb000kg4251
+curl https://preservation-catalog-prod-01.stanford.edu/v1/objects/druid:bb000kg4251
 {
   "id": 1786188,
   "druid": "bb000kg4251",
@@ -301,9 +304,9 @@ curl https://preservation-catalog-prod-01.stanford.edu/objects/druid:bb000kg4251
   "updated_at": "2019-06-26T18:38:03.077Z",
   "preservation_policy_id": 1
 }
-``` 
+```
 
-### `GET /objects/:druid/file?category=:category&filepath=:filepath&version=:version`
+#### `GET /v1/objects/:druid/file?category=:category&filepath=:filepath&version=:version`
 Returns a content, metadata, or manifest file for the object.
 
 Parameters:
@@ -312,7 +315,7 @@ Parameters:
 * version (optional, default: latest): version of Moab
 
 ```
-curl "https://preservation-catalog-prod-01.stanford.edu/objects/druid:bb000kg4251/file?category=manifest&filepath=signatureCatalog.xml&version=1"
+curl "https://preservation-catalog-prod-01.stanford.edu/v1/objects/druid:bb000kg4251/file?category=manifest&filepath=signatureCatalog.xml&version=1"
 <?xml version="1.0" encoding="UTF-8"?>
 <signatureCatalog objectId="druid:bb000kg4251" versionId="1" catalogDatetime="2019-06-26T18:38:02Z" fileCount="10" byteCount="1364250" blockCount="1337">
   <entry originalVersion="1" groupId="content" storagePath="bb000kg4251.jpg">
@@ -322,11 +325,11 @@ curl "https://preservation-catalog-prod-01.stanford.edu/objects/druid:bb000kg425
 </signatureCatalog>
 ```
 
-### `GET /objects/:druid/checksum`
+#### `GET /v1/objects/:druid/checksum`
 Return the checksums and filesize for a single object.
 
 ```
-curl https://preservation-catalog-prod-01.stanford.edu/objects/druid:bb000kg4251/checksum
+curl https://preservation-catalog-prod-01.stanford.edu/v1/objects/druid:bb000kg4251/checksum
 [
   {
     "filename": "bb000kg4251.jpg",
@@ -338,14 +341,14 @@ curl https://preservation-catalog-prod-01.stanford.edu/objects/druid:bb000kg4251
 ]
 ```
 
-### `GET|POST /objects/checksums?druids[]=:druid`
+#### `GET|POST /objects/checksums?druids[]=:druid`
 Return the checksums and filesize for multiple objects.
 
 Parameters:
 * druid[] (repeatable): druid for the object
 
 ```
-curl "https://preservation-catalog-prod-01.stanford.edu/objects/checksums?druids[]=druid:bb000kg4251&druids[]=druid:bb000kq3835"
+curl "https://preservation-catalog-prod-01.stanford.edu/v1/objects/checksums?druids[]=druid:bb000kg4251&druids[]=druid:bb000kq3835"
 [
   {
     "druid:bb000kg4251": [
@@ -372,7 +375,7 @@ curl "https://preservation-catalog-prod-01.stanford.edu/objects/checksums?druids
 ]
 ```
 
-### `POST /objects/:druid/content_diff`
+#### `POST /v1/objects/:druid/content_diff`
 Retrieves FileInventoryDifference model from comparison of passed contentMetadata.xml with latest (or specified) version in Moab for all files (default) or a specified subset.
 
 Parameters:
@@ -381,7 +384,7 @@ Parameters:
 * version (optional, default: latest): version of Moab
 
 ```
-curl -F 'content_metadata= 
+curl -F 'content_metadata=
 <?xml version="1.0"?>
 <contentMetadata objectId="bb000kg4251" type="image">
   <resource id="bb000kg4251_1" sequence="1" type="image">
@@ -397,7 +400,7 @@ curl -F 'content_metadata=
       <imageData width="3184" height="2205"/>
     </file>
   </resource>
-</contentMetadata>' https://preservation-catalog-prod-01.stanford.edu/objects/druid:bb000kg4251/content_diff
+</contentMetadata>' https://preservation-catalog-prod-01.stanford.edu/v1/objects/druid:bb000kg4251/content_diff
 
 <?xml version="1.0"?>
 <fileInventoryDifference objectId="bb000kg4251" differenceCount="0" basis="v1-contentMetadata-all" other="new-contentMetadata-all" reportDatetime="2019-12-12T20:20:30Z">
@@ -420,7 +423,7 @@ curl -F 'content_metadata=
 </fileInventoryDifference>
 ```
 
-### `POST /catalog`
+#### `POST /v1/catalog`
 Add an existing moab object to the catalog.
 
 Parameters:
@@ -437,7 +440,7 @@ Response codes:
 * 500: some other problem.
 
 ```
-curl -F 'druid=druid:bj102hs9688' -F 'incoming_version=3' -F 'incoming_size=2070039' -F 'storage_location=spec/fixtures/storage_root01' -F 'checksums_validated=true' https://preservation-catalog-stage-01.stanford.edu/catalog
+curl -F 'druid=druid:bj102hs9688' -F 'incoming_version=3' -F 'incoming_size=2070039' -F 'storage_location=spec/fixtures/storage_root01' -F 'checksums_validated=true' https://preservation-catalog-stage-01.stanford.edu/catalog/v1
 
 {
 	"druid": "bj102hs9688",
@@ -447,7 +450,7 @@ curl -F 'druid=druid:bj102hs9688' -F 'incoming_version=3' -F 'incoming_size=2070
 }
 ```
 
-### `PUT/PATCH /catalog/:druid`
+#### `PUT/PATCH /v1/catalog/:druid`
 Updating an existing record for a moab object in the catalog for a new version.
 
 Parameters:
@@ -464,7 +467,7 @@ Response codes:
 * 500: some other problem.
 
 ```
-curl -X PUT -F 'incoming_version=4' -F 'incoming_size=2136079' -F 'storage_location=spec/fixtures/storage_root01' -F 'checksums_validated=true' https://preservation-catalog-stage-01.stanford.edu/catalog/druid:bj102hs9688
+curl -X PUT -F 'incoming_version=4' -F 'incoming_size=2136079' -F 'storage_location=spec/fixtures/storage_root01' -F 'checksums_validated=true' https://preservation-catalog-stage-01.stanford.edu/v1/catalog/druid:bj102hs9688
 
 {
 	"druid": "bj102hs9688",

--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ The Resque Pool admin interface is available at `<hostname>/resque/overview`.
 
 ## API
 
+Note that the API is now versioned. Until all clients have been modified to use the V1 routes, requests to URIs without explicit versions -- *i.e.*, hitting /catalog instead of /v1/catalog -- will automatically be redirected to their V1 equivalents. After that point, only requests to explicitly versioned endpoints will be serviced.
+
 ### V1
 
 #### `GET /v1/objects/:druid`

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,7 +8,7 @@ class CatalogController < ApplicationController
 
   attr_accessor :poh
 
-  # POST /catalog
+  # POST /v1/catalog
   def create
     @poh = PreservedObjectHandler.new(bare_druid, incoming_version, incoming_size, moab_storage_root)
     poh.create(checksums_validated)
@@ -25,7 +25,7 @@ class CatalogController < ApplicationController
     render status: status_code, json: poh.results.to_json
   end
 
-  # PATCH /catalog/:id
+  # PATCH /v1/catalog/:id
   # User can only update a partial record (application controls what can be updated)
   def update
     @poh = PreservedObjectHandler.new(bare_druid, incoming_version, incoming_size, moab_storage_root)

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -7,13 +7,13 @@ require 'csv'
 #  (Note: methods will eventually be ported from sdr-services-app)
 class ObjectsController < ApplicationController
   # return the PreservedObject model for the druid (supplied with druid: prefix)
-  # GET /objects/:druid
+  # GET /v1/objects/:druid
   def show
     render json: PreservedObject.find_by!(druid: druid).to_json
   end
 
   # return a specific file from the Moab
-  # GET /objects/:druid/file?category=manifest&filepath=signatureCatalog.xml
+  # GET /v1/objects/:druid/file?category=manifest&filepath=signatureCatalog.xml
   # useful params:
   # - category (content|manifest|metadata)
   # - filepath path of file, relative to category directory
@@ -38,14 +38,14 @@ class ObjectsController < ApplicationController
   end
 
   # return the checksums and filesize for a single druid (supplied with druid: prefix)
-  # GET /objects/:druid/checksum
+  # GET /v1/objects/:druid/checksum
   def checksum
     render json: content_files_checksums(druid).to_json
   end
 
   # return the checksums and filesize for a list of druids (supplied with druid: prefix)
   # note: this is deliberately allowed to be a POST to allow for a large number of druids to be passed in
-  # GET OR POST /objects/checksums?druids[]=druid1&druids[]=druid2&druids[]=druid3
+  # GET OR POST /v1/objects/checksums?druids[]=druid1&druids[]=druid2&druids[]=druid3
   def checksums
     unless normalized_druids.present?
       render(plain: "400 bad request - druids param must be populated", status: :bad_request)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,21 +3,31 @@
 require 'resque/server'
 
 Rails.application.routes.draw do
-  resources :catalog, param: :druid, only: %i[create update]
+  mount Resque::Server.new,
+        at: '/resque',
+        constraints: ->(req) { Settings.resque_dashboard_hostnames.include?(req.host) }
 
-  resources :objects, only: %i[show] do
-    member do
-      get 'checksum'
-      get 'file', format: false # no need to add extension to url
-      post 'content_diff'
-    end
-    collection do
-      match 'checksums', via: %i[get post]
+  scope 'v1' do
+    resources :catalog, param: :druid, only: %i[create update]
+
+    resources :objects, only: %i[show] do
+      member do
+        get 'checksum'
+        get 'file', format: false # no need to add extension to url
+        post 'content_diff'
+      end
+      collection do
+        match 'checksums', via: %i[get post]
+      end
     end
   end
 
-  mount Resque::Server.new, at: '/resque',
-                            constraints: ->(req) { Settings.resque_dashboard_hostnames.include?(req.host) }
-
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  # TODO: Remove these when all clients are using the version-scoped routes above
+  post '/catalog', to: redirect('/v1/catalog')
+  match '/catalog/:druid', to: redirect('/v1/catalog/%{druid}'), via: %i[patch put]
+  get '/objects/:id/checksum', to: redirect('/v1/objects/%{id}/checksum')
+  get '/objects/:id/file', to: redirect('/v1/objects/%{id}/file')
+  post '/objects/:id/content_diff', to: redirect('/v1/objects/%{id}/content_diff')
+  match '/objects/checksums', to: redirect('/v1/objects/checksums'), via: %i[get post]
+  get '/objects/:id', to: redirect('/v1/objects/%{id}')
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -321,11 +321,4 @@ RSpec.describe CatalogController, type: :controller do
       end
     end
   end
-
-  describe 'Routing' do
-    let(:druid) { "xx000xx0000" }
-
-    it { is_expected.to route(:post, '/catalog').to(controller: :catalog, action: :create) }
-    it { is_expected.to route(:patch, "/catalog/#{druid}").to(controller: :catalog, action: :update, druid: druid) }
-  end
 end

--- a/spec/requests/catalog_controller_spec.rb
+++ b/spec/requests/catalog_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CatalogController, type: :request do
+  let(:druid) { 'druid:bj102hs9687' }
+
+  describe 'POST /catalog' do
+    it 'redirects to /v1/catalog' do
+      post '/catalog'
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to(catalog_index_url)
+    end
+  end
+
+  describe 'PUT /catalog/:druid' do
+    it 'redirects to /v1/catalog/:druid' do
+      put "/catalog/#{druid}"
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to(catalog_url(druid))
+    end
+  end
+
+  describe 'PATCH /catalog/:druid' do
+    it 'redirects to /v1/catalog/:druid' do
+      patch "/catalog/#{druid}"
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to(catalog_url(druid))
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1206

## Why was this change made?

To begin versioning routes in prescat without breaking clients that use current routes which don't contain a path segment specifying the API version.

For now, prescat is taking the same approach as dor-services-app: using a `scope` rather than a `namespace`. A `namespace` would have the following additional consequences:

* The path helper prefixes would change, to include `v1` in them, *e.g., `v1_catalog`, `checksum_v1_object`
* The controller#action routing would change, looking for controllers in a namespaced directory, *e.g.*, `app/controllers/v1/catalog_controller.rb` (and, accordingly, all the controllers would need to be added to a new `V1` module`)

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

Yes, API docs iN README.