### PR TITLE
rake task to dump list of druids on storage root to CSV file (page through select results w/ cursor)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'jwt' # for gating programmatic access to the application
 gem 'okcomputer' # ReST endpoint with upness status
 gem 'pg' # postgres database
 gem "factory_bot_rails", "~> 4.0"
+gem 'postgresql_cursor' # for paging over large result sets efficiently
 # pry is useful for debugging, even in prod
 gem 'pry-byebug' # call 'binding.pry' anywhere in the code to stop execution and get a pry-byebug console
 gem 'pry-rails' # use pry as the rails console shell instead of IRB

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,8 @@ GEM
     parser (2.7.0.2)
       ast (~> 2.4.0)
     pg (1.2.2)
+    postgresql_cursor (0.6.4)
+      activerecord (>= 3.1.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -406,6 +408,7 @@ DEPENDENCIES
   moab-versioning
   okcomputer
   pg
+  postgresql_cursor
   pry-byebug
   pry-rails
   puma (~> 3.12)

--- a/app/models/moab_storage_root.rb
+++ b/app/models/moab_storage_root.rb
@@ -4,10 +4,15 @@
 # Metadata about a Moab storage root (a POSIX file system which contains Moab objects).
 class MoabStorageRoot < ApplicationRecord
   has_many :complete_moabs, dependent: :restrict_with_exception
+  has_many :preserved_objects, through: :complete_moabs
   has_and_belongs_to_many :preservation_policies
 
   validates :name, presence: true, uniqueness: true
   validates :storage_location, presence: true
+
+  scope :preserved_objects, lambda {
+    joins(complete_moabs: [:preserved_object])
+  }
 
   # Use a queue to validate CompleteMoab objects
   def validate_expired_checksums!

--- a/app/services/reporter.rb
+++ b/app/services/reporter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+##
+# run queries and produce reports from the results, for consumption
+# by preservation catalog maintainers
+class Reporter
+  # @param [String] the name of the storage root for which druids should be listed
+  # @return [String] the name of the CSV file to which the list was written
+  def self.moab_storage_root_druid_list_to_csv(storage_root_name:, csv_filename: nil)
+    msr = MoabStorageRoot.find_by!(name: storage_root_name) # fail fast if given a bad storage root name
+
+    csv_filename ||= default_filename(filename_prefix: "MoabStorageRoot_#{storage_root_name}_druids", filename_suffix: 'csv')
+    raise "#{csv_filename} already exists, aborting!" if FileTest.exist?(csv_filename)
+
+    ensure_containing_dir(csv_filename)
+    CSV.open(csv_filename, 'w') do |csv|
+      PreservedObject
+        .joins(:complete_moabs)
+        .where(complete_moabs: { moab_storage_root: msr })
+        .select(:druid)
+        .order(:druid)
+        .each_row do |po_hash| # #each_row is from postgresql_cursor gem
+          csv << [po_hash['druid']]
+        end
+    end
+
+    csv_filename
+  end
+
+  def self.default_filename(filename_prefix:, filename_suffix:)
+    File.join(default_filepath, "#{filename_prefix}_#{DateTime.now.utc.iso8601}.#{filename_suffix}")
+  end
+
+  def self.default_filepath
+    File.join(Rails.root, 'log', 'reports')
+  end
+
+  def self.ensure_containing_dir(filename)
+    basename_len = File.basename(filename).length
+    filepath_str = filename[0..-(basename_len + 1)] # add 1 to basename_len because ending at -1 gets the whole string
+    FileUtils.mkdir_p(filepath_str) unless FileTest.exist?(filepath_str)
+  end
+end

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -12,4 +12,12 @@ namespace :prescat do
     migration_service = StorageRootMigrationService.new(args[:from], args[:to])
     migration_service.migrate.each { |druid| puts druid }
   end
+
+  namespace :reports do
+    desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
+    task :msr_druids, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
+      csv_loc = Reporter.moab_storage_root_druid_list_to_csv(storage_root_name: args[:storage_root_name], csv_filename: args[:csv_filename])
+      puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
+    end
+  end
 end

--- a/spec/services/reporter_spec.rb
+++ b/spec/services/reporter_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Reporter do
+  let!(:test_start_time) { DateTime.now } # useful for both output cleanup and CSV filename testing
+
+  let!(:msr_a) { create(:moab_storage_root) }
+  let!(:complete_moab_1) { create(:complete_moab, moab_storage_root: msr_a) }
+  let!(:complete_moab_2) { create(:complete_moab, moab_storage_root: msr_a) }
+  let!(:complete_moab_3) { create(:complete_moab, moab_storage_root: msr_a) }
+
+  let!(:msr_b) { create(:moab_storage_root) }
+  let!(:complete_moab_4) { create(:complete_moab, moab_storage_root: msr_b) }
+  let!(:complete_moab_5) { create(:complete_moab, moab_storage_root: msr_b) }
+  let!(:complete_moab_6) { create(:complete_moab, moab_storage_root: msr_b) }
+
+  after do
+    next unless FileTest.exist?(described_class.default_filepath)
+    Dir.each_child(described_class.default_filepath) do |filename|
+      fullpath_filename = File.join(described_class.default_filepath, filename)
+      File.unlink(fullpath_filename) if File.stat(fullpath_filename).mtime > test_start_time
+    end
+  end
+
+  describe '.moab_storage_root_druid_list_to_csv' do
+    it 'creates a file containing a list of druids from the given storage root' do
+      csv_filename = described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_b.name)
+      expect(CSV.read(csv_filename)).to eq(
+        [complete_moab_4, complete_moab_5, complete_moab_6].map { |cm| [cm.preserved_object.druid] }
+      )
+    end
+
+    it 'names the file with the default prefix and a timestamp and writes it to the default location' do
+      # file timestamp is to the second, but test_start_time is more precise.  this sleep allows us to compare
+      # timestamp to test start time without having to round fractions of a second.
+      sleep(1.second)
+
+      csv_filename = described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_a.name)
+      expect(csv_filename).to match(%r{^#{described_class.default_filepath}\/MoabStorageRoot_#{msr_a.name}_druids_.*\.csv$})
+      timestamp_str = /MoabStorageRoot_#{msr_a.name}_druids_(.*)\.csv$/.match(csv_filename).captures[0]
+      expect(DateTime.parse(timestamp_str)).to be >= test_start_time
+    end
+
+    it 'allows the caller to specify an alternate filename, including full path' do
+      alternate_filename = '/tmp/my_cool_druid_export.csv'
+      csv_filename = described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_a.name, csv_filename: alternate_filename)
+      expect(csv_filename).to eq(alternate_filename)
+      expect(CSV.read(csv_filename)).to eq(
+        [complete_moab_1, complete_moab_2, complete_moab_3].map { |cm| [cm.preserved_object.druid] }
+      )
+    ensure
+      File.unlink(alternate_filename) if FileTest.exist?(alternate_filename)
+    end
+
+    it 'lets the DB error bubble up if the given storage root does not exist' do
+      expect { described_class.moab_storage_root_druid_list_to_csv(storage_root_name: 'nonexistent') }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'raises an error if the intended file name is already in use' do
+      duplicated_filename = File.join(described_class.default_filepath, 'my_duplicated_filename.csv')
+      described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_b.name, csv_filename: duplicated_filename)
+      expect {
+        described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_b.name, csv_filename: duplicated_filename)
+      }.to raise_error(StandardError, "#{duplicated_filename} already exists, aborting!")
+    end
+  end
+end


### PR DESCRIPTION
* obtain results using DB cursor and page through them using default batch size to write CSV
  * install supporting gem for easier cursor usage

## Why was this change made?

this is an alternative implementation to #1345, prompted by PR review.

this implements #1317, to help migrate moabs from old storage hardware to new.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

there is a description on the rake task. happy to add to README if folks want, though i have a slight preference for further documenting this usage as part of process writeup for #1332.

closes #1317