### PR TITLE
fix PreservationCatalog::Ibm::Audit#bucket, add a test

### DIFF
--- a/app/lib/preservation_catalog/ibm/audit.rb
+++ b/app/lib/preservation_catalog/ibm/audit.rb
@@ -4,7 +4,7 @@ module PreservationCatalog
   module Ibm
     # Methods for auditing the state of a ZippedMoabVersion on an IBM S3 compatible endpoint.
     class Audit
-      delegate :bucket, :bucket_name, to: ::PreservationCatalog::Ibm
+      delegate :bucket_name, to: ::PreservationCatalog::Ibm
 
       attr_reader :zmv, :results
 
@@ -70,6 +70,16 @@ module PreservationCatalog
           part.update(status: 'not_found', last_existence_check: Time.zone.now)
           false
         end
+      end
+
+      def bucket
+        endpoint = zmv.zip_endpoint.endpoint_name
+        ::PreservationCatalog::Ibm.configure(
+          region: Settings.zip_endpoints[endpoint].region,
+          access_key_id: Settings.zip_endpoints[endpoint].access_key_id,
+          secret_access_key: Settings.zip_endpoints[endpoint].secret_access_key
+        )
+        ::PreservationCatalog::Ibm.bucket
       end
     end
   end


### PR DESCRIPTION
same idea as #1310

## Why was this change made?

audits that check for replicated zip parts on the IBM endpoint are still failing.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

N/A

fixes #1337