### PR TITLE
gate API access by JWT

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require: rubocop-rspec
 inherit_from: .rubocop_todo.yml
 
 AllCops:
+  TargetRubyVersion: 2.5
   DisplayCopNames: true
   Include:
     - './Rakefile'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,10 @@ Naming/FileName:
 RSpec/ContextWording:
   Enabled: false # too dogmatic
 
+RSpec/DescribeClass:
+    Exclude:
+      - 'spec/requests/auth_spec.rb' # technically testing ApplicationController, but rubocop complains even if you provide that
+
 RSpec/ExampleLength:
   Max: 25
 

--- a/README.md
+++ b/README.md
@@ -295,11 +295,11 @@ docker-compose run app bundle exec rails db:reset db:seed
 
 Interact with the application via localhost:
 ```sh
-curl -F 'druid=druid:bj102hs9688' -F 'incoming_version=3' -F 'incoming_size=2070039' -F 'storage_location=spec/fixtures/storage_root01' -F 'checksums_validated=true' http://localhost:3000/v1/catalog
+curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' -F 'druid=druid:bj102hs9688' -F 'incoming_version=3' -F 'incoming_size=2070039' -F 'storage_location=spec/fixtures/storage_root01' -F 'checksums_validated=true' http://localhost:3000/v1/catalog
 ```
 
 ```sh
-curl http://localhost:3000/v1/objects/druid:bj102hs9688
+curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' http://localhost:3000/v1/objects/druid:bj102hs9688
 
 {
   "id":1,
@@ -332,7 +332,7 @@ The Resque Pool admin interface is available at `<hostname>/resque/overview`.
 
 Note that the API is now versioned. Until all clients have been modified to use the V1 routes, requests to URIs without explicit versions -- *i.e.*, hitting /catalog instead of /v1/catalog -- will automatically be redirected to their V1 equivalents. After that point, only requests to explicitly versioned endpoints will be serviced.
 
-## AuthN _WIP - we can mint tokens for services now, access will be restricted to clients with tokens shortly_
+### AuthN
 
 Authentication/authorization is handled by JWT.  Preservation Catalog mints JWTs for individual client services, and the client services each provide their respective JWT when making HTTP API calls to PresCat.
 
@@ -350,11 +350,13 @@ At present, all tokens grant the same (full) access to the read/update API.
 
 ### V1
 
+##### NOTE: The first token in the first `curl` example below is a full valid token generated from the public (bad, low entropy) example HMAC secret.  For readability, all other token values are abbreviated (and so those example tokens will be invalid).
+
 #### `GET /v1/objects/:druid`
 Return the PreservedObject model for the object.
 
 ```
-curl https://preservation-catalog-prod-01.stanford.edu/v1/objects/druid:bb000kg4251
+curl -H 'Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJwcmVzLXRlc3RfMjAyMC0wMS0xMyJ9.lWMJ66Wjfl2lY5MdikDpjjhpyD_uBX4DMZC5mlgq2T2-bSmrYcbcxfyNfQKXWrUzBc1xOuwYZWxkYL6EejzHvQ' https://preservation-catalog-prod-01.stanford.edu/v1/objects/druid:bb000kg4251
 {
   "id": 1786188,
   "druid": "bb000kg4251",
@@ -374,7 +376,7 @@ Parameters:
 * version (optional, default: latest): version of Moab
 
 ```
-curl "https://preservation-catalog-prod-01.stanford.edu/v1/objects/druid:bb000kg4251/file?category=manifest&filepath=signatureCatalog.xml&version=1"
+curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' "https://preservation-catalog-prod-01.stanford.edu/v1/objects/druid:bb000kg4251/file?category=manifest&filepath=signatureCatalog.xml&version=1"
 <?xml version="1.0" encoding="UTF-8"?>
 <signatureCatalog objectId="druid:bb000kg4251" versionId="1" catalogDatetime="2019-06-26T18:38:02Z" fileCount="10" byteCount="1364250" blockCount="1337">
   <entry originalVersion="1" groupId="content" storagePath="bb000kg4251.jpg">
@@ -388,7 +390,7 @@ curl "https://preservation-catalog-prod-01.stanford.edu/v1/objects/druid:bb000kg
 Return the checksums and filesize for a single object.
 
 ```
-curl https://preservation-catalog-prod-01.stanford.edu/v1/objects/druid:bb000kg4251/checksum
+curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' https://preservation-catalog-prod-01.stanford.edu/v1/objects/druid:bb000kg4251/checksum
 [
   {
     "filename": "bb000kg4251.jpg",
@@ -407,7 +409,7 @@ Parameters:
 * druid[] (repeatable): druid for the object
 
 ```
-curl "https://preservation-catalog-prod-01.stanford.edu/v1/objects/checksums?druids[]=druid:bb000kg4251&druids[]=druid:bb000kq3835"
+curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' "https://preservation-catalog-prod-01.stanford.edu/v1/objects/checksums?druids[]=druid:bb000kg4251&druids[]=druid:bb000kq3835"
 [
   {
     "druid:bb000kg4251": [
@@ -443,7 +445,7 @@ Parameters:
 * version (optional, default: latest): version of Moab
 
 ```
-curl -F 'content_metadata=
+curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' -F 'content_metadata=
 <?xml version="1.0"?>
 <contentMetadata objectId="bb000kg4251" type="image">
   <resource id="bb000kg4251_1" sequence="1" type="image">
@@ -499,7 +501,7 @@ Response codes:
 * 500: some other problem.
 
 ```
-curl -F 'druid=druid:bj102hs9688' -F 'incoming_version=3' -F 'incoming_size=2070039' -F 'storage_location=spec/fixtures/storage_root01' -F 'checksums_validated=true' https://preservation-catalog-stage-01.stanford.edu/v1/catalog
+curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' -F 'druid=druid:bj102hs9688' -F 'incoming_version=3' -F 'incoming_size=2070039' -F 'storage_location=spec/fixtures/storage_root01' -F 'checksums_validated=true' https://preservation-catalog-stage-01.stanford.edu/v1/catalog
 
 {
 	"druid": "bj102hs9688",
@@ -526,7 +528,7 @@ Response codes:
 * 500: some other problem.
 
 ```
-curl -X PUT -F 'incoming_version=4' -F 'incoming_size=2136079' -F 'storage_location=spec/fixtures/storage_root01' -F 'checksums_validated=true' https://preservation-catalog-stage-01.stanford.edu/v1/catalog/druid:bj102hs9688
+curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' -X PUT -F 'incoming_version=4' -F 'incoming_size=2136079' -F 'storage_location=spec/fixtures/storage_root01' -F 'checksums_validated=true' https://preservation-catalog-stage-01.stanford.edu/v1/catalog/druid:bj102hs9688
 
 {
 	"druid": "bj102hs9688",

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Parameters:
 * druid[] (repeatable): druid for the object
 
 ```
-curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' "https://preservation-catalog-prod-01.stanford.edu/v1/objects/checksums?druids[]=druid:bb000kg4251&druids[]=druid:bb000kq3835"
+curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' "https://preservation-catalog-prod-01.stanford.edu/v1/objects/checksums?druids\[\]=druid:bb000kg4251&druids\[\]=druid:bb000kq3835"
 [
   {
     "druid:bb000kg4251": [

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,11 +3,48 @@
 class ApplicationController < ActionController::API
   include ActionController::MimeResponds
 
+  before_action :check_auth_token!
+
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from Moab::ObjectNotFoundException, with: :not_found
   rescue_from Moab::InvalidSuriSyntaxError, with: :bad_request
 
+  TOKEN_HEADER = 'Authorization'
+
   protected
+
+  # IMPORTANT!  all non-API routes must be protected by shibboleth and restricted to an
+  # appropritaly small workgroup.
+  def non_api_route?
+    request.fullpath.match(%r{^/resque(/.*)?$})
+  end
+
+  def check_auth_token!
+    return if non_api_route?
+
+    unless bearer_token
+      Honeybadger.notify("no #{TOKEN_HEADER} token was provided by #{request.remote_ip}")
+      return render json: { error: 'Not Authorized' }, status: 401
+    end
+
+    decoded_jwt = decode_bearer_token!
+    Honeybadger.context(invoked_by: decoded_jwt[:sub])
+  rescue StandardError => e
+    Honeybadger.notify("error validating bearer token #{bearer_token} provided by #{request.remote_ip}: #{e}")
+    render json: { error: 'Not Authorized' }, status: 401
+  end
+
+  def decode_bearer_token!
+    token = bearer_token
+    body = JWT.decode(token, Settings.api_jwt.hmac_secret, true, algorithm: 'HS512').first
+    HashWithIndifferentAccess.new body
+  end
+
+  def bearer_token
+    return nil if request.headers[TOKEN_HEADER].blank?
+
+    request.headers[TOKEN_HEADER].sub(/^Bearer /, '')
+  end
 
   def strip_druid(id)
     id&.split(':', 2)&.last

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -116,11 +116,9 @@ class ObjectsController < ApplicationController
     checksum_list = []
     missing_druids = []
     normalized_druids.each do |druid|
-      begin
-        checksum_list << { returned_druid(druid) => content_files_checksums(druid) }
-      rescue Moab::ObjectNotFoundException
-        missing_druids << druid
-      end
+      checksum_list << { returned_druid(druid) => content_files_checksums(druid) }
+    rescue Moab::ObjectNotFoundException
+      missing_druids << druid
     end
     [checksum_list, missing_druids]
   end

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -30,3 +30,6 @@ zip_endpoints:
     audit_class: 'PreservationCatalog::Ibm::Audit'
     access_key_id: 'overridden-by-env-var-in-ci'
     secret_access_key: 'overridden-by-env-var-in-ci'
+
+resque_dashboard_hostnames:
+  - 'www.example.com' # this is what the test env sees itself as.  and we want to mount the resque dashboard in test to protect non-API endpoints

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 RSpec.describe CatalogController, type: :controller do
   before do
     allow(WorkflowReporter).to receive(:report_error)
+    allow(controller).to receive(:check_auth_token!) # gating on valid token tested in request specs and auth spec
   end
 
   let(:size) { 2342 }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,4 +57,6 @@ RSpec.configure do |config|
     allow(ZipmakerJob).to receive(:perform_later).with(any_args) # by default, block callback replication
     allow(ChecksumValidationJob).to receive(:perform_later).with(any_args) # by default, block callback CV
   end
+
+  config.include AuthHelper
 end

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'auth' do
+  let(:pres_obj) { create(:preserved_object) }
+
+  before do
+    allow(Honeybadger).to receive(:notify)
+    allow(Honeybadger).to receive(:context)
+  end
+
+  context 'without a bearer token' do
+    it 'rejects the request as Not Authorized' do
+      get "/v1/objects/#{pres_obj.druid}", headers: {}
+      expect(response.body).to eq '{"error":"Not Authorized"}'
+      expect(response).to be_unauthorized
+    end
+
+    it 'notifies Honeybadger' do
+      get "/v1/objects/#{pres_obj.druid}", headers: {}
+      expect(Honeybadger).to have_received(:notify).with("no Authorization token was provided by 127.0.0.1")
+    end
+  end
+
+  context 'with an invalid bearer token' do
+    it 'rejects the request as Not Authorized' do
+      get "/v1/objects/#{pres_obj.druid}", headers: invalid_auth_header
+      expect(response.body).to eq '{"error":"Not Authorized"}'
+      expect(response).to be_unauthorized
+    end
+
+    it 'notifies Honeybadger' do
+      get "/v1/objects/#{pres_obj.druid}", headers: invalid_auth_header
+      expect(Honeybadger).to have_received(:notify).with(
+        "error validating bearer token #{invalid_jwt_value} provided by 127.0.0.1: Signature verification raised"
+      )
+    end
+  end
+
+  context 'with a bearer token' do
+    it 'logs token and caller to honeybadger' do
+      get "/v1/objects/#{pres_obj.druid}", headers: valid_auth_header
+      expect(Honeybadger).not_to have_received(:notify)
+      expect(Honeybadger).to have_received(:context).with(invoked_by: jwt_payload[:sub])
+    end
+
+    it 'responds with a 200 OK and the correct body' do
+      get "/v1/objects/#{pres_obj.druid}", headers: valid_auth_header
+      expect(response.body).to include(pres_obj.to_json)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when requesting an unprotected route' do
+    it 'lets the request through without checking a Bearer token' do
+      get '/resque/overview'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/catalog_controller_spec.rb
+++ b/spec/requests/catalog_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CatalogController, type: :request do
 
   describe 'POST /catalog' do
     it 'redirects to /v1/catalog' do
-      post '/catalog'
+      post '/catalog', headers: valid_auth_header
       expect(response).to have_http_status(:moved_permanently)
       expect(response).to redirect_to(catalog_index_url)
     end
@@ -15,7 +15,7 @@ RSpec.describe CatalogController, type: :request do
 
   describe 'PUT /catalog/:druid' do
     it 'redirects to /v1/catalog/:druid' do
-      put "/catalog/#{druid}"
+      put "/catalog/#{druid}", headers: valid_auth_header
       expect(response).to have_http_status(:moved_permanently)
       expect(response).to redirect_to(catalog_url(druid))
     end
@@ -23,7 +23,7 @@ RSpec.describe CatalogController, type: :request do
 
   describe 'PATCH /catalog/:druid' do
     it 'redirects to /v1/catalog/:druid' do
-      patch "/catalog/#{druid}"
+      patch "/catalog/#{druid}", headers: valid_auth_header
       expect(response).to have_http_status(:moved_permanently)
       expect(response).to redirect_to(catalog_url(druid))
     end

--- a/spec/requests/objects_controller_content_diff_spec.rb
+++ b/spec/requests/objects_controller_content_diff_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ObjectsController, type: :request do
     context 'when object exists' do
       context 'when druid is prefixed' do
         it 'returns the Moab::FileInventoryDifference as xml' do
-          post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md }
+          post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md }, headers: valid_auth_header
           expect(response).to have_http_status(:ok)
           result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
           expect(result.object_id).to eq 'bj102hs9687'
@@ -25,7 +25,7 @@ RSpec.describe ObjectsController, type: :request do
 
       context 'when druid is bare' do
         it 'returns the Moab::FileInventoryDifference as xml' do
-          post content_diff_object_url(id: bare_druid), params: { content_metadata: content_md }
+          post content_diff_object_url(id: bare_druid), params: { content_metadata: content_md }, headers: valid_auth_header
           expect(response).to have_http_status(:ok)
           result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
           expect(result.object_id).to eq 'bj102hs9687'
@@ -35,7 +35,7 @@ RSpec.describe ObjectsController, type: :request do
 
       context 'when version specified' do
         it 'returns correct Moab::FileInventoryDifference data' do
-          post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md, version: '1' }
+          post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md, version: '1' }, headers: valid_auth_header
           expect(response).to have_http_status(:ok)
           result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
           expect(result.object_id).to eq 'bj102hs9687'
@@ -44,7 +44,7 @@ RSpec.describe ObjectsController, type: :request do
 
         context 'when version is too high' do
           it 'returns 500 response code with details' do
-            post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md, version: '666' }
+            post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md, version: '666' }, headers: valid_auth_header
             expect(response).to have_http_status(:internal_server_error)
             expect(response.body).to eq '500 Unable to get content diff: Version ID 666 does not exist'
           end
@@ -52,7 +52,7 @@ RSpec.describe ObjectsController, type: :request do
 
         context 'when version param is not digits only' do
           it 'returns 400 response code with details' do
-            post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md, version: 'v3' }
+            post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md, version: 'v3' }, headers: valid_auth_header
             expect(response).to have_http_status(:bad_request)
             expect(response.body).to eq '400 Bad Request: version parameter must be positive integer'
           end
@@ -61,7 +61,8 @@ RSpec.describe ObjectsController, type: :request do
 
       context 'when ArgumentError from MoabStorageService' do
         it 'returns 400 response code with details' do
-          post content_diff_object_url(id: prefixed_druid), params: { content_metadata: content_md, subset: 'unrecognized' }
+          params = { content_metadata: content_md, subset: 'unrecognized' }
+          post content_diff_object_url(id: prefixed_druid), params: params, headers: valid_auth_header
           expect(response).to have_http_status(:bad_request)
           m = "400 Bad Request: subset arg must be 'all', 'shelve', 'preserve', or 'publish' (MoabStorageService.content_diff for druid bj102hs9687)"
           expect(response.body).to eq m
@@ -74,7 +75,7 @@ RSpec.describe ObjectsController, type: :request do
           allow(Stanford::StorageServices).to receive(:compare_cm_to_version)
             .with(content_md, bare_druid, 'all', nil)
             .and_raise(Moab::MoabRuntimeError, emsg)
-          post content_diff_object_url(id: bare_druid), params: { content_metadata: content_md }
+          post content_diff_object_url(id: bare_druid), params: { content_metadata: content_md }, headers: valid_auth_header
           expect(response).to have_http_status(:internal_server_error)
           expect(response.body).to eq '500 Unable to get content diff: my error'
           expect(Honeybadger).to have_received(:notify).with(Moab::MoabRuntimeError)
@@ -84,7 +85,7 @@ RSpec.describe ObjectsController, type: :request do
 
     context 'when object does not exist' do
       it 'returns an empty Moab::FileInventoryDifference as xml' do
-        post content_diff_object_url(id: 'druid:xx123yy9999'), params: { content_metadata: content_md }
+        post content_diff_object_url(id: 'druid:xx123yy9999'), params: { content_metadata: content_md }, headers: valid_auth_header
         expect(response).to have_http_status(:ok)
         result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
         expect(result.object_id).to eq 'xx123yy9999'
@@ -96,7 +97,7 @@ RSpec.describe ObjectsController, type: :request do
       context 'when id param is empty' do
         it "will raise RoutingError" do
           expect do
-            post content_diff_object_url(id: '')
+            post content_diff_object_url(id: ''), headers: valid_auth_header
           end.to raise_error(ActionController::RoutingError)
         end
       end
@@ -104,7 +105,7 @@ RSpec.describe ObjectsController, type: :request do
       context "when id param missing" do
         it 'Rails will raise error and do the right thing' do
           expect do
-            post content_diff_object_url({})
+            post content_diff_object_url({}), headers: valid_auth_header
           end.to raise_error(ActionController::UrlGenerationError)
         end
       end
@@ -112,7 +113,7 @@ RSpec.describe ObjectsController, type: :request do
 
     context 'when druid invalid' do
       it 'returns 500 response code with "Identifier has invalid suri syntax"' do
-        post content_diff_object_url(id: 'foobar'), params: { content_metadata: content_md, subset: 'all' }
+        post content_diff_object_url(id: 'foobar'), params: { content_metadata: content_md, subset: 'all' }, headers: valid_auth_header
         expect(response).to have_http_status(:internal_server_error)
         expect(response.body).to eq '500 Unable to get content diff: Identifier has invalid suri syntax: foobar'
       end

--- a/spec/requests/objects_controller_file_spec.rb
+++ b/spec/requests/objects_controller_file_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ObjectsController, type: :request do
     context 'when object exists' do
       context 'when druid is prefixed' do
         it 'returns the requested file' do
-          get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'manifestInventory.xml' }
+          get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'manifestInventory.xml' }, headers: valid_auth_header
           expect(response).to have_http_status(:ok)
           expect(response.body).to include 'md5'
         end
@@ -18,7 +18,7 @@ RSpec.describe ObjectsController, type: :request do
 
       context 'when druid is bare' do
         it 'returns the requested file' do
-          get file_object_url(id: bare_druid), params: { category: 'manifest', filepath: 'manifestInventory.xml' }
+          get file_object_url(id: bare_druid), params: { category: 'manifest', filepath: 'manifestInventory.xml' }, headers: valid_auth_header
           expect(response).to have_http_status(:ok)
           expect(response.body).to include 'md5'
         end
@@ -26,7 +26,7 @@ RSpec.describe ObjectsController, type: :request do
 
       context 'when file is not present in Moab' do
         it 'returns 404 response code; body has additional information' do
-          get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'foobar' }
+          get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'foobar' }, headers: valid_auth_header
           expect(response).to have_http_status(:not_found)
           expect(response.body).to eq '404 Not Found: manifest file foobar not found for bj102hs9687 - 3'
         end
@@ -34,14 +34,15 @@ RSpec.describe ObjectsController, type: :request do
 
       context 'when version specified' do
         it 'retrieves the correct version of the file' do
-          get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'manifestInventory.xml', version: '3' }
+          params = { category: 'manifest', filepath: 'manifestInventory.xml', version: '3' }
+          get file_object_url(id: prefixed_druid), params: params, headers: valid_auth_header
           expect(response).to have_http_status(:ok)
           expect(response.body).to include 'size="7133"'
         end
 
         context 'when version is too high' do
           it 'returns 404 response code with details' do
-            get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'ignored', version: '666' }
+            get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'ignored', version: '666' }, headers: valid_auth_header
             expect(response).to have_http_status(:not_found)
             expect(response.body).to eq '404 Not Found: Version ID 666 does not exist'
           end
@@ -49,7 +50,8 @@ RSpec.describe ObjectsController, type: :request do
 
         context 'when version param is not digits only' do
           it 'returns 400 response code with details' do
-            get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'manifestInventory.xml', version: 'v3' }
+            params = { category: 'manifest', filepath: 'manifestInventory.xml', version: 'v3' }
+            get file_object_url(id: prefixed_druid), params: params, headers: valid_auth_header
             expect(response).to have_http_status(:bad_request)
             expect(response.body).to eq '400 Bad Request: version parameter must be positive integer'
           end
@@ -58,7 +60,7 @@ RSpec.describe ObjectsController, type: :request do
 
       context 'when ArgumentError from MoabStorageService' do
         it 'returns 400 response code with details' do
-          get file_object_url(id: prefixed_druid), params: { category: 'metadata' }
+          get file_object_url(id: prefixed_druid), params: { category: 'metadata' }, headers: valid_auth_header
           expect(response).to have_http_status(:bad_request)
           expect(response.body).to eq '400 Bad Request: No filename provided to MoabStorageService.filepath for druid bj102hs9687'
         end
@@ -66,7 +68,7 @@ RSpec.describe ObjectsController, type: :request do
 
       context 'when MoabRuntimeError from MoabStorageService' do
         it 'returns 404 response code; body has additional information' do
-          get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'foobar' }
+          get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'foobar' }, headers: valid_auth_header
           expect(response).to have_http_status(:not_found)
           expect(response.body).to eq '404 Not Found: manifest file foobar not found for bj102hs9687 - 3'
         end
@@ -75,7 +77,7 @@ RSpec.describe ObjectsController, type: :request do
 
     context 'when object does not exist' do
       it 'returns 404 response code with "No storage object found"' do
-        get file_object_url(id: 'druid:xx123yy9999'), params: { category: 'manifest', filepath: 'manifestInventory.xml' }
+        get file_object_url(id: 'druid:xx123yy9999'), params: { category: 'manifest', filepath: 'manifestInventory.xml' }, headers: valid_auth_header
         expect(response).to have_http_status(:not_found)
         expect(response.body).to eq '404 Not Found: No storage object found for xx123yy9999'
       end
@@ -84,7 +86,7 @@ RSpec.describe ObjectsController, type: :request do
     context 'when no id param' do
       context 'when id param is empty' do
         it "returns 404 with 'Couldn't find PreservedObject'" do
-          get file_object_url(id: ''), params: { category: 'manifest', filepath: 'manifestInventory.xml' }
+          get file_object_url(id: ''), params: { category: 'manifest', filepath: 'manifestInventory.xml' }, headers: valid_auth_header
           expect(response).to have_http_status(:not_found)
           expect(response.body).to eq "404 Not Found: Couldn't find PreservedObject"
         end
@@ -93,7 +95,7 @@ RSpec.describe ObjectsController, type: :request do
       context "when id param missing" do
         it 'Rails will raise error and do the right thing' do
           expect do
-            get file_object_url({}), params: { category: 'manifest', filepath: 'manifestInventory.xml' }
+            get file_object_url({}), params: { category: 'manifest', filepath: 'manifestInventory.xml' }, headers: valid_auth_header
           end.to raise_error(ActionController::UrlGenerationError)
         end
       end
@@ -101,7 +103,7 @@ RSpec.describe ObjectsController, type: :request do
 
     context 'when druid invalid' do
       it 'returns 404 response code with "Identifier has invalid suri syntax"' do
-        get file_object_url(id: 'foobar'), params: { category: 'manifest', filepath: 'manifestInventory.xml' }
+        get file_object_url(id: 'foobar'), params: { category: 'manifest', filepath: 'manifestInventory.xml' }, headers: valid_auth_header
         expect(response).to have_http_status(:not_found)
         expect(response.body).to eq '404 Not Found: Identifier has invalid suri syntax: foobar'
       end

--- a/spec/requests/objects_controller_object_spec.rb
+++ b/spec/requests/objects_controller_object_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe ObjectsController, type: :request do
   describe 'GET #show' do
     context 'when object found' do
       it 'response contains the object when given prefixed druid' do
-        get object_url "druid:#{pres_obj.druid}", format: :json
+        get object_url("druid:#{pres_obj.druid}", format: :json), headers: valid_auth_header
         expect(response.body).to include(pres_obj.to_json)
         expect(response).to have_http_status(:ok)
       end
 
       it 'response contains the object when given bare druid' do
-        get object_url pres_obj.druid, format: :json
+        get object_url(pres_obj.druid, format: :json), headers: valid_auth_header
         expect(response.body).to include(pres_obj.to_json)
         expect(response).to have_http_status(:ok)
       end
@@ -25,12 +25,12 @@ RSpec.describe ObjectsController, type: :request do
 
     context 'when object not found' do
       it 'returns a 404 response code' do
-        get object_url 'druid:garbage', format: :json
+        get object_url('druid:garbage', format: :json), headers: valid_auth_header
         expect(response).to have_http_status(:not_found)
       end
 
       it 'returns useful info in the body' do
-        get object_url 'druid:garbage', format: :json
+        get object_url('druid:garbage', format: :json), headers: valid_auth_header
         expect(response.body).to eq "404 Not Found: Couldn't find PreservedObject"
       end
     end

--- a/spec/requests/objects_controller_object_spec.rb
+++ b/spec/requests/objects_controller_object_spec.rb
@@ -2,10 +2,6 @@
 
 require 'rails_helper'
 RSpec.describe ObjectsController, type: :request do
-  let(:prefixed_druid) { 'druid:bj102hs9687' }
-  let(:prefixed_druid2) { 'druid:bz514sm9647' }
-  let(:bare_druid) { 'bj102hs9687' }
-  let(:bare_druid2) { 'bz514sm9647' }
   let(:pres_obj) { create(:preserved_object) }
 
   describe 'GET #show' do

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module AuthHelper
+  def valid_auth_header
+    { 'Authorization' => "Bearer #{valid_jwt_value}" }
+  end
+
+  def invalid_auth_header
+    { 'Authorization' => "Bearer #{invalid_jwt_value}" }
+  end
+
+  def valid_jwt_value
+    JWT.encode(jwt_payload, Settings.api_jwt.hmac_secret, 'HS512')
+  end
+
+  def invalid_jwt_value
+    valid_jwt_value[0..-2] # just lop the last char off the signature to make a bad token
+  end
+
+  def jwt_payload
+    { sub: 'pres-test' }
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This change restricts all API access to callers that provide a valid JWT, generated on the pres cat server being accessed (with its current HMAC secret).

Groundwork for this (to allow token generation) is laid in #1305.  That should be merged and all supporting work should be completed before this branch is merged and deployed.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

yes

## TODO

- [x] review/merge PR adding `preservation-client` gem support
- [x] cut a new release of `preservation-client`
- [x] [upgrade `preservation-client` consumers](https://github.com/search?q=org%3Asul-dlss+%22Preservation%3A%3AClient.configure%22&type=Code)
  - [x] [argo](https://github.com/sul-dlss/argo/issues/1770)
    - [x] code changes: pres client gem upgrade, config call update, example in settings.yml
    - [x] mint prod and stage tokens, add to shared configs (PRs sul-dlss/shared_configs/pull/1176, sul-dlss/shared_configs/pull/1173)
  - [x] [dor-services-app](https://github.com/sul-dlss/dor-services-app/issues/573)
    - [x] code changes: pres client gem upgrade, config call update, example in settings.yml
    - [x] mint prod and stage tokens, add to shared configs (PRs sul-dlss/shared_configs/pull/1172, sul-dlss/shared_configs/pull/1174)
  - [x] [common-accessioning](https://github.com/sul-dlss/common-accessioning/issues/502)
    - [x] code changes: pres client gem upgrade, config call update, example in settings.yml
    - [x] mint prod and stage tokens, add to shared configs (PRs sul-dlss/shared_configs/pull/1171, sul-dlss/shared_configs/pull/1175)
  - [x] [preservation_robots](https://github.com/sul-dlss/preservation_robots/blob/f6a1f768207c47d93544d5b76644a060505ef1e2/config/boot.rb#L39)
    - [x] code changes: pres client gem upgrade, config call update, example in settings.yml
    - [x] mint prod and stage tokens, add to shared configs (PRs sul-dlss/shared_configs/pull/1177, sul-dlss/shared_configs/pull/1178, sul-dlss/shared_configs/pull/1169, sul-dlss/shared_configs/pull/1170)
- [x] **TEST UPDATED CLIENTS ON STAGE**
- [x] deploy updated pres cat API consumer apps to prod so that they are using the new `preservation-client` gem version and sending along their newly minted tokens
- [x] **TEST THIS BRANCH OF PRES CAT ON STAGE WITH THE NEWLY UPDATED CLIENT APPS**
- [ ] merge this PR and deploy it



closes #1298 