### PR TITLE
Add storage root detail reports to rake tasks

### DIFF
--- a/app/services/reporter.rb
+++ b/app/services/reporter.rb
@@ -13,6 +13,7 @@ class Reporter
   def initialize(params)
     @storage_root = MoabStorageRoot.find_by!(name: params[:storage_root_name])
     @druids = []
+    moab_storage_root_druid_list
   end
 
   # @return [Array] an array of druids on the storage root
@@ -51,7 +52,7 @@ class Reporter
   # @param [Array] values to output on each line of the csv
   # @param [String] optional filename
   # @return [String] the name of the CSV file to which the list was written
-  def write_to_csv(data, filename)
+  def write_to_csv(data, filename: nil)
     filename ||= default_filename(filename_prefix: "MoabStorageRoot_#{storage_root.name}_druids", filename_suffix: 'csv')
     raise "#{filename} already exists, aborting!" if FileTest.exist?(filename)
 

--- a/app/services/reporter.rb
+++ b/app/services/reporter.rb
@@ -22,8 +22,27 @@ class Reporter
         .select(:druid)
         .order(:druid)
         .each_row do |po_hash| # #each_row is from postgresql_cursor gem
+          byebug
           csv << [po_hash['druid']]
         end
+    end
+
+    csv_filename
+  end
+
+  def self.moab_storage_root_druid_details_to_csv(storage_root_name:, csv_filename: nil)
+    msr = MoabStorageRoot.find_by!(name: storage_root_name)
+    msr.complete_moabs.each do |cm|
+      puts "#{cm.preserved_object.druid},#{cm.status},#{cm.moab_storage_root.name},#{cm.from_moab_storage_root&.name}"
+    end
+
+    csv_filename
+  end
+
+  def self.moab_storage_root_audit_errors_to_csv(storage_root_name:, csv_filename: nil)
+    msr = MoabStorageRoot.find_by!(name: storage_root_name)
+    msr.complete_moabs.where.not(status: 'ok').each do |cm|
+      puts "#{cm.preserved_object.druid},#{cm.status},#{cm.moab_storage_root.name},#{cm.from_moab_storage_root&.name}"
     end
 
     csv_filename

--- a/app/services/reporter.rb
+++ b/app/services/reporter.rb
@@ -6,49 +6,64 @@ require 'csv'
 # run queries and produce reports from the results, for consumption
 # by preservation catalog maintainers
 class Reporter
-  attr_reader :storage_root
+  attr_reader :storage_root, :druids
 
   # @param [String] the name of the storage root to initialize for reporter
   # @return [Reporter] the reporter
   def initialize(params)
     @storage_root = MoabStorageRoot.find_by!(name: params[:storage_root_name])
+    @druids = []
   end
 
-  def output_file
-    default_filename(filename_prefix: "MoabStorageRoot_#{storage_root.name}_druids", filename_suffix: 'csv')
-    # raise "#{output_file} already exists, aborting!" if FileTest.exist?(output_file)
+  # @return [Array] an array of druids on the storage root
+  def moab_storage_root_druid_list
+    PreservedObject
+      .joins(:complete_moabs)
+      .where(complete_moabs: { moab_storage_root: storage_root })
+      .select(:druid, :status)
+      .order(:druid)
+      .each_row do |po_hash|
+        @druids << po_hash['druid']
+      end
   end
 
-  # @param [String] the name of the storage root for which druids should be listed
+  # @param [Array] druids to output details for
+  # @param [Boolean] optionally only output lines with audit errors
+  # @return [Array] an array of hashes with details for each druid provided
+  def moab_detail_for(data, errors_only: false)
+    detail_array = []
+    data.each do |druid|
+      preserved_object = PreservedObject.find_by(druid: druid)
+      preserved_object.complete_moabs.each do |cm|
+        next if errors_only && cm.status == 'ok'
+        detail_array << { druid: druid,
+                          status: cm.status,
+                          status_details: cm.status_details,
+                          last_moab_validation: cm.last_moab_validation,
+                          last_checksum_validation: cm.last_checksum_validation,
+                          storage_root: cm.moab_storage_root.name,
+                          from_storage_root: cm.from_moab_storage_root&.name }
+      end
+    end
+    detail_array
+  end
+
+  # @param [Array] values to output on each line of the csv
+  # @param [String] optional filename
   # @return [String] the name of the CSV file to which the list was written
