### PR TITLE
moab_to_catalog gets clarification in class comment

### DIFF
--- a/app/lib/audit/moab_to_catalog.rb
+++ b/app/lib/audit/moab_to_catalog.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Audit
+  #  NOTE:  this class is used by Julian as a CLI tool; it is not called anywhere else
+  #
   # finds Moab objects on a single Moab storage_dir and interacts with Catalog (db)
   #   according to method called
   class MoabToCatalog


### PR DESCRIPTION
## Why was this change made?

Fixes #1300 

Adds minimal documentation to indicate that moab_to_catalog class is used as CLI tool only.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a