### PR TITLE
MoabToCatalog#perform remove path argument

### DIFF
--- a/app/jobs/moab_to_catalog_job.rb
+++ b/app/jobs/moab_to_catalog_job.rb
@@ -11,9 +11,8 @@ class MoabToCatalogJob < ApplicationJob
 
   # @param [MoabStorageRoot] root mount containing the Moab
   # @param [String] druid
-  # @param [String] optional path
-  def perform(root, druid, path=nil)
-    path = "#{root.storage_location}/#{DruidTools::Druid.new(druid).tree.join('/')}" if path.nil?
+  def perform(root, druid)
+    path = "#{root.storage_location}/#{DruidTools::Druid.new(druid).tree.join('/')}"
     moab = Moab::StorageObject.new(druid, path)
     PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, root).check_existence
   end

--- a/app/jobs/moab_to_catalog_job.rb
+++ b/app/jobs/moab_to_catalog_job.rb
@@ -11,8 +11,9 @@ class MoabToCatalogJob < ApplicationJob
 
   # @param [MoabStorageRoot] root mount containing the Moab
   # @param [String] druid
-  # @param [String] path
-  def perform(root, druid, path)
+  # @param [String] optional path
+  def perform(root, druid, path=nil)
+    path = "#{root.storage_location}/#{DruidTools::Druid.new(druid).tree.join('/')}" if path.nil?
     moab = Moab::StorageObject.new(druid, path)
     PreservedObjectHandler.new(druid, moab.current_version_id, moab.size, root).check_existence
   end

--- a/app/models/moab_storage_root.rb
+++ b/app/models/moab_storage_root.rb
@@ -25,8 +25,8 @@ class MoabStorageRoot < ApplicationRecord
 
   # Use a queue to ensure each druid on this root's directory is in the catalog database
   def m2c_check!
-    Stanford::MoabStorageDirectory.find_moab_paths(storage_location) do |druid, path, _match|
-      MoabToCatalogJob.perform_later(self, druid, path)
+    Stanford::MoabStorageDirectory.find_moab_paths(storage_location) do |druid, _path, _match|
+      MoabToCatalogJob.perform_later(self, druid)
     end
   end
 

--- a/spec/jobs/moab_to_catalog_job_spec.rb
+++ b/spec/jobs/moab_to_catalog_job_spec.rb
@@ -20,4 +20,18 @@ describe MoabToCatalogJob, type: :job do
       job.perform(msr, druid, path)
     end
   end
+
+  describe '#perform without path' do
+    let(:msr) { create :moab_storage_root }
+    let(:path) { "#{msr.storage_location}/bj/102/hs/9687/bj102hs9687" }
+    let(:handler) { instance_double(PreservedObjectHandler) }
+
+    it 'builds a PreservedObjectHandler from MoabStorageRoot and druid if path is missing' do
+      expect(Moab::StorageObject).to receive(:new).with(druid, path).and_return(moab)
+      expect(PreservedObjectHandler).to receive(:new)
+        .with(druid, moab.current_version_id, moab.size, msr).and_return(handler)
+      expect(handler).to receive(:check_existence)
+      job.perform(msr, druid)
+    end
+  end
 end

--- a/spec/jobs/moab_to_catalog_job_spec.rb
+++ b/spec/jobs/moab_to_catalog_job_spec.rb
@@ -6,27 +6,13 @@ describe MoabToCatalogJob, type: :job do
   let(:job) { described_class.new(msr, druid, path) }
   let(:msr) { create :moab_storage_root }
   let(:druid) { 'bj102hs9687' }
-  let(:path) { 'foobar' }
+  let(:path) { "#{msr.storage_location}/bj/102/hs/9687/bj102hs9687" }
   let(:moab) { instance_double(Moab::StorageObject, size: 22, current_version_id: 3) }
 
   describe '#perform' do
     let(:handler) { instance_double(PreservedObjectHandler) }
 
     it 'builds a PreservedObjectHandler and calls #check_existence' do
-      expect(Moab::StorageObject).to receive(:new).with(druid, path).and_return(moab)
-      expect(PreservedObjectHandler).to receive(:new)
-        .with(druid, moab.current_version_id, moab.size, msr).and_return(handler)
-      expect(handler).to receive(:check_existence)
-      job.perform(msr, druid, path)
-    end
-  end
-
-  describe '#perform without path' do
-    let(:msr) { create :moab_storage_root }
-    let(:path) { "#{msr.storage_location}/bj/102/hs/9687/bj102hs9687" }
-    let(:handler) { instance_double(PreservedObjectHandler) }
-
-    it 'builds a PreservedObjectHandler from MoabStorageRoot and druid if path is missing' do
       expect(Moab::StorageObject).to receive(:new).with(druid, path).and_return(moab)
       expect(PreservedObjectHandler).to receive(:new)
         .with(druid, moab.current_version_id, moab.size, msr).and_return(handler)

--- a/spec/models/moab_storage_root_spec.rb
+++ b/spec/models/moab_storage_root_spec.rb
@@ -87,11 +87,11 @@ RSpec.describe MoabStorageRoot, type: :model do
       it 'calls MoabToCatalogJob for each eligible on-disk Moab' do
         msr.storage_location = 'spec/fixtures/storage_root01/sdr2objects' # using enumerated fixtures
         expect(MoabToCatalogJob).to receive(:perform_later)
-          .with(msr, 'bj102hs9687', "#{msr.storage_location}/bj/102/hs/9687/bj102hs9687")
+          .with(msr, 'bj102hs9687')
         expect(MoabToCatalogJob).to receive(:perform_later)
-          .with(msr, 'bz514sm9647', "#{msr.storage_location}/bz/514/sm/9647/bz514sm9647")
+          .with(msr, 'bz514sm9647')
         expect(MoabToCatalogJob).to receive(:perform_later)
-          .with(msr, 'jj925bx9565', "#{msr.storage_location}/jj/925/bx/9565/jj925bx9565")
+          .with(msr, 'jj925bx9565')
         msr.m2c_check!
       end
     end


### PR DESCRIPTION
## Why was this change made?
Request by Julian for `MoabToCatalogJob#preform`'s arguments when manually remediating druids.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
n/a

Fixes #1158 