### PR TITLE
[HOLD] rake task to dump list of druids on storage root to CSV file (select everything at once to memory)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,10 @@ Naming/FileName:
     - 'Gemfile'
     - 'lib/capistrano/tasks/capistrano-resque-pool.rake'
 
+RSpec/BeforeAfterAll:
+  Exclude:
+    - 'spec/services/reporter_spec.rb' # allows inter-example state leak, & after(:all) won't auto-rollback fixtures it creates, but used here for file cleanup
+
 RSpec/ContextWording:
   Enabled: false # too dogmatic
 
@@ -70,6 +74,10 @@ RSpec/ExampleLength:
 
 RSpec/ImplicitSubject: # we use this for `define_enum_for`, `validate_presence_of`, etc.
   Enabled: false
+
+RSpec/LeakyConstantDeclaration:
+  Exclude:
+    - 'spec/services/reporter_spec.rb' # rubocop doesn't like constants in specs because they leak between examples, but this one helps cleanup
 
 # we like 'expect(x).to receive' better than 'have_received'
 RSpec/MessageSpies:

--- a/app/services/reporter.rb
+++ b/app/services/reporter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+##
+# run queries and produce reports from the results, for consumption
+# by preservation catalog maintainers
+class Reporter
+  # @param [String] the name of the storage root for which druids should be listed
+  # @return [String] the name of the CSV file to which the list was written
+  def self.moab_storage_root_druid_list_to_csv(storage_root_name:, csv_filename: nil)
+    msr = MoabStorageRoot.find_by!(name: storage_root_name) # fail fast if given a bad storage root name
+
+    csv_filename ||= default_filename(filename_prefix: "MoabStorageRoot_#{storage_root_name}_druids", filename_suffix: 'csv')
+    raise "#{csv_filename} already exists, aborting!" if FileTest.exist?(csv_filename)
+
+    ensure_containing_dir(csv_filename)
+    CSV.open(csv_filename, 'w') do |csv|
+      msr.druid_list_sorted.each { |druid| csv << [druid] }
+    end
+
+    csv_filename
+  end
+
+  def self.default_filename(filename_prefix:, filename_suffix:)
+    File.join(default_filepath, "#{filename_prefix}_#{DateTime.now.utc.iso8601}.#{filename_suffix}")
+  end
+
+  def self.default_filepath
+    File.join(Rails.root, 'log', 'reports')
+  end
+
+  def self.ensure_containing_dir(filename)
+    basename_len = File.basename(filename).length
+    filepath_str = filename[0..-(basename_len + 1)] # add 1 to basename_len because ending at -1 gets the whole string
+    FileUtils.mkdir_p(filepath_str) unless FileTest.exist?(filepath_str)
+  end
+end

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -12,4 +12,12 @@ namespace :prescat do
     migration_service = StorageRootMigrationService.new(args[:from], args[:to])
     migration_service.migrate.each { |druid| puts druid }
   end
+
+  namespace :reports do
+    desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
+    task :msr_druids, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
+      csv_loc = Reporter.moab_storage_root_druid_list_to_csv(storage_root_name: args[:storage_root_name], csv_filename: args[:csv_filename])
+      puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
+    end
+  end
 end

--- a/spec/services/reporter_spec.rb
+++ b/spec/services/reporter_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Reporter do
+  TEST_START_TIME = DateTime.now # useful for both output cleanup and CSV filename testing
+
+  after(:all) do
+    next unless FileTest.exist?(described_class.default_filepath)
+    Dir.each_child(described_class.default_filepath) do |filename|
+      fullpath_filename = File.join(described_class.default_filepath, filename)
+      File.unlink(fullpath_filename) if File.stat(fullpath_filename).mtime > TEST_START_TIME
+    end
+  end
+
+  let!(:msr_a) { create(:moab_storage_root) }
+  let!(:complete_moab_1) { create(:complete_moab, moab_storage_root: msr_a) }
+  let!(:complete_moab_2) { create(:complete_moab, moab_storage_root: msr_a) }
+  let!(:complete_moab_3) { create(:complete_moab, moab_storage_root: msr_a) }
+
+  let!(:msr_b) { create(:moab_storage_root) }
+  let!(:complete_moab_4) { create(:complete_moab, moab_storage_root: msr_b) }
+  let!(:complete_moab_5) { create(:complete_moab, moab_storage_root: msr_b) }
+  let!(:complete_moab_6) { create(:complete_moab, moab_storage_root: msr_b) }
+
+  describe '.moab_storage_root_druid_list_to_csv' do
+    it 'creates a file containing a list of druids from the given storage root' do
+      csv_filename = described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_b.name)
+      expect(CSV.read(csv_filename)).to eq(
+        [complete_moab_4, complete_moab_5, complete_moab_6].map { |cm| [cm.preserved_object.druid] }
+      )
+    end
+
+    it 'names the file with the default prefix and a timestamp and writes it to the default location' do
+      csv_filename = described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_a.name)
+      expect(csv_filename).to match(%r{^#{described_class.default_filepath}\/MoabStorageRoot_#{msr_a.name}_druids_.*\.csv$})
+      timestamp_str = /MoabStorageRoot_#{msr_a.name}_druids_(.*)\.csv$/.match(csv_filename).captures[0]
+      expect(DateTime.parse(timestamp_str)).to be >= TEST_START_TIME
+    end
+
+    it 'allows the caller to specify an alternate filename, including full path' do
+      alternate_filename = '/tmp/my_cool_druid_export.csv'
+      csv_filename = described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_a.name, csv_filename: alternate_filename)
+      expect(csv_filename).to eq(alternate_filename)
+      expect(CSV.read(csv_filename)).to eq(
+        [complete_moab_1, complete_moab_2, complete_moab_3].map { |cm| [cm.preserved_object.druid] }
+      )
+    ensure
+      File.unlink(alternate_filename) if FileTest.exist?(alternate_filename)
+    end
+
+    it 'lets the DB error bubble up if the given storage root does not exist' do
+      expect { described_class.moab_storage_root_druid_list_to_csv(storage_root_name: 'nonexistent') }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'raises an error if the intended file name is already in use' do
+      duplicated_filename = File.join(described_class.default_filepath, 'my_duplicated_filename.csv')
+      described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_b.name, csv_filename: duplicated_filename)
+      expect {
+        described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_b.name, csv_filename: duplicated_filename)
+      }.to raise_error(StandardError, "#{duplicated_filename} already exists, aborting!")
+    end
+  end
+end


### PR DESCRIPTION
### HOLD:  likely superseded by #1347

## Why was this change made?

implementation for #1317, to help migrate moabs from old storage hardware to new

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

there is a description on the rake task.  happy to add to README if folks want, though i have a slight preference for further documenting this usage as part of process writeup for #1332.

closes #1317