### PR TITLE
switch to log level debugging in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
## Why was this change made?

reduce noise levels in production logging after upgrade to rails 6 switched default to debug


## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
