### PR TITLE
Pass only namespaced druids to dor-workflow-client

### DIFF
--- a/app/services/workflow_reporter.rb
+++ b/app/services/workflow_reporter.rb
@@ -37,7 +37,8 @@ class WorkflowReporter
   end
 
   def self.create_wf(druid, version)
-    workflow_client.create_workflow_by_name(druid, PRESERVATIONAUDITWF, version: version)
+    namespaced_druid = druid.start_with?('druid:') ? druid : "druid:#{druid}"
+    workflow_client.create_workflow_by_name(namespaced_druid, PRESERVATIONAUDITWF, version: version)
   end
   private_class_method :create_wf
 

--- a/spec/services/workflow_reporter_spec.rb
+++ b/spec/services/workflow_reporter_spec.rb
@@ -4,12 +4,41 @@ require 'rails_helper'
 
 RSpec.describe WorkflowReporter do
   let(:druid) { 'jj925bx9565' }
+  let(:namespaced_druid) { "druid:#{druid}" }
   let(:version) { '1' }
   let(:err_msg) { "Failed to retrieve response #{Settings.workflow_services_url}/preservationAuditWF/something (HTTP status 404)" }
   let(:wf_server_response_json) { { some: 'json response from wf server' } }
 
   before do
     allow(Dor::Workflow::Client).to receive(:new).and_return(stub_wf_client)
+  end
+
+  describe '.create_wf' do
+    let(:stub_wf_client) { instance_double(Dor::Workflow::Client) }
+
+    before do
+      allow(stub_wf_client).to receive(:create_workflow_by_name)
+    end
+
+    context 'when passed a namespaced druid' do
+      it 'passes the supplied druid along to the workflow client' do
+        described_class.send(:create_wf, namespaced_druid, version)
+
+        expect(stub_wf_client).to have_received(:create_workflow_by_name)
+          .once
+          .with(namespaced_druid, described_class::PRESERVATIONAUDITWF, version: version)
+      end
+    end
+
+    context 'when passed a bare druid' do
+      it 'adds a namespace to the druid and sends it to the workflow client' do
+        described_class.send(:create_wf, druid, version)
+
+        expect(stub_wf_client).to have_received(:create_workflow_by_name)
+          .once
+          .with(namespaced_druid, described_class::PRESERVATIONAUDITWF, version: version)
+      end
+    end
   end
 
   describe '.report_error' do


### PR DESCRIPTION
Fixes #1267

## Why was this change made?

To prevent passing non-namespaced ("bare") druids to the workflow client and service.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

no