### PR TITLE
add status_detail field to complete_moabs table; audit_results refactor

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -83,6 +83,7 @@ class AuditResults
     FILE_NOT_IN_MOAB,
     FILE_NOT_IN_SIGNATURE_CATALOG,
     INVALID_MANIFEST,
+    INVALID_MOAB,
     MANIFEST_NOT_IN_MOAB,
     MOAB_FILE_CHECKSUM_MISMATCH,
     MOAB_NOT_FOUND,
@@ -153,6 +154,8 @@ class AuditResults
     result_array.each do |r|
       log_result(r, logger)
       if r.key?(INVALID_MOAB)
+        # Temporary fix for workflow-service throwing exceptions
+        # because some error reports from MoabReplicationAudit are too long
         msg = "#{workflows_msg_prefix} || #{r.values.first}"
         WorkflowReporter.report_error(druid, actual_version, 'moab-valid', msg)
       elsif status_changed_to_ok?(r)

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -14,96 +14,96 @@
 #   result2 = {response_code => msg}
 class AuditResults
 
-  INVALID_ARGUMENTS = :invalid_arguments
-  VERSION_MATCHES = :version_matches
   ACTUAL_VERS_GT_DB_OBJ = :actual_vers_gt_db_obj
   ACTUAL_VERS_LT_DB_OBJ = :actual_vers_lt_db_obj
+  CM_PO_VERSION_MISMATCH = :cm_po_version_mismatch
+  CM_STATUS_CHANGED = :cm_status_changed
   CREATED_NEW_OBJECT = :created_new_object
-  DB_UPDATE_FAILED = :db_update_failed
   DB_OBJ_ALREADY_EXISTS = :db_obj_already_exists
   DB_OBJ_DOES_NOT_EXIST = :db_obj_does_not_exist
-  CM_STATUS_CHANGED = :cm_status_changed
-  UNEXPECTED_VERSION = :unexpected_version
-  INVALID_MOAB = :invalid_moab
-  CM_PO_VERSION_MISMATCH = :cm_po_version_mismatch
-  MOAB_NOT_FOUND = :moab_not_found
-  MOAB_FILE_CHECKSUM_MISMATCH = :moab_file_checksum_mismatch
-  MOAB_CHECKSUM_VALID = :moab_checksum_valid
-  FILE_NOT_IN_MOAB = :file_not_in_moab
+  DB_UPDATE_FAILED = :db_update_failed
   FILE_NOT_IN_MANIFEST = :file_not_in_manifest
+  FILE_NOT_IN_MOAB = :file_not_in_moab
   FILE_NOT_IN_SIGNATURE_CATALOG = :file_not_in_signature_catalog
-  MANIFEST_NOT_IN_MOAB = :manifest_not_in_moab
-  SIGNATURE_CATALOG_NOT_IN_MOAB = :signature_catalog_not_in_moab
+  INVALID_ARGUMENTS = :invalid_arguments
   INVALID_MANIFEST = :invalid_manifest
+  INVALID_MOAB = :invalid_moab
+  MANIFEST_NOT_IN_MOAB = :manifest_not_in_moab
+  MOAB_CHECKSUM_VALID = :moab_checksum_valid
+  MOAB_FILE_CHECKSUM_MISMATCH = :moab_file_checksum_mismatch
+  MOAB_NOT_FOUND = :moab_not_found
+  SIGNATURE_CATALOG_NOT_IN_MOAB = :signature_catalog_not_in_moab
   UNABLE_TO_CHECK_STATUS = :unable_to_check_status
-  ZIP_PART_NOT_FOUND = :zip_part_not_found
+  UNEXPECTED_VERSION = :unexpected_version
+  VERSION_MATCHES = :version_matches
   ZIP_PART_CHECKSUM_MISMATCH = :zip_part_checksum_mismatch
-  ZIP_PARTS_NOT_CREATED = :zip_parts_not_created
-  ZIP_PARTS_COUNT_INCONSISTENCY = :zip_parts_count_inconsistency
+  ZIP_PART_NOT_FOUND = :zip_part_not_found
   ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL = :zip_parts_count_differs_from_actual
+  ZIP_PARTS_COUNT_INCONSISTENCY = :zip_parts_count_inconsistency
   ZIP_PARTS_NOT_ALL_REPLICATED = :zip_parts_not_all_replicated
