### PR TITLE
Pinned rack version for compatability with OKComputer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "factory_bot_rails", "~> 4.0"
 gem 'pry-byebug' # call 'binding.pry' anywhere in the code to stop execution and get a pry-byebug console
 gem 'pry-rails' # use pry as the rails console shell instead of IRB
 gem 'puma', '~> 3.12' # app server
+gem 'rack', '~> 2.0.8' # pending https://github.com/sportngin/okcomputer/pull/161
 gem 'rails', '~> 6.0.2'
 gem 'resque', '~> 1.27'
 gem 'resque-lock' # deduplication of worker queue jobs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,7 +260,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (4.0.3)
     puma (3.12.2)
-    rack (2.1.1)
+    rack (2.0.8)
     rack-protection (2.0.8.1)
       rack
     rack-test (1.1.0)
@@ -413,6 +413,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 3.12)
+  rack (~> 2.0.8)
   rails (~> 6.0.2)
   rails-controller-testing
   resque (~> 1.27)


### PR DESCRIPTION
closes #1308

## Why was this change made?



## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
