### PR TITLE
write to status_details for complete_moab

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -177,6 +177,10 @@ class AuditResults
     /to ok$/.match(result[AuditResults::CM_STATUS_CHANGED]) != nil
   end
 
+  def results_as_string(error_results)
+    "#{string_prefix} #{error_results.map(&:values).flatten.join(' && ')}"
+  end
+
   def to_json(*_args)
     { druid: druid, result_array: result_array }.to_json
   end
@@ -213,10 +217,6 @@ class AuditResults
 
   def log_msg_prefix
     @log_msg_prefix ||= "#{check_name}(#{druid}, #{moab_storage_root&.name})"
-  end
-
-  def results_as_string(error_results)
-    "#{string_prefix} #{error_results.map(&:values).flatten.join(' && ')}"
   end
 
   def string_prefix

--- a/app/services/moab_validation_handler.rb
+++ b/app/services/moab_validation_handler.rb
@@ -54,11 +54,14 @@ module MoabValidationHandler
 
   def update_status(new_status)
     complete_moab.status = new_status
-    return unless complete_moab.status_changed?
 
-    results.add_result(
-      AuditResults::CM_STATUS_CHANGED, old_status: complete_moab.status_was, new_status: complete_moab.status
-    )
+    if complete_moab.status_changed?
+      results.add_result(
+        AuditResults::CM_STATUS_CHANGED, old_status: complete_moab.status_was, new_status: complete_moab.status
+      )
+    end
+
+    complete_moab.status_details = results.results_as_string(results.result_array)
   end
 
   # found_expected_version is a boolean indicating whether the latest version of the moab

--- a/app/services/storage_root_migration_service.rb
+++ b/app/services/storage_root_migration_service.rb
@@ -30,7 +30,7 @@ class StorageRootMigrationService
   def migrate_moab(moab)
     moab.moab_storage_root = to_root
     moab.status = 'validity_unknown' # This will queue a CV.
-    # Fate of this to be determined by https://github.com/sul-dlss/preservation_catalog/issues/1329
+    moab.status_details = nil
     moab.last_moab_validation = nil
     moab.last_checksum_validation = nil
     moab.save!

--- a/spec/lib/audit/catalog_to_moab_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_spec.rb
@@ -14,8 +14,15 @@ RSpec.describe Audit::CatalogToMoab do
   end
   let(:logger_double) { instance_double(Logger, info: nil, error: nil, add: nil) }
   let(:results_double) do
-    instance_double(AuditResults, add_result: nil, :actual_version= => nil, :check_name= => nil, report_results: nil)
+    instance_double(AuditResults,
+                    add_result: nil,
+                    :actual_version= => nil,
+                    :check_name= => nil,
+                    report_results: nil,
+                    result_array: [],
+                    results_as_string: nil)
   end
+  let(:exp_details_prefix) { 'check_catalog_version (actual location: fixture_sr1; ' }
 
   before do
     allow(WorkflowReporter).to receive(:report_error)
@@ -39,6 +46,7 @@ RSpec.describe Audit::CatalogToMoab do
 
   describe '#check_catalog_version' do
     let(:object_dir) { "#{storage_location}/#{DruidTools::Druid.new(druid).tree.join('/')}" }
+    let(:b4_details) { 'before details' }
 
     before { comp_moab.ok! }
 
@@ -89,7 +97,7 @@ RSpec.describe Audit::CatalogToMoab do
         c2m.check_catalog_version
       end
 
-      context 'updates status correctly' do
+      context 'updates status and status_details correctly' do
         [
           'validity_unknown',
           'ok',
@@ -98,11 +106,23 @@ RSpec.describe Audit::CatalogToMoab do
           'unexpected_version_on_storage',
           'invalid_checksum'
         ].each do |orig_status|
-          it "had #{orig_status}, should now have ONLINE_MOAB_NOT_FOUND_STATUS" do
-            comp_moab.status = orig_status
-            comp_moab.save!
-            c2m.check_catalog_version
-            expect(comp_moab.reload.status).to eq 'online_moab_not_found'
+          context "had #{orig_status};" do
+            before do
+              comp_moab.status = orig_status
+              comp_moab.status_details = b4_details
+              comp_moab.save!
+              c2m.check_catalog_version
+            end
+
+            it "status becomes 'online_moab_not_found'" do
+              expect(comp_moab.reload.status).to eq 'online_moab_not_found'
+            end
+
+            it "status_details updated" do
+              exp = exp_details_prefix + ') '
+              exp += "CompleteMoab status changed from #{orig_status} to online_moab_not_found" unless orig_status == 'online_moab_not_found'
+              expect(comp_moab.reload.status_details).to eq exp
+            end
           end
         end
       end
@@ -119,24 +139,41 @@ RSpec.describe Audit::CatalogToMoab do
     end
 
     context 'complete_moab version != current_version of preserved_object' do
+      # database is inconsistent with itself!
       before do
         comp_moab.version = 666
+        comp_moab.status_details = b4_details
+        comp_moab.ok!
+        allow(Moab::StorageObject).to receive(:new).with(druid, a_string_matching(object_dir))
         c2m.instance_variable_set(:@results, results_double)
-      end
-
-      it 'adds a CM_PO_VERSION_MISMATCH result and finishes processing' do
-        expect(c2m.results).to receive(:add_result).with(
+        allow(c2m.results).to receive(:add_result).with(
           AuditResults::CM_PO_VERSION_MISMATCH,
           cm_version: comp_moab.version,
           po_version: comp_moab.preserved_object.current_version
         )
-        expect(Moab::StorageObject).not_to receive(:new).with(druid, a_string_matching(object_dir))
+        allow(c2m.results).to receive(:report_results)
         c2m.check_catalog_version
       end
 
+      it 'adds a CM_PO_VERSION_MISMATCH result and finishes processing' do
+        expect(Moab::StorageObject).not_to have_received(:new).with(druid, a_string_matching(object_dir))
+        expect(c2m.results).to have_received(:add_result).with(
+          AuditResults::CM_PO_VERSION_MISMATCH,
+          cm_version: comp_moab.version,
+          po_version: comp_moab.preserved_object.current_version
+        )
+      end
+
       it 'calls AuditResults.report_results' do
-        expect(c2m.results).to receive(:report_results)
-        c2m.check_catalog_version
+        expect(c2m.results).to have_received(:report_results)
+      end
+
+      it "does NOT update status" do
+        expect(comp_moab.reload.status).to eq 'ok'
+      end
+
+      it 'does NOT update status_details' do
+        expect(comp_moab.reload.status_details).to eq b4_details
       end
     end
 
@@ -147,61 +184,102 @@ RSpec.describe Audit::CatalogToMoab do
         c2m.check_catalog_version
       end
 
-      context 'check whether CompleteMoab already has a status other than OK_STATUS, re-check status if so;' do
-        it "had OK_STATUS, should keep OK_STATUS" do
+      context "starts with status 'ok'" do
+        before do
+          c2m.instance_variable_set(:@results, results_double)
+          allow(c2m.results).to receive(:add_result).with(AuditResults::VERSION_MATCHES, 'CompleteMoab')
+          comp_moab.status_details = b4_details
           comp_moab.ok!
-          allow(c2m).to receive(:moab_validation_errors).and_return([])
           c2m.check_catalog_version
+        end
+
+        it "does NOT update status" do
           expect(comp_moab.reload).to be_ok
         end
 
+        it 'does NOT update status_details' do
+          expect(comp_moab.reload.status_details).to eq b4_details
+        end
+      end
+
+      context "re-check when CompleteMoab does not start with status 'ok'" do
         [
           'validity_unknown',
           'online_moab_not_found',
           'invalid_moab',
           'unexpected_version_on_storage'
         ].each do |orig_status|
-          it "had #{orig_status}, should now have validity_unknown" do
-            comp_moab.status = orig_status
-            comp_moab.save!
-            allow(c2m).to receive(:moab_validation_errors).and_return([])
-            c2m.check_catalog_version
-            expect(comp_moab.reload).to be_validity_unknown
+          context "had #{orig_status} and found no moab validation errors;" do
+            before do
+              comp_moab.status = orig_status
+              comp_moab.status_details = b4_details
+              comp_moab.save!
+              allow(c2m).to receive(:moab_validation_errors).and_return([])
+              c2m.check_catalog_version
+            end
+
+            it "status becomes validity_unknown" do
+              expect(comp_moab.reload.status).to eq 'validity_unknown'
+            end
+
+            it "updates status_details" do
+              exp = exp_details_prefix + 'actual version: 3) '
+              exp += "CompleteMoab status changed from #{orig_status} to validity_unknown" unless orig_status == 'validity_unknown'
+              expect(comp_moab.reload.status_details).to eq exp
+            end
           end
         end
 
-        # 'ok' intentionally omitted, since we don't check status on disk
-        # if versions match
+        # 'ok' intentionally omitted, since we don't check status on disk if versions match
         [
           'validity_unknown',
           'online_moab_not_found',
           'invalid_moab',
           'unexpected_version_on_storage'
         ].each do |orig_status|
-          it "had #{orig_status}, should now have INVALID_MOAB_STATUS" do
-            comp_moab.status = orig_status
-            comp_moab.save!
-            allow(c2m).to receive(:moab_validation_errors).and_return(
-              [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
-            )
-            c2m.check_catalog_version
-            expect(comp_moab.reload.status).to eq 'invalid_moab'
+          context "had #{orig_status} and found moab validation errors;" do
+            before do
+              comp_moab.status = orig_status
+              comp_moab.status_details = b4_details
+              comp_moab.save!
+              allow(c2m).to receive(:moab_validation_errors).and_return(
+                [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
+              )
+              c2m.check_catalog_version
+            end
+
+            it "status becomes INVALID_MOAB_STATUS" do
+              expect(comp_moab.reload.status).to eq 'invalid_moab'
+            end
+
+            it "updates status_details" do
+              exp = exp_details_prefix + 'actual version: 3) '
+              exp += "CompleteMoab status changed from #{orig_status} to invalid_moab" unless orig_status == 'invalid_moab'
+              expect(comp_moab.reload.status_details).to eq exp
+            end
           end
         end
 
         context 'started with INVALID_CHECKSUM_STATUS' do
-          before { comp_moab.invalid_checksum! }
-
-          it 'remains in INVALID_CHECKSUM_STATUS' do
+          before do
+            comp_moab.status_details = b4_details
+            comp_moab.invalid_checksum!
+            comp_moab.save!
             allow(c2m).to receive(:moab_validation_errors).and_return(
               [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
             )
             c2m.check_catalog_version
+          end
+
+          it 'status remains invalid_checksum' do
             expect(comp_moab.reload.status).to eq 'invalid_checksum'
           end
 
+          it 'does NOT update status_details' do
+            expect(comp_moab.reload.status_details).to eq b4_details
+          end
+
           it 'has an AuditResults entry indicating inability to check the given status' do
-            c2m.check_catalog_version
             expect(c2m.results.contains_result_code?(AuditResults::UNABLE_TO_CHECK_STATUS)).to eq true
           end
         end
@@ -231,13 +309,25 @@ RSpec.describe Audit::CatalogToMoab do
             'invalid_moab',
             'unexpected_version_on_storage'
           ].each do |orig_status|
-            it "#{orig_status} changes to validity_unknown" do
-              comp_moab.status = orig_status
-              comp_moab.save!
-              allow(mock_sov).to receive(:validation_errors).and_return([])
-              allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
-              c2m.check_catalog_version
-              expect(comp_moab.reload).to be_validity_unknown
+            context "had #{orig_status};" do
+              before do
+                comp_moab.status = orig_status
+                comp_moab.status_details = b4_details
+                comp_moab.save!
+                allow(mock_sov).to receive(:validation_errors).and_return([])
+                allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
+                c2m.check_catalog_version
+              end
+
+              it "status becomes 'validity_unknown'" do
+                expect(comp_moab.reload).to be_validity_unknown
+              end
+
+              it 'status_details updated' do
+                exp = exp_details_prefix + 'actual version: 4) '
+                exp += "CompleteMoab status changed from #{orig_status} to validity_unknown" unless orig_status == 'validity_unknown'
+                expect(comp_moab.reload.status_details).to eq exp
+              end
             end
           end
         end
@@ -249,15 +339,27 @@ RSpec.describe Audit::CatalogToMoab do
             'online_moab_not_found',
             'unexpected_version_on_storage'
           ].each do |orig_status|
-            it "#{orig_status} changes to INVALID_MOAB_STATUS" do
-              comp_moab.status = orig_status
-              comp_moab.save!
-              allow(mock_sov).to receive(:validation_errors).and_return(
-                [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
-              )
-              allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
-              c2m.check_catalog_version
-              expect(comp_moab.reload.status).to eq 'invalid_moab'
+            context "had #{orig_status}" do
+              before do
+                comp_moab.status = orig_status
+                comp_moab.status_details = b4_details
+                comp_moab.save!
+                allow(mock_sov).to receive(:validation_errors).and_return(
+                  [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
+                )
+                allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
+                c2m.check_catalog_version
+              end
+
+              it "status becomes 'invalid_moab'" do
+                expect(comp_moab.reload.status).to eq 'invalid_moab'
+              end
+
+              it 'status_details updated' do
+                exp = exp_details_prefix + 'actual version: 4) Invalid Moab, validation errors: ["err msg"] && ' \
+                      "CompleteMoab status changed from #{orig_status} to invalid_moab"
+                expect(comp_moab.reload.status_details).to eq exp
+              end
             end
           end
 
@@ -269,27 +371,33 @@ RSpec.describe Audit::CatalogToMoab do
             allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
             c2m.check_catalog_version
             expect(comp_moab.reload.status).to eq 'validity_unknown'
+            exp = exp_details_prefix + 'actual version: 4) Invalid Moab, validation errors: ["err msg"]'
+            expect(comp_moab.status_details).to eq exp
           end
         end
 
-        context 'had INVALID_CHECKSUM_STATUS (which C2M cannot validate)' do
+        context 'starts with INVALID_CHECKSUM_STATUS (which C2M cannot validate)' do
           before do
             allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
             comp_moab.invalid_checksum!
           end
 
-          it 'may have moab validation errors, but should still have INVALID_CHECKSUM_STATUS' do
+          it 'may have moab validation errors but does not update status or status_details' do
+            orig_details = comp_moab.status_details
             allow(mock_sov).to receive(:validation_errors).and_return(
               [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
             )
             c2m.check_catalog_version
             expect(comp_moab.reload.status).to eq 'invalid_checksum'
+            expect(comp_moab.status_details).to eq orig_details
           end
 
-          it 'would have no moab validation errors, but should still have INVALID_CHECKSUM_STATUS' do
+          it 'without moab validation errors does not update status or status_details' do
+            orig_details = comp_moab.status_details
             allow(mock_sov).to receive(:validation_errors).and_return([])
             c2m.check_catalog_version
             expect(comp_moab.reload.status).to eq 'invalid_checksum'
+            expect(comp_moab.status_details).to eq orig_details
           end
 
           it 'has an AuditResults entry indicating inability to check the given status' do
@@ -320,32 +428,47 @@ RSpec.describe Audit::CatalogToMoab do
         c2m.check_catalog_version
       end
 
-      it 'valid moab sets status to UNEXPECTED_VERSION_ON_STORAGE_STATUS' do
+      it 'valid moab sets status to "unexpected_version_on_storage"' do
         orig = comp_moab.status
+        expect(orig).to eq 'ok'
         c2m.check_catalog_version
         new_status = comp_moab.reload.status
         expect(new_status).not_to eq orig
         expect(new_status).to eq 'unexpected_version_on_storage'
       end
 
+      it 'valid moab updates status_details' do
+        c2m.check_catalog_version
+        exp = exp_details_prefix + 'actual version: 2) CompleteMoab status changed from ok to unexpected_version_on_storage'
+        expect(comp_moab.reload.status_details).to eq exp
+      end
+
       context 'moab not found' do
         before do
           allow(mock_sov).to receive(:validation_errors).and_raise(Errno::ENOENT)
           allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
+          my_results_double = instance_double(AuditResults,
+                                              add_result: nil,
+                                              :actual_version= => nil,
+                                              :check_name= => nil,
+                                              report_results: nil,
+                                              result_array: [],
+                                              results_as_string: 'mock results as string')
+          c2m.instance_variable_set(:@results, my_results_double)
+          allow(c2m.results).to receive(:add_result).with(AuditResults::MOAB_NOT_FOUND, anything)
+          c2m.check_catalog_version
         end
 
         it 'sets status to online_moab_not_found' do
-          orig = comp_moab.status
-          c2m.check_catalog_version
-          new_status = comp_moab.reload.status
-          expect(new_status).not_to eq orig
-          expect(new_status).to eq 'online_moab_not_found'
+          expect(comp_moab.reload.status).to eq 'online_moab_not_found'
+        end
+
+        it 'updates status_details' do
+          expect(comp_moab.reload.status_details).to eq 'mock results as string'
         end
 
         it 'adds a MOAB_NOT_FOUND result' do
-          c2m.instance_variable_set(:@results, results_double)
-          expect(c2m.results).to receive(:add_result).with(AuditResults::MOAB_NOT_FOUND, anything)
-          c2m.check_catalog_version
+          expect(c2m.results).to have_received(:add_result).with(AuditResults::MOAB_NOT_FOUND, anything)
         end
       end
 
@@ -353,20 +476,28 @@ RSpec.describe Audit::CatalogToMoab do
         before do
           allow(mock_sov).to receive(:validation_errors).and_return([foo: 'error message'])
           allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
+          my_results_double = instance_double(AuditResults,
+                                              add_result: nil,
+                                              :actual_version= => nil,
+                                              :check_name= => nil,
+                                              report_results: nil,
+                                              result_array: [],
+                                              results_as_string: 'mock results as string')
+          c2m.instance_variable_set(:@results, my_results_double)
+          allow(c2m.results).to receive(:add_result).with(AuditResults::INVALID_MOAB, anything)
+          c2m.check_catalog_version
         end
 
         it 'sets status to INVALID_MOAB_STATUS' do
-          orig = comp_moab.status
-          c2m.check_catalog_version
-          new_status = comp_moab.reload.status
-          expect(new_status).not_to eq orig
-          expect(new_status).to eq 'invalid_moab'
+          expect(comp_moab.reload.status).to eq 'invalid_moab'
+        end
+
+        it 'updates status_details' do
+          expect(comp_moab.reload.status_details).to eq 'mock results as string'
         end
 
         it 'adds an INVALID_MOAB result' do
-          c2m.instance_variable_set(:@results, results_double)
-          expect(c2m.results).to receive(:add_result).with(AuditResults::INVALID_MOAB, anything)
-          c2m.check_catalog_version
+          expect(c2m.results).to have_received(:add_result).with(AuditResults::INVALID_MOAB, anything)
         end
       end
 
@@ -386,12 +517,26 @@ RSpec.describe Audit::CatalogToMoab do
           'invalid_moab',
           'unexpected_version_on_storage'
         ].each do |orig_status|
-          it "had #{orig_status}, should now have EXPECTED_VERS_NOT_FOUND_ON_STORAGE_STATUS" do
-            comp_moab.status = orig_status
-            comp_moab.save!
-            allow(c2m).to receive(:moab_validation_errors).and_return([])
-            c2m.check_catalog_version
-            expect(comp_moab.reload.status).to eq 'unexpected_version_on_storage'
+          context "had #{orig_status};" do
+            before do
+              comp_moab.status = orig_status
+              comp_moab.status_details = b4_details
+              comp_moab.save!
+              allow(c2m).to receive(:moab_validation_errors).and_return([])
+              c2m.check_catalog_version
+            end
+
+            it 'status becomes unexpected_version_on_storage' do
+              expect(comp_moab.reload.status).to eq 'unexpected_version_on_storage'
+            end
+
+            it 'status_details updated' do
+              exp = exp_details_prefix + 'actual version: 2) '
+              unless orig_status == 'unexpected_version_on_storage'
+                exp += "CompleteMoab status changed from #{orig_status} to unexpected_version_on_storage"
+              end
+              expect(comp_moab.reload.status_details).to eq exp
+            end
           end
         end
 
@@ -402,35 +547,50 @@ RSpec.describe Audit::CatalogToMoab do
           'invalid_moab',
           'unexpected_version_on_storage'
         ].each do |orig_status|
-          it "had #{orig_status}, should now have INVALID_MOAB_STATUS" do
-            comp_moab.status = orig_status
-            comp_moab.save!
-            allow(c2m).to receive(:moab_validation_errors).and_return(
-              [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
-            )
-            c2m.check_catalog_version
-            expect(comp_moab.reload.status).to eq 'invalid_moab'
+          context "had #{orig_status};" do
+            before do
+              comp_moab.status = orig_status
+              comp_moab.status_details = b4_details
+              comp_moab.save!
+              allow(c2m).to receive(:moab_validation_errors).and_return(
+                [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
+              )
+              c2m.check_catalog_version
+            end
+
+            it "status becomes 'invalid_moab'" do
+              expect(comp_moab.reload.status).to eq 'invalid_moab'
+            end
+
+            it 'status_details updated' do
+              exp = exp_details_prefix + 'actual version: 2) '
+              exp += "CompleteMoab status changed from #{orig_status} to invalid_moab" unless orig_status == 'invalid_moab'
+              expect(comp_moab.reload.status_details).to eq exp
+            end
           end
         end
 
         context 'had INVALID_CHECKSUM_STATUS, which C2M cannot validate' do
           before do
             allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
+            comp_moab.status_details = b4_details
             comp_moab.invalid_checksum!
           end
 
-          it 'may have moab validation errors, but should still have INVALID_CHECKSUM_STATUS' do
+          it 'may have moab validation errors but does not update status or status_details' do
             allow(mock_sov).to receive(:validation_errors).and_return(
               [{ Moab::StorageObjectValidator::MISSING_DIR => 'err msg' }]
             )
             c2m.check_catalog_version
             expect(comp_moab.reload.status).to eq 'invalid_checksum'
+            expect(comp_moab.reload.status_details).to eq b4_details
           end
 
-          it 'would have no moab validation errors, but should still have INVALID_CHECKSUM_STATUS' do
+          it 'without moab validation errors does not update status or status_details' do
             allow(mock_sov).to receive(:validation_errors).and_return([])
             c2m.check_catalog_version
             expect(comp_moab.reload.status).to eq 'invalid_checksum'
+            expect(comp_moab.reload.status_details).to eq b4_details
           end
 
           it 'has an AuditResults entry indicating inability to check the given status' do

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe AuditResults do
         audit_results.report_results
       end
 
-      it 'multiple errors are concatenated together with || separator' do
+      it 'multiple errors are concatenated together with && separator' do
         code1 = AuditResults::CM_PO_VERSION_MISMATCH
         result_msg_args1 = { cm_version: 1, po_version: 2 }
         audit_results.add_result(code1, result_msg_args1)
@@ -256,7 +256,7 @@ RSpec.describe AuditResults do
       end
     end
 
-    context 'resets workflow error' do
+    context 'resets error in workflow service' do
       it 'has AuditResult:CM_STATUS_CHANGED and PreseredCopy::OK_STATUS' do
         result_code = AuditResults::CM_STATUS_CHANGED
         addl_hash = { old_status: 'invalid_checksum', new_status: 'ok' }

--- a/spec/services/shared_examples_preserved_object_handler.rb
+++ b/spec/services/shared_examples_preserved_object_handler.rb
@@ -53,7 +53,11 @@ end
 
 RSpec.shared_examples 'calls AuditResults.report_results' do |method_sym|
   it 'outputs results to Rails.logger and sends errors to WorkflowErrorReporter' do
-    mock_results = instance_double(AuditResults, add_result: nil, :check_name= => nil)
+    mock_results = instance_double(AuditResults,
+                                   add_result: nil,
+                                   :check_name= => nil,
+                                   result_array: [],
+                                   results_as_string: nil)
     expect(mock_results).to receive(:report_results)
     allow(po_handler).to receive(:results).and_return(mock_results)
     po_handler.send(method_sym)

--- a/spec/services/storage_root_migration_service_spec.rb
+++ b/spec/services/storage_root_migration_service_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe StorageRootMigrationService do
     complete_moab1.reload
 
     expect(complete_moab1.status).to eq('validity_unknown')
+    expect(complete_moab1.status_details).to be_nil
     expect(complete_moab1.last_moab_validation).to be_nil
     expect(complete_moab1.last_checksum_validation).to be_nil
     expect(complete_moab1.last_archive_audit).not_to be_nil


### PR DESCRIPTION
FIxes #1331

Replaces PR #1352

## Why was this change made?

To populate the status_details field for a CompleteMoab with any error results from the latest audit of the Moab. This helps us with storage root migration, and it also positions us to provide audit results via ReST API (#1249)

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a