+  ZIP_PARTS_NOT_CREATED = :zip_parts_not_created
 
   RESPONSE_CODE_TO_MESSAGES = {
-    INVALID_ARGUMENTS => "encountered validation error(s): %{addl}",
-    VERSION_MATCHES => "actual version (%{actual_version}) matches %{addl} db version",
     ACTUAL_VERS_GT_DB_OBJ => "actual version (%{actual_version}) greater than %{db_obj_name} db version (%{db_obj_version})",
     ACTUAL_VERS_LT_DB_OBJ => "actual version (%{actual_version}) less than %{db_obj_name} db version (%{db_obj_version}); ERROR!",
+    CM_PO_VERSION_MISMATCH => "CompleteMoab online Moab version %{cm_version} does not match PreservedObject current_version %{po_version}",
+    CM_STATUS_CHANGED => "CompleteMoab status changed from %{old_status} to %{new_status}",
     CREATED_NEW_OBJECT => "added object to db as it did not exist",
-    DB_UPDATE_FAILED => "db update failed: %{addl}",
     DB_OBJ_ALREADY_EXISTS => "%{addl} db object already exists",
     DB_OBJ_DOES_NOT_EXIST => "%{addl} db object does not exist",
-    CM_STATUS_CHANGED => "CompleteMoab status changed from %{old_status} to %{new_status}",
-    UNEXPECTED_VERSION => "actual version (%{actual_version}) has unexpected relationship to %{db_obj_name} db version (%{db_obj_version}); ERROR!",
-    INVALID_MOAB => "Invalid Moab, validation errors: %{addl}",
-    CM_PO_VERSION_MISMATCH => "CompleteMoab online Moab version %{cm_version} does not match PreservedObject current_version %{po_version}",
-    MOAB_NOT_FOUND => "db CompleteMoab (created %{db_created_at}; last updated %{db_updated_at}) exists but Moab not found",
-    MOAB_FILE_CHECKSUM_MISMATCH => "checksums for %{file_path} version %{version} do not match.",
-    MOAB_CHECKSUM_VALID => "checksum(s) match",
-    FILE_NOT_IN_MOAB => "%{manifest_file_path} refers to file (%{file_path}) not found in Moab",
+    DB_UPDATE_FAILED => "db update failed: %{addl}",
     FILE_NOT_IN_MANIFEST => "Moab file %{file_path} was not found in Moab manifest %{manifest_file_path}",
+    FILE_NOT_IN_MOAB => "%{manifest_file_path} refers to file (%{file_path}) not found in Moab",
     FILE_NOT_IN_SIGNATURE_CATALOG => "Moab file %{file_path} was not found in Moab signature catalog %{signature_catalog_path}",
-    MANIFEST_NOT_IN_MOAB => "%{manifest_file_path} not found in Moab",
-    SIGNATURE_CATALOG_NOT_IN_MOAB => "%{signature_catalog_path} not found in Moab",
+    INVALID_ARGUMENTS => "encountered validation error(s): %{addl}",
     INVALID_MANIFEST => "unable to parse %{manifest_file_path} in Moab",
+    INVALID_MOAB => "Invalid Moab, validation errors: %{addl}",
+    MANIFEST_NOT_IN_MOAB => "%{manifest_file_path} not found in Moab",
+    MOAB_CHECKSUM_VALID => "checksum(s) match",
+    MOAB_FILE_CHECKSUM_MISMATCH => "checksums for %{file_path} version %{version} do not match.",
+    MOAB_NOT_FOUND => "db CompleteMoab (created %{db_created_at}; last updated %{db_updated_at}) exists but Moab not found",
+    SIGNATURE_CATALOG_NOT_IN_MOAB => "%{signature_catalog_path} not found in Moab",
     UNABLE_TO_CHECK_STATUS => "unable to validate when CompleteMoab status is %{current_status}",
-    ZIP_PART_NOT_FOUND => "replicated part not found on %{endpoint_name}: %{s3_key} was not found on %{bucket_name}",
+    UNEXPECTED_VERSION => "actual version (%{actual_version}) has unexpected relationship to %{db_obj_name} db version (%{db_obj_version}); ERROR!",
+    VERSION_MATCHES => "actual version (%{actual_version}) matches %{addl} db version",
     ZIP_PART_CHECKSUM_MISMATCH => "replicated md5 mismatch on %{endpoint_name}: %{s3_key} catalog md5 (%{md5}) doesn't match the replicated md5 (%{replicated_checksum}) on %{bucket_name}",
-    ZIP_PARTS_NOT_CREATED => "%{version} on %{endpoint_name}: no zip_parts exist yet for this ZippedMoabVersion",
-    ZIP_PARTS_COUNT_INCONSISTENCY => "%{version} on %{endpoint_name}: ZippedMoabVersion has variation in child parts_counts: %{child_parts_counts}",
+    ZIP_PART_NOT_FOUND => "replicated part not found on %{endpoint_name}: %{s3_key} was not found on %{bucket_name}",
     ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL => "%{version} on %{endpoint_name}: ZippedMoabVersion stated parts count (%{db_count}) doesn't match actual number of zip parts rows (%{actual_count})",
-    ZIP_PARTS_NOT_ALL_REPLICATED => "%{version} on %{endpoint_name}: not all ZippedMoabVersion parts are replicated yet: %{unreplicated_parts_list}"
+    ZIP_PARTS_COUNT_INCONSISTENCY => "%{version} on %{endpoint_name}: ZippedMoabVersion has variation in child parts_counts: %{child_parts_counts}",
+    ZIP_PARTS_NOT_ALL_REPLICATED => "%{version} on %{endpoint_name}: not all ZippedMoabVersion parts are replicated yet: %{unreplicated_parts_list}",
+    ZIP_PARTS_NOT_CREATED => "%{version} on %{endpoint_name}: no zip_parts exist yet for this ZippedMoabVersion"
   }.freeze
 
   WORKFLOW_REPORT_CODES = [
     ACTUAL_VERS_LT_DB_OBJ,
-    DB_UPDATE_FAILED,
-    DB_OBJ_ALREADY_EXISTS,
-    UNEXPECTED_VERSION,
     CM_PO_VERSION_MISMATCH,
-    MOAB_NOT_FOUND,
-    MOAB_FILE_CHECKSUM_MISMATCH,
-    FILE_NOT_IN_MOAB,
+    DB_OBJ_ALREADY_EXISTS,
+    DB_UPDATE_FAILED,
     FILE_NOT_IN_MANIFEST,
+    FILE_NOT_IN_MOAB,
     FILE_NOT_IN_SIGNATURE_CATALOG,
-    MANIFEST_NOT_IN_MOAB,
-    SIGNATURE_CATALOG_NOT_IN_MOAB,
     INVALID_MANIFEST,
-    UNABLE_TO_CHECK_STATUS
+    MANIFEST_NOT_IN_MOAB,
+    MOAB_FILE_CHECKSUM_MISMATCH,
+    MOAB_NOT_FOUND,
+    SIGNATURE_CATALOG_NOT_IN_MOAB,
+    UNABLE_TO_CHECK_STATUS,
+    UNEXPECTED_VERSION
     # Temporary fix for workflow-service throwing exceptions
     # because some error reports from MoabReplicationAudit are too long
-    # ZIP_PART_NOT_FOUND,
     # ZIP_PART_CHECKSUM_MISMATCH,
-    # ZIP_PARTS_COUNT_INCONSISTENCY,
+    # ZIP_PART_NOT_FOUND,
     # ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL,
+    # ZIP_PARTS_COUNT_INCONSISTENCY,
     # ZIP_PARTS_NOT_ALL_REPLICATED
   ].freeze
 
   HONEYBADGER_REPORT_CODES = [
     MOAB_FILE_CHECKSUM_MISMATCH,
-    ZIP_PART_NOT_FOUND,
     ZIP_PART_CHECKSUM_MISMATCH,
-    ZIP_PARTS_COUNT_INCONSISTENCY,
+    ZIP_PART_NOT_FOUND,
     ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL,
+    ZIP_PARTS_COUNT_INCONSISTENCY,
     ZIP_PARTS_NOT_ALL_REPLICATED
   ].freeze
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,6 +5,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
   host: <%= ENV.fetch("POSTGRES_HOST", 'localhost') %>