-  def moab_storage_root_druid_list_to_csv
-    CSV.open(output_file, 'w') do |csv|
-      storage_root.complete_moabs.each do |cm|
-        csv << [cm.preserved_object.druid]
+  def write_to_csv(data, filename)
+    filename ||= default_filename(filename_prefix: "MoabStorageRoot_#{storage_root.name}_druids", filename_suffix: 'csv')
+    raise "#{filename} already exists, aborting!" if FileTest.exist?(filename)
+
+    ensure_containing_dir(filename)
+    CSV.open(filename, 'w') do |csv|
+      data.each do |line|
+        line = line.values if line.is_a? Hash
+        csv << line
       end
     end
 
-    output_file
-  end
-
-  def moab_storage_root_druid_details_to_csv
-    CSV.open(output_file, 'w') do |csv|
-      storage_root.complete_moabs.each do |cm|
-        csv << [cm.preserved_object.druid, cm.status, cm.moab_storage_root.name, cm.from_moab_storage_root&.name]
-      end
-    end
-
-    output_file
-  end
-
-  def moab_storage_root_audit_errors_to_csv
-    CSV.open(output_file, 'w') do |csv|
-      msr.complete_moabs.where.not(status: 'ok').each do |cm|
-        csv << [cm.preserved_object.druid, cm.status, cm.moab_storage_root.name, cm.from_moab_storage_root&.name]
-      end
-    end
-
-    output_file
+    filename
   end
 
   def default_filename(filename_prefix:, filename_suffix:)
@@ -59,7 +74,7 @@ class Reporter
     File.join(Rails.root, 'log', 'reports')
   end
 
-  def self.ensure_containing_dir(filename)
+  def ensure_containing_dir(filename)
     basename_len = File.basename(filename).length
     filepath_str = filename[0..-(basename_len + 1)] # add 1 to basename_len because ending at -1 gets the whole string
     FileUtils.mkdir_p(filepath_str) unless FileTest.exist?(filepath_str)

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -16,19 +16,22 @@ namespace :prescat do
   namespace :reports do
     desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
     task :msr_druids, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
-      csv_loc = Reporter.moab_storage_root_druid_list_to_csv(storage_root_name: args[:storage_root_name], csv_filename: args[:csv_filename])
+      reporter = Reporter.new(args)
+      csv_loc = reporter.moab_storage_root_druid_list_to_csv
       puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
     end
 
     desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
     task :msr_druid_detail, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
-      csv_loc = Reporter.moab_storage_root_druid_details_to_csv(storage_root_name: args[:storage_root_name], csv_filename: args[:csv_filename])
-      puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
+      reporter = Reporter.new(args)
+      csv_loc = reporter.moab_storage_root_druid_details_to_csv
+      puts "druid details for #{args[:storage_root_name]} written to #{csv_loc}"
     end
 
     desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
     task :msr_audit_errors, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
-      csv_loc = Reporter.moab_storage_root_audit_errors_to_csv(storage_root_name: args[:storage_root_name], csv_filename: args[:csv_filename])
+      reporter = Reporter.new(args)
+      csv_loc = reporter.moab_storage_root_audit_errors_to_csv
       puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
     end
   end

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -19,5 +19,17 @@ namespace :prescat do
       csv_loc = Reporter.moab_storage_root_druid_list_to_csv(storage_root_name: args[:storage_root_name], csv_filename: args[:csv_filename])
       puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
     end
+
+    desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
+    task :msr_druid_detail, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
+      csv_loc = Reporter.moab_storage_root_druid_details_to_csv(storage_root_name: args[:storage_root_name], csv_filename: args[:csv_filename])
+      puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
+    end
+
+    desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
+    task :msr_audit_errors, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
+      csv_loc = Reporter.moab_storage_root_audit_errors_to_csv(storage_root_name: args[:storage_root_name], csv_filename: args[:csv_filename])
+      puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
+    end
   end
 end

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -16,23 +16,28 @@ namespace :prescat do
   namespace :reports do
     desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
     task :msr_druids, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
-      reporter = Reporter.new(args)
-      csv_loc = reporter.moab_storage_root_druid_list_to_csv
+      reporter = Reporter.new(storage_root_name: args[:storage_root_name])
+      reporter.moab_storage_root_druid_list
+      csv_loc = reporter.write_to_csv(reporter.druids, args[:csv_filename])
       puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
     end
 
-    desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
+    desc 'query for druids on storage root & dump details to CSV (2nd arg optional)'
     task :msr_druid_detail, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
-      reporter = Reporter.new(args)
-      csv_loc = reporter.moab_storage_root_druid_details_to_csv
+      reporter = Reporter.new(storage_root_name: args[:storage_root_name])
+      reporter.moab_storage_root_druid_list
+      data = reporter.moab_detail_for(reporter.druids)
+      csv_loc = reporter.write_to_csv(data, args[:csv_filename])
       puts "druid details for #{args[:storage_root_name]} written to #{csv_loc}"
     end
 
-    desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
+    desc 'query for druids on storage root & dump audit error details to CSV (2nd arg optional)'
     task :msr_audit_errors, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
-      reporter = Reporter.new(args)
-      csv_loc = reporter.moab_storage_root_audit_errors_to_csv
-      puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
+      reporter = Reporter.new(storage_root_name: args[:storage_root_name])
+      reporter.moab_storage_root_druid_list
+      data = reporter.moab_detail_for(reporter.druids, errors_only: true)
+      csv_loc = reporter.write_to_csv(data, args[:csv_filename])
+      puts "druids with errors details for #{args[:storage_root_name]} written to #{csv_loc}"
     end
   end
 end

--- a/spec/services/reporter_spec.rb
+++ b/spec/services/reporter_spec.rb
@@ -3,65 +3,93 @@
 require 'rails_helper'
 
 RSpec.describe Reporter do
-  let!(:test_start_time) { DateTime.now } # useful for both output cleanup and CSV filename testing
+  let!(:test_start_time) { DateTime.now.utc.iso8601 } # useful for both output cleanup and CSV filename testing
 
   let!(:msr_a) { create(:moab_storage_root) }
   let!(:complete_moab_1) { create(:complete_moab, moab_storage_root: msr_a) }
   let!(:complete_moab_2) { create(:complete_moab, moab_storage_root: msr_a) }
   let!(:complete_moab_3) { create(:complete_moab, moab_storage_root: msr_a) }
 
-  let!(:msr_b) { create(:moab_storage_root) }
-  let!(:complete_moab_4) { create(:complete_moab, moab_storage_root: msr_b) }
-  let!(:complete_moab_5) { create(:complete_moab, moab_storage_root: msr_b) }
-  let!(:complete_moab_6) { create(:complete_moab, moab_storage_root: msr_b) }
+  let(:reporter) { described_class.new(storage_root_name: msr_a.name) }
 
-  after do
-    next unless FileTest.exist?(described_class.default_filepath)
-    Dir.each_child(described_class.default_filepath) do |filename|
-      fullpath_filename = File.join(described_class.default_filepath, filename)
-      File.unlink(fullpath_filename) if File.stat(fullpath_filename).mtime > test_start_time
+  describe '.druids' do
+    let(:druid_list) {
+      [complete_moab_1.preserved_object.druid,
+       complete_moab_2.preserved_object.druid,
+       complete_moab_3.preserved_object.druid]
+    }
+
+    it 'returns a list of druids on a storage_root' do
+      expect(reporter.druids).to eq(druid_list)
     end
   end
 
-  describe '.moab_storage_root_druid_list_to_csv' do
-    it 'creates a file containing a list of druids from the given storage root' do
-      csv_filename = described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_b.name)
-      expect(CSV.read(csv_filename)).to eq(
-        [complete_moab_4, complete_moab_5, complete_moab_6].map { |cm| [cm.preserved_object.druid] }
-      )
+  describe '.moab_detail_for' do
+    let(:pos) { [complete_moab_1.preserved_object.druid] }
+    let(:moab_detail) {
+      [{ druid: complete_moab_1.preserved_object.druid,
+         from_storage_root: nil,
+         last_checksum_validation: nil,
+         last_moab_validation: nil,
+         status: 'ok',
+         status_details: nil,
+         storage_root: complete_moab_1.moab_storage_root.name }]
+    }
+
+    before do
+      allow(PreservedObject).to receive(:find_by!).with(druid: pos.first)
     end
 
-    it 'names the file with the default prefix and a timestamp and writes it to the default location' do
-      # file timestamp is to the second, but test_start_time is more precise.  this sleep allows us to compare
-      # timestamp to test start time without having to round fractions of a second.
-      sleep(1.second)
+    it 'returns a hash of values for the given moab' do
+      expect(reporter.moab_detail_for(pos)).to eq(moab_detail)
+    end
+  end
 
-      csv_filename = described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_a.name)
-      expect(csv_filename).to match(%r{^#{described_class.default_filepath}\/MoabStorageRoot_#{msr_a.name}_druids_.*\.csv$})
+  describe '.write_to_csv' do
+    let(:moab_detail) {
+      [{ druid: 'bj102hs9687',
+         from_storage_root: nil,
+         last_checksum_validation: nil,
+         last_moab_validation: nil,
+         status: 'ok',
+         status_details: nil,
+         storage_root: 'moab_storage_root01' }]
+    }
+
+    after do
+      next unless FileTest.exist?(reporter.default_filepath)
+      Dir.each_child(reporter.default_filepath) do |filename|
+        fullpath_filename = File.join(reporter.default_filepath, filename)
+        File.unlink(fullpath_filename) if File.stat(fullpath_filename).mtime > test_start_time
+      end
+    end
+
+    it 'creates a default file containing a list of druids from the given storage root' do
+      csv_filename = reporter.write_to_csv(moab_detail)
+      expect(CSV.read(csv_filename)).to eq([["bj102hs9687", nil, nil, nil, "ok", nil, "moab_storage_root01"]])
+      expect(csv_filename).to match(%r{^#{reporter.default_filepath}\/MoabStorageRoot_#{msr_a.name}_druids_.*\.csv$})
       timestamp_str = /MoabStorageRoot_#{msr_a.name}_druids_(.*)\.csv$/.match(csv_filename).captures[0]
       expect(DateTime.parse(timestamp_str)).to be >= test_start_time
     end
 
     it 'allows the caller to specify an alternate filename, including full path' do
       alternate_filename = '/tmp/my_cool_druid_export.csv'
-      csv_filename = described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_a.name, csv_filename: alternate_filename)
+      csv_filename = reporter.write_to_csv(moab_detail, filename: alternate_filename)
       expect(csv_filename).to eq(alternate_filename)
-      expect(CSV.read(csv_filename)).to eq(
-        [complete_moab_1, complete_moab_2, complete_moab_3].map { |cm| [cm.preserved_object.druid] }
-      )
+      expect(CSV.read(csv_filename)).to eq([["bj102hs9687", nil, nil, nil, "ok", nil, "moab_storage_root01"]])
     ensure
       File.unlink(alternate_filename) if FileTest.exist?(alternate_filename)
     end
 
     it 'lets the DB error bubble up if the given storage root does not exist' do
-      expect { described_class.moab_storage_root_druid_list_to_csv(storage_root_name: 'nonexistent') }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { described_class.new(storage_root_name: 'nonexistent') }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'raises an error if the intended file name is already in use' do
-      duplicated_filename = File.join(described_class.default_filepath, 'my_duplicated_filename.csv')
-      described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_b.name, csv_filename: duplicated_filename)
+      duplicated_filename = File.join(reporter.default_filepath, 'my_duplicated_filename.csv')
+      reporter.write_to_csv(moab_detail, filename: duplicated_filename)
       expect {
-        described_class.moab_storage_root_druid_list_to_csv(storage_root_name: msr_b.name, csv_filename: duplicated_filename)
+        reporter.write_to_csv(moab_detail, filename: duplicated_filename)
       }.to raise_error(StandardError, "#{duplicated_filename} already exists, aborting!")
     end
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #1318 
Fixes #1319 

The refactor proposed here is also in order to make the service usable for #1320 

Adds storage root detail report and storage root audit error detail report.

DRAFT until completion of some DRY refactoring and cleanup of rake arguments.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

TBD