### PR TITLE
DB_UPDATE_FAILED message tweaked

### DIFF
--- a/app/lib/active_record_utils.rb
+++ b/app/lib/active_record_utils.rb
@@ -12,8 +12,9 @@ module ActiveRecordUtils
     rescue ActiveRecord::RecordNotFound => e
       audit_results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, e.inspect)
     rescue ActiveRecord::ActiveRecordError => e
+      Rails.logger.error("db update error; more context to follow: #{e.inspect}: #{e.backtrace.inspect}")
       audit_results.add_result(
-        AuditResults::DB_UPDATE_FAILED, "#{e.inspect} #{e.message} #{e.backtrace.inspect}"
+        AuditResults::DB_UPDATE_FAILED, e.inspect
       )
     end
     false


### PR DESCRIPTION
## Why was this change made?

Because stack traces are most useful in Rails logs, not in messages in the workflow service, or in argo.  Honeybadger generates its own stacktrace.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a