+  port: <%= ENV.fetch("POSTGRES_PORT", '5432') %>
   user: <%= ENV.fetch("PGUSER", 'postgres') %>
   password: <%= ENV.fetch("PGPASSWORD", 'sekret') %>
 

--- a/db/migrate/20200122001712_add_status_details_to_complete_moabs.rb
+++ b/db/migrate/20200122001712_add_status_details_to_complete_moabs.rb
@@ -1,0 +1,5 @@
+class AddStatusDetailsToCompleteMoabs < ActiveRecord::Migration[5.1]
+  def change
+    add_column :complete_moabs, :status_details, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_10_203927) do
+ActiveRecord::Schema.define(version: 2020_01_22_001712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2018_10_10_203927) do
     t.integer "status", null: false
     t.datetime "last_version_audit"
     t.datetime "last_archive_audit"
+    t.string "status_details"
     t.index ["created_at"], name: "index_complete_moabs_on_created_at"
     t.index ["last_archive_audit"], name: "index_complete_moabs_on_last_archive_audit"
     t.index ["last_checksum_validation"], name: "index_complete_moabs_on_last_checksum_validation"


### PR DESCRIPTION
## Why was this change made?

Connects to #1331 - have the db retain full audit error info for Moabs.  This is related to preservation migration work (an easy way to see what the last audit showed).  It is also a prerequisite for #1249 - have audit results available via ReST API call instead of using workflows for this information.

This PR should unblock some pres migration work;  I will continue working on *populating* this new field in a separate PR.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a
