### PR TITLE
[Draft] Adds preserved object audit service.

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -22,6 +22,7 @@ class AuditResults
   DB_UPDATE_FAILED = :db_update_failed
   DB_OBJ_ALREADY_EXISTS = :db_obj_already_exists
   DB_OBJ_DOES_NOT_EXIST = :db_obj_does_not_exist
+  DELETED_OBJECT = :deleted_object
   CM_STATUS_CHANGED = :cm_status_changed
   UNEXPECTED_VERSION = :unexpected_version
   INVALID_MOAB = :invalid_moab
@@ -52,6 +53,7 @@ class AuditResults
     DB_UPDATE_FAILED => "db update failed: %{addl}",
     DB_OBJ_ALREADY_EXISTS => "%{addl} db object already exists",
     DB_OBJ_DOES_NOT_EXIST => "%{addl} db object does not exist",
+    DELETED_OBJECT => "deleted object from database",
     CM_STATUS_CHANGED => "CompleteMoab status changed from %{old_status} to %{new_status}",
     UNEXPECTED_VERSION => "actual version (%{actual_version}) has unexpected relationship to %{db_obj_name} db version (%{db_obj_version}); ERROR!",
     INVALID_MOAB => "Invalid Moab, validation errors: %{addl}",
@@ -109,14 +111,15 @@ class AuditResults
 
   DB_UPDATED_CODES = [
     CREATED_NEW_OBJECT,
-    CM_STATUS_CHANGED
+    CM_STATUS_CHANGED,
+    DELETED_OBJECT
   ].freeze
 
   def self.logger_severity_level(result_code)
     case result_code
     when DB_OBJ_DOES_NOT_EXIST, ZIP_PARTS_NOT_CREATED, ZIP_PARTS_NOT_ALL_REPLICATED
       Logger::WARN
-    when VERSION_MATCHES, ACTUAL_VERS_GT_DB_OBJ, CREATED_NEW_OBJECT, CM_STATUS_CHANGED, MOAB_CHECKSUM_VALID
+    when VERSION_MATCHES, ACTUAL_VERS_GT_DB_OBJ, CREATED_NEW_OBJECT, CM_STATUS_CHANGED, MOAB_CHECKSUM_VALID, DELETED_OBJECT
       Logger::INFO
     else
       Logger::ERROR

