### PR TITLE
Use Resque as ActiveJob adapter in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,8 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  config.active_job.queue_adapter     = :resque
+  # NOTE: This was commented out before as well. Leaving it commented out.
   # config.active_job.queue_name_prefix = "preservation_catalog_production"
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
## Why was this change made?

To use Resque for workers!

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

no