### PR TITLE
Adds a storage root migration service and rake task.

### DIFF
--- a/app/services/storage_root_migration_service.rb
+++ b/app/services/storage_root_migration_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Migrates Complete Moab records to a new Moab Storate Root.
+class StorageRootMigrationService
+  def initialize(from_name, to_name)
+    @from_name = from_name
+    @to_name = to_name
+  end
+
+  # @return [Array<String>] druids of migrated moabs
+  def migrate
+    druids = []
+    from_root.complete_moabs.find_each do |complete_moab|
+      migrate_moab(complete_moab)
+      druids << complete_moab.preserved_object.druid
+    end
+    druids
+  end
+
+  private
+
+  def from_root
+    @from_root ||= MoabStorageRoot.find_by!(name: @from_name)
+  end
+
+  def to_root
+    @to_root ||= MoabStorageRoot.find_by!(name: @to_name)
+  end
+
+  def migrate_moab(moab)
+    moab.moab_storage_root = to_root
+    moab.status = 'validity_unknown' # This will queue a CV.
+    # Fate of this to be determined by https://github.com/sul-dlss/preservation_catalog/issues/1329
+    moab.last_moab_validation = nil
+    moab.last_checksum_validation = nil
+    moab.save!
+  end
+end

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :prescat do
+  desc 'Migrate storage root, returning druids of all migrated moabs'
+  task :migrate_storage_root, [:from, :to] => :environment do |_task, _args|
+    puts 'This will move all complete_moabs to a new storage root.'
+    puts 'WARNING: expects that "from" storage root is no longer being written to (no Moabs being created or modified)!'
+    print 'Enter YES to continue: '
+    input = $stdin.gets.chomp
+    next unless input == 'YES'
+
+    migration_service = StorageRootMigrationService.new(args[:from], args[:to])
+    migration_service.migrate.each { |druid| puts druid }
+  end
+end

--- a/spec/services/storage_root_migration_service_spec.rb
+++ b/spec/services/storage_root_migration_service_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StorageRootMigrationService do
+  let(:to_storage_root) { create(:moab_storage_root) }
+
+  let(:from_storage_root) { complete_moab1.moab_storage_root }
+
+  let(:complete_moab1) {
+    create(:complete_moab, status: 'ok',
+                           last_moab_validation: Time.now,
+                           last_checksum_validation: Time.now,
+                           last_archive_audit: Time.now)
+  }
+
+  let(:complete_moab2) { create(:complete_moab, status: 'invalid_moab', moab_storage_root: from_storage_root) }
+
+  let(:complete_moab3) { create(:complete_moab) }
+
+  it 'migrates the storage root' do
+    # Before migration
+    expect(complete_moab1.moab_storage_root).to eq(complete_moab2.moab_storage_root)
+    expect(complete_moab1.moab_storage_root).not_to eq(complete_moab3.moab_storage_root)
+
+    druids = described_class.new(from_storage_root.name, to_storage_root.name).migrate
+    expect(druids).to include(complete_moab1.preserved_object.druid, complete_moab2.preserved_object.druid)
+
+    complete_moab1.reload
+    complete_moab2.reload
+
+    expect(complete_moab1.moab_storage_root).to eq(to_storage_root)
+    expect(complete_moab2.moab_storage_root).to eq(to_storage_root)
+  end
+
+  it 'resets field values' do
+    described_class.new(from_storage_root.name, to_storage_root.name).migrate
+
+    complete_moab1.reload
+
+    expect(complete_moab1.status).to eq('validity_unknown')
+    expect(complete_moab1.last_moab_validation).to be_nil
+    expect(complete_moab1.last_checksum_validation).to be_nil
+    expect(complete_moab1.last_archive_audit).not_to be_nil
+  end
+
+  it 'does not migrate moabs on other storage roots' do
+    # Before migration
+    orig_complete_moab3_storage_root = complete_moab3.moab_storage_root
+
+    described_class.new(from_storage_root.name, to_storage_root.name).migrate
+
+    complete_moab3.reload
+
+    expect(complete_moab3.moab_storage_root).to eq(orig_complete_moab3_storage_root)
+  end
+end


### PR DESCRIPTION
closes #1322

## Why was this change made?
To update complete moab records when migrating storage roots.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
No.