### PR TITLE
add target ruby version to rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require: rubocop-rspec
 inherit_from: .rubocop_todo.yml
 
 AllCops:
+  TargetRubyVersion: 2.5
   DisplayCopNames: true
   Include:
     - './Rakefile'


### PR DESCRIPTION
## Why was this change made?

to fix rubocop error in PR #1306 

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a