### PR TITLE
Add additional relationship for migrated moab storage root

### DIFF
--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -20,6 +20,8 @@ class CompleteMoab < ApplicationRecord
 
   belongs_to :preserved_object, inverse_of: :complete_moabs
   belongs_to :moab_storage_root, inverse_of: :complete_moabs
+  belongs_to :from_moab_storage_root, class_name: 'MoabStorageRoot', required: false
+
   has_many :zipped_moab_versions, dependent: :restrict_with_exception, inverse_of: :complete_moab
 
   delegate :s3_key, to: :druid_version_zip

--- a/app/models/moab_storage_root.rb
+++ b/app/models/moab_storage_root.rb
@@ -4,6 +4,7 @@
 # Metadata about a Moab storage root (a POSIX file system which contains Moab objects).
 class MoabStorageRoot < ApplicationRecord
   has_many :complete_moabs, dependent: :restrict_with_exception
+  has_many :migrated_moabs, class_name: 'CompleteMoab', foreign_key: :from_moab_storage_root_id
   has_many :preserved_objects, through: :complete_moabs
   has_and_belongs_to_many :preservation_policies
 

--- a/app/services/storage_root_migration_service.rb
+++ b/app/services/storage_root_migration_service.rb
@@ -28,6 +28,7 @@ class StorageRootMigrationService
   end
 
   def migrate_moab(moab)
+    moab.from_moab_storage_root = from_root
     moab.moab_storage_root = to_root
     moab.status = 'validity_unknown' # This will queue a CV.
     # Fate of this to be determined by https://github.com/sul-dlss/preservation_catalog/issues/1329

--- a/db/migrate/20200206163659_add_from_moab_storage_root_to_complete_moabs.rb
+++ b/db/migrate/20200206163659_add_from_moab_storage_root_to_complete_moabs.rb
@@ -1,6 +1,6 @@
 class AddFromMoabStorageRootToCompleteMoabs < ActiveRecord::Migration[6.0]
   def change
     add_column :complete_moabs, :from_moab_storage_root_id, :bigint
-    add_foreign_key :complete_moabs, :complete_moabs, column: :from_moab_storage_root_id
+    add_foreign_key :complete_moabs, :moab_storage_roots, column: :from_moab_storage_root_id
   end
 end

--- a/db/migrate/20200206163659_add_from_moab_storage_root_to_complete_moabs.rb
+++ b/db/migrate/20200206163659_add_from_moab_storage_root_to_complete_moabs.rb
@@ -1,6 +1,8 @@
 class AddFromMoabStorageRootToCompleteMoabs < ActiveRecord::Migration[6.0]
   def change
     add_column :complete_moabs, :from_moab_storage_root_id, :bigint
-    add_foreign_key :complete_moabs, :moab_storage_roots, column: :from_moab_storage_root_id
+    add_foreign_key :complete_moabs, :moab_storage_roots, column: :from_moab_storage_root_id 
+    add_index :complete_moabs, :from_moab_storage_root_id, :unique => false,
+      name: 'index_complete_moabs_on_from_moab_storage_root_id' 
   end
 end

--- a/db/migrate/20200206163659_add_from_moab_storage_root_to_complete_moabs.rb
+++ b/db/migrate/20200206163659_add_from_moab_storage_root_to_complete_moabs.rb
@@ -1,0 +1,6 @@
+class AddFromMoabStorageRootToCompleteMoabs < ActiveRecord::Migration[6.0]
+  def change
+    add_column :complete_moabs, :from_moab_storage_root_id, :bigint
+    add_foreign_key :complete_moabs, :complete_moabs, column: :from_moab_storage_root_id
+  end
+end

--- a/db/migrate/20200206163659_add_migrated_at_to_complete_moabs.rb
+++ b/db/migrate/20200206163659_add_migrated_at_to_complete_moabs.rb
@@ -1,5 +1,0 @@
-class AddMigratedAtToCompleteMoabs < ActiveRecord::Migration[6.0]
-  def change
-    add_column :complete_moabs, :from_moab_storage_root_id, :bigint
-  end
-end

--- a/db/migrate/20200206163659_add_migrated_at_to_complete_moabs.rb
+++ b/db/migrate/20200206163659_add_migrated_at_to_complete_moabs.rb
@@ -1,0 +1,5 @@
+class AddMigratedAtToCompleteMoabs < ActiveRecord::Migration[6.0]
+  def change
+    add_column :complete_moabs, :from_moab_storage_root_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2020_02_06_163659) do
     t.string "status_details"
     t.bigint "from_moab_storage_root_id"
     t.index ["created_at"], name: "index_complete_moabs_on_created_at"
+    t.index ["from_moab_storage_root_id"], name: "index_complete_moabs_on_from_moab_storage_root_id"
     t.index ["last_archive_audit"], name: "index_complete_moabs_on_last_archive_audit"
     t.index ["last_checksum_validation"], name: "index_complete_moabs_on_last_checksum_validation"
     t.index ["last_moab_validation"], name: "index_complete_moabs_on_last_moab_validation"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -118,8 +118,8 @@ ActiveRecord::Schema.define(version: 2020_02_06_163659) do
     t.index ["zip_endpoint_id"], name: "index_zipped_moab_versions_on_zip_endpoint_id"
   end
 
-  add_foreign_key "complete_moabs", "complete_moabs", column: "from_moab_storage_root_id"
   add_foreign_key "complete_moabs", "moab_storage_roots"
+  add_foreign_key "complete_moabs", "moab_storage_roots", column: "from_moab_storage_root_id"
   add_foreign_key "complete_moabs", "preserved_objects"
   add_foreign_key "moab_storage_roots_preservation_policies", "moab_storage_roots"
   add_foreign_key "moab_storage_roots_preservation_policies", "preservation_policies"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -118,6 +118,7 @@ ActiveRecord::Schema.define(version: 2020_02_06_163659) do
     t.index ["zip_endpoint_id"], name: "index_zipped_moab_versions_on_zip_endpoint_id"
   end
 
+  add_foreign_key "complete_moabs", "complete_moabs", column: "from_moab_storage_root_id"
   add_foreign_key "complete_moabs", "moab_storage_roots"
   add_foreign_key "complete_moabs", "preserved_objects"
   add_foreign_key "moab_storage_roots_preservation_policies", "moab_storage_roots"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_22_001712) do
+ActiveRecord::Schema.define(version: 2020_02_06_163659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2020_01_22_001712) do
     t.datetime "last_version_audit"
     t.datetime "last_archive_audit"
     t.string "status_details"
+    t.bigint "from_moab_storage_root_id"
     t.index ["created_at"], name: "index_complete_moabs_on_created_at"
     t.index ["last_archive_audit"], name: "index_complete_moabs_on_last_archive_audit"
     t.index ["last_checksum_validation"], name: "index_complete_moabs_on_last_checksum_validation"

--- a/spec/services/storage_root_migration_service_spec.rb
+++ b/spec/services/storage_root_migration_service_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe StorageRootMigrationService do
 
   let(:complete_moab3) { create(:complete_moab) }
 
+  # rubocop:disable RSpec/MultipleExpectations
   it 'migrates the storage root' do
     # Before migration
     expect(complete_moab1.moab_storage_root).to eq(complete_moab2.moab_storage_root)
@@ -34,6 +35,7 @@ RSpec.describe StorageRootMigrationService do
     expect(complete_moab2.moab_storage_root).to eq(to_storage_root)
     expect(complete_moab2.from_moab_storage_root).to eq(from_storage_root)
   end
+  # rubocop:enable RSpec/MultipleExpectations
 
   it 'resets field values' do
     described_class.new(from_storage_root.name, to_storage_root.name).migrate

--- a/spec/services/storage_root_migration_service_spec.rb
+++ b/spec/services/storage_root_migration_service_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe StorageRootMigrationService do
     complete_moab2.reload
 
     expect(complete_moab1.moab_storage_root).to eq(to_storage_root)
+    expect(complete_moab1.from_moab_storage_root).to eq(from_storage_root)
     expect(complete_moab2.moab_storage_root).to eq(to_storage_root)
+    expect(complete_moab2.from_moab_storage_root).to eq(from_storage_root)
   end
 
   it 'resets field values' do
@@ -53,5 +55,6 @@ RSpec.describe StorageRootMigrationService do
     complete_moab3.reload
 
     expect(complete_moab3.moab_storage_root).to eq(orig_complete_moab3_storage_root)
+    expect(complete_moab3.from_moab_storage_root).to be_nil
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #1321 

This adds an additional relationship between `CompleteMoab` and `MoabStorageRoot` to record the from storage root when recording migration results.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
