### PR TITLE
fix comments re: S3 creds, useful example query for db readme

### DIFF
--- a/app/jobs/ibm_south_delivery_job.rb
+++ b/app/jobs/ibm_south_delivery_job.rb
@@ -2,7 +2,7 @@
 
 # Different provider than parent class
 class IbmSouthDeliveryJob < S3WestDeliveryJob
-  queue_as :ibm_us_south_delivery # note: as with Amazon, still needs proper ENVs for AWS_REGION, etc.
+  queue_as :ibm_us_south_delivery
 
   def bucket
     PreservationCatalog::Ibm.configure(

--- a/app/jobs/s3_east_delivery_job.rb
+++ b/app/jobs/s3_east_delivery_job.rb
@@ -2,7 +2,7 @@
 
 # Same as parent class, just a different queue.
 class S3EastDeliveryJob < S3WestDeliveryJob
-  queue_as :s3_us_east_1_delivery # note: still needs proper ENVs for AWS_REGION, etc.
+  queue_as :s3_us_east_1_delivery
 
   def bucket
     PreservationCatalog::S3.configure(

--- a/app/lib/preservation_catalog/ibm.rb
+++ b/app/lib/preservation_catalog/ibm.rb
@@ -21,8 +21,6 @@ module PreservationCatalog
         resource.bucket(bucket_name)
       end
 
-      # Because AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION will be managed via
-      # ENV vars, and the bucket must match those, we check for AWS_BUCKET_NAME first.
       # @return [String]
       def bucket_name
         ENV['AWS_BUCKET_NAME'] || Settings.zip_endpoints.ibm_us_south.storage_location || Settings.ibm.bucket_name

--- a/app/lib/preservation_catalog/ibm/audit.rb
+++ b/app/lib/preservation_catalog/ibm/audit.rb
@@ -2,8 +2,7 @@
 
 module PreservationCatalog
   module Ibm
-    # Methods for auditing checking the state of a ZippedMoabVersion on an IBM S3 compatible endpoint.  Requires IBM credentials are
-    # available in the environment.  At the time of this comment, ONLY running queue workers will have proper creds loaded.
+    # Methods for auditing the state of a ZippedMoabVersion on an IBM S3 compatible endpoint.
     class Audit
       delegate :bucket, :bucket_name, to: ::PreservationCatalog::Ibm
 

--- a/app/lib/preservation_catalog/s3.rb
+++ b/app/lib/preservation_catalog/s3.rb
@@ -20,8 +20,6 @@ module PreservationCatalog
         resource.bucket(bucket_name)
       end
 
-      # Because AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION will be managed via
-      # ENV vars, and the bucket must match those, we check for AWS_BUCKET_NAME first.
       # @return [String]
       def bucket_name
         ENV['AWS_BUCKET_NAME'] || Settings.zip_endpoints[region_config_section].storage_location || Settings.aws.bucket_name

--- a/app/lib/preservation_catalog/s3/audit.rb
+++ b/app/lib/preservation_catalog/s3/audit.rb
@@ -2,8 +2,7 @@
 
 module PreservationCatalog
   module S3
-    # Methods for auditing checking the state of a ZippedMoabVersion on an S3 endpoint.  Requires AWS credentials are
-    # available in the environment.  At the time of this comment, ONLY running queue workers will have proper creds loaded.
+    # Methods for auditing the state of a ZippedMoabVersion on an AWS S3 endpoint.
     class Audit
       delegate :bucket_name, to: ::PreservationCatalog::S3
 

--- a/db/README.md
+++ b/db/README.md
@@ -167,3 +167,26 @@ input> CompleteMoab.joins(:preserved_object, :moab_storage_root).where(moab_stor
 # example result
 ["bp628nk4868", "dc048cw1328", "yy000yy0000"]
 ```
+
+#### view the zip parts for a given druid
+
+```ruby
+input> druid = 'by718ks4879'
+input> ZipPart.joins(zipped_moab_version: [{ complete_moab: [:preserved_object] }, :zip_endpoint]).where(preserved_objects: { druid: druid }).pluck(:druid, 'current_version AS highest_version', 'zipped_moab_versions.version AS zip_version', :endpoint_name, :status)
+```
+```sql
+-- example sql produced by above AR query
+SELECT druid, current_version AS highest_version, zipped_moab_versions.version AS zip_version, endpoint_name, zip_parts.status
+FROM zip_parts
+INNER JOIN zipped_moab_versions ON zipped_moab_versions.id = zip_parts.zipped_moab_version_id
+  INNER JOIN complete_moabs ON complete_moabs.id = zipped_moab_versions.complete_moab_id
+    INNER JOIN preserved_objects ON preserved_objects.id = complete_moabs.preserved_object_id
+  INNER JOIN zip_endpoints ON zip_endpoints.id = zipped_moab_versions.zip_endpoint_id
+WHERE preserved_objects.druid = 'by718ks4879'
+```
+```ruby
+# example result
+[["by718ks4879", 1, 1, "ibm_us_south", "ok"],
+ ["by718ks4879", 1, 1, "aws_s3_east_1", "ok"],
+ ["by718ks4879", 1, 1, "aws_s3_west_2", "ok"]]
+```


### PR DESCRIPTION
* former in light of switch from provisioning creds via environment variables
* latter because it was useful when i was looking into a replication failure, and is also a nice example of a multi-table join in ActiveRecord

## Why was this change made?

i stumbled across the opportunity for these touchups while poking at a couple replication errors.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

this is a documentation only fix.