--- a/app/services/preserved_object_audit_service.rb
+++ b/app/services/preserved_object_audit_service.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+# A service for auditing complete_moabs against moabs on disk (and vice versa.)
+# If a preserved_object is missing, it is created.
+# If a complete_moab is missing for a moab, it is created.
+# For each complete_moab / moab, versions are compared and validations possibly performed.
+# Complete_moabs are deleted for any moved moabs (i.e., moab missing for complete_moab, but another moab exists in a different location)
+class PreservedObjectAuditService
+
+  attr_reader :druid, :all_results
+  attr_writer :logger
+
+  def initialize(druid)
+    @druid = druid
+    @logger = PreservationCatalog::Application.logger
+    # Each moab / complete moab has own audit result
+    create_all_results
+  end
+
+  def audit
+    unless preserved_object
+      # TODO: Is raising the correct way to handle?
+      raise "No preserved object and no moabs on disk for #{druid}" if moabs.empty?
+      create_preserved_object
+    end
+    raise 'preserved_object does not exist' unless preserved_object # Assertion
+
+    # For each moab, if there is no complete_moab then create one.
+    create_missing_complete_moabs
+
+    preserved_object.complete_moabs.all.each do |complete_moab|
+      moab = moab_for_complete_moab(complete_moab)
+
+      # Moab on disk does not exist
+      unless moab.exist?
+        handle_missing_moab(complete_moab)
+        next
+      end
+
+      if moab.current_version_id == complete_moab.version
+        handle_version_matches(complete_moab)
+        if complete_moab.status == 'ok'
+          complete_moab.update_audit_timestamps(false, true) # Version audited
+          next
+        end
+      end
+
+      next unless validate(moab, complete_moab) # Also adds to results and updates complete_moab
+
+      if moab.current_version_id < complete_moab.version
+        handle_unexpected_version(complete_moab)
+        next
+      end
+
+      update_status(complete_moab,'validity_unknown') # This will queue a checksum validation.
+
+      handle_bumped_version(complete_moab, moab) if moab.current_version_id > complete_moab.version
+
+      handle_preserved_object_version_mismatch(complete_moab) if preserved_object.current_version != complete_moab.version
+
+    end
+
+    # Save all of the complete_moabs
+    preserved_object.complete_moabs.all.each { |complete_moab| complete_moab.save! }
+
+    delete_moved_complete_moabs
+
+    # Report the results
+    all_results.values.map { |results| results.report_results}
+  end
+
+  private
+
+  def preserved_object
+    @preserved_object ||= PreservedObject.find_by!(druid: druid)
+  end
+
+  def preservation_policy
+    PreservationPolicy.default_policy.id
+  end
+
+  def storage_trunk
+    Settings.moab.storage_trunk
+  end
+
+  def moabs
+    @moabs ||= Moab::StorageServices.search_storage_objects(druid)
+  end
+
+  def create_preserved_object
+    raise "preserved_object already exists" if preserved_object # Assertion
+    # Setting current_version to 1 should be OK because will be corrected.
+    @preserved_object = PreservedObject.create!(druid: druid, current_version: 1, preservation_policy_id: preservation_policy)
+    # TODO: Should this be added to results? Since results are for a complete_moab, does that make sense?
+    # results.add_result(AuditResults::CREATED_NEW_OBJECT)
+  end
+
+  def create_complete_moab(moab)
+    raise "preserved_object does not exist" unless preserved_object # Assertion
+
+    preserved_object.complete_moabs.create!(
+        version: moab.current_version_id,
+        size: moab.size,
+        moab_storage_root: find_moab_storage_root(moab),
+        status: 'validity_unknown'
+    )
+    results_for_moab(moab).add_result(AuditResults::CREATED_NEW_OBJECT)
+  end
+
+  def create_missing_complete_moabs
+    moabs.each do |moab|
+      moab_storage_root = find_moab_storage_root(moab)
+      create_complete_moab(moab) unless preserved_object.complete_moabs.exists?(moab_storage_root: moab_storage_root)
+    end
+  end
+
+  def create_all_results
+    @all_results = {}
+    moabs.each do |moab|
+      moab_storage_root = find_moab_storage_root(moab)
+      all_results[moab_storage_root] = AuditResults.new(druid, moab.current_version_id, moab_storage_root)
+    end
+
+    return unless preserved_object
+
+    preserved_object.complete_moabs.all.each do |complete_moab|
+      all_results[moab_storage_root] = AuditResults.new(druid, nil, complete_moab.moab_storage_root) unless all_results.has_key?(complete_moab.moab_storage_root)
+    end
+  end
+
+  def update_status(complete_moab, new_status)
+    complete_moab.status = new_status
+    return unless complete_moab.status_changed?
+
+    results_for_complete_moab(complete_moab).add_result(
+        AuditResults::CM_STATUS_CHANGED, old_status: complete_moab.status_was, new_status: complete_moab.status
+    )
+  end
+
+  def find_moab_storage_root(moab)
+    storage_location = "#{moab.object_pathname.to_s.split(storage_trunk).first}#{storage_trunk}"
+    MoabStorageRoot.find_by!(storage_location: storage_location)
+  end
+
+  def moab_for_complete_moab(complete_moab)
+    object_dir = "#{complete_moab.moab_storage_root.storage_location}/#{DruidTools::Druid.new(druid).tree.join('/')}"
+    Moab::StorageObject.new(druid, object_dir)
+  end
+
+  def results_for_complete_moab(complete_moab)
+    all_results[complete_moab.moab_storage_root]
+  end
+
+  def results_for_moab(moab)
+    all_results[find_moab_storage_root(moab)]
+  end
+
+  def validate(moab, complete_moab)
+    object_validator = Stanford::StorageObjectValidator.new(moab)
+    moab_errors = object_validator.validation_errors(Settings.moab.allow_content_subdirs)
+    complete_moab.update_audit_timestamps(true, true) # Moab validated and version audited
+    if moab_errors.any?
+      moab_error_msgs = []
+      moab_errors.each do |error_hash|
+        moab_error_msgs += error_hash.values
+      end
+      results_for_moab(moab).add_result(AuditResults::INVALID_MOAB, moab_error_msgs)
+      update_status(complete_moab, 'invalid_moab')
+      return false
+    end
+    true
+  end
+
+  def delete_moved_complete_moabs
+    # Must be at least one other complete_moab that != MOAB_NOT_FOUND
+    return if preserved_object.complete_moabs.where.not(status: MOAB_NOT_FOUND).exists?
+
+    preserved_object.complete_moabs.where(status: MOAB_NOT_FOUND).each do |complete_moab|
+      results_for_complete_moab(complete_moab).add_result(AuditResults::DELETED_OBJECT)
+      complete_moab.destroy
+    end
+  end
+
+  def handle_missing_moab(complete_moab)
+    update_status(complete_moab, 'online_moab_not_found')
+    results_for_complete_moab(complete_moab).add_result(AuditResults::MOAB_NOT_FOUND,
+                                                        db_created_at: complete_moab.created_at.iso8601,
+                                                        db_updated_at: complete_moab.updated_at.iso8601)
+  end
+
+  def handle_unexpected_version(complete_moab)
+    update_status(complete_moab, 'unexpected_version_on_storage')
+    results_for_complete_moab(complete_moab).add_result(
+      AuditResults::UNEXPECTED_VERSION, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version
+    )
+  end
+
+  def handle_bumped_version(complete_moab, moab)
+    results_for_complete_moab(complete_moab).add_result(
+        AuditResults::ACTUAL_VERS_GT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version
+    )
+    complete_moab.upd_audstamps_version_size(true, moab.current_version_id, moab.size)
+    if preserved_object.current_version < moab.current_version_id
+      preserved_object.current_version = moab.current_version_id
+      preserved_object.save!
+    end
+  end
+
+  def handle_version_matches(complete_moab)
+    results_for_complete_moab(complete_moab).add_result(AuditResults::VERSION_MATCHES, 'CompleteMoab')
+  end
+
+  def handle_preserved_object_version_mismatch(complete_moab)
+    results_for_complete_moab(complete_moab).add_result(
+        AuditResults::CM_PO_VERSION_MISMATCH, cm_version: complete_moab.version, po_version: preserved_object.current_version
+    )
+  end
+end

--- a/spec/services/preserved_object_audit_service_spec.rb
+++ b/spec/services/preserved_object_audit_service_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+RSpec.describe PreservedObjectAuditService do
+  context 'no preserved object' do
+    context 'no moabs on disk' do
+      it 'raises an error' do
+      end
+    end
+
+    context 'moabs on disk exist' do
+      it 'creates the preserved object' do
+      end
+      it 'proceeds with audit' do
+      end
+    end
+  end
+
+  context 'missing complete_moab' do
+    it 'creates the complete_moab' do
+    end
+    it 'adds to results' do
+    end
+    it 'proceeds with audit' do
+    end
+  end
+
+  context 'missing moab on disk' do
+    it 'updates status' do
+    end
+    it 'adds to results' do
+    end
+  end
+
+  context 'complete_moab and moab on disk versions match' do
+    context 'complete_moab status is ok' do
+      it 'updates timestamps' do
+      end
+      it 'adds to results' do
+      end
+    end
+    context 'complete_moab status is not ok' do
+      it 'updates timestamps' do
+      end
+      it 'validates' do
+      end
+    end
+  end
+
+  context 'invalid moab' do
+    it 'updates timestamps' do
+    end
+    it 'updates status' do
+    end
+    it 'adds to results' do
+    end
+  end
+
+  context 'valid moab' do
+    it 'updates timestamps' do
+    end
+  end
+
+  context 'moab version < complete_moab version' do
+    it 'updates status' do
+    end
+    it 'adds to results' do
+    end
+  end
+
+  context 'moab version > complete_moab version' do
+    context 'preserved object version is correct' do
+      it 'updates version' do
+      end
+      it 'updates size' do
+      end
+      it 'adds to results' do
+      end
+      it 'does not update preserved object version' do
+      end
+    end
+
+    context 'preserved object version is incorrect' do
+      it 'updates version' do
+      end
+      it 'updates size' do
+      end
+      it 'adds to results' do
+      end
+      it 'updates preserved object version' do
+      end
+    end
+  end
+
+  context 'preserved object version and complete_moab version do not match' do
+    it 'adds to results' do
+    end
+  end
+
+  context 'complete_moab with MOAB_NOT_FOUND status' do
+    context 'other complete_moabs with a different status' do
+      it 'deletes complete_moab with MOAB_NOT_FOUND status' do
+      end
+      it 'adds to results' do
+      end
+    end
+    context 'no other complete_moabs with a different status' do
+      it 'does not delete complete_moab with MOAB_NOT_FOUND status' do
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #1159

## Why was this change made?
* Support multiple moabs on different storage roots.
* Consolidate M2C and C2M

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
Not yet.