### PR TITLE
comment about exceptions to API token requirement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::API
   # IMPORTANT!  all non-API routes must be protected by shibboleth and restricted to an
   # appropritaly small workgroup.
   def non_api_route?
+    # no need to list /status (okcomputer) URLs here, because those aren't handled by ApplicationController
     request.fullpath.match(%r{^/resque(/.*)?$})
   end
 


### PR DESCRIPTION
## Why was this change made?

to clarify which URL requests need to be excluded explicitly from auth checks for an API token.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

comment only update