### PR TITLE
Notify honeybadger when there is a Moab error

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -90,6 +90,7 @@ class ObjectsController < ApplicationController
     render(plain: "400 Bad Request: #{e}", status: :bad_request)
   rescue Moab::MoabRuntimeError => e
     render(plain: "500 Unable to get content diff: #{e}", status: :internal_server_error)
+    Honeybadger.notify(e)
   end
 
   private


### PR DESCRIPTION
## Why was this change made?

I'm seeing the client return 500, but I don't know where this problem originates. Logging the original exception will assist in this.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
n/a