### PR TITLE
fix broken okcomputer WFS check

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -101,7 +101,7 @@ end
 #   - in /status/all, these checks will display their result text, but will not affect HTTP response code
 
 # Audit Checks (only) report errors to workflow service so they appear in Argo
-workflows_url = "#{Settings.workflow_services_url}sdr/objects/druid:oo000oo0000/workflows"
+workflows_url = "#{Settings.workflow_services_url}/objects/druid:oo000oo0000/workflows"
 OkComputer::Registry.register "external-workflow-services-url", OkComputer::HttpCheck.new(workflows_url)
 
 # Replication (only) uses zip_storage directory to build the zips to send to zip endpoints


### PR DESCRIPTION
the optional okcomputer check for reachability was failing, because it was using a defunct URL.  this fixes the checked URL so that it's reachable again.

## Why was this change made?

when looking at the okcomputer checks with @kamchan (to investigate a nagios alert), i discovered some failing checks, of which this was one.  i assume the URL that was used before in this check went bad when we got rid of the need to refer to workflows by repository (@jcoyne?).

e.g. this URL returns a 404:  https://sul-lyberservices-test.stanford.edu/workflowsdr/objects/druid:oo000oo0000/workflows

but this URL returns a 200:  https://sul-lyberservices-test.stanford.edu/workflow/objects/druid:oo000oo0000/workflows

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

N/A