### PR TITLE
Reporting fix and touchup

### DIFF
--- a/app/services/reporter.rb
+++ b/app/services/reporter.rb
@@ -35,10 +35,15 @@ class Reporter
   # @param [Boolean] errors_only (default: false) - optionally only output lines with audit errors
   # @return [Array] an array of hashes with details for each druid provided
   def moab_detail_csv_list(errors_only: false)
+    query = if errors_only
+      moab_storage_root_list_preserved_objects_relation.where.not(complete_moabs: { status: 'ok' })
+    else
+      moab_storage_root_list_preserved_objects_relation
+    end
+
     detail_array = [['druid', 'from_storage_root', 'storage_root', 'last_checksum_validation', 'last_moab_validation', 'status', 'status_details']]
-    moab_storage_root_list_preserved_objects_relation.each_instance do |preserved_object|
+    query.each_instance do |preserved_object|
       preserved_object.complete_moabs.each do |cm|
-        next if errors_only && cm.status == 'ok'
         detail_array << [
           preserved_object.druid, cm.from_moab_storage_root&.name, cm.moab_storage_root.name,
           cm.last_checksum_validation, cm.last_moab_validation, cm.status, cm.status_details

--- a/app/services/reporter.rb
+++ b/app/services/reporter.rb
@@ -12,9 +12,10 @@ class Reporter
   # @return [Reporter] the reporter
   def initialize(params)
     @storage_root = MoabStorageRoot.find_by!(name: params[:storage_root_name])
+    @msr_names = {}
   end
 
-  def moab_storage_root_list_preserved_objects_relation
+  def moab_storage_root_list_pres_obj_comp_moabs_relation
     PreservedObject
       .joins(:complete_moabs)
       .where(complete_moabs: { moab_storage_root: storage_root })
@@ -24,7 +25,7 @@ class Reporter
   # @return [Array] an array of druids on the storage root
   def druid_csv_list
     druid_array = [['druid']]
-    moab_storage_root_list_preserved_objects_relation
+    moab_storage_root_list_pres_obj_comp_moabs_relation
       .select(:druid)
       .each_row do |po_hash|
         druid_array << [po_hash['druid']]
@@ -35,22 +36,36 @@ class Reporter
   # @param [Boolean] errors_only (default: false) - optionally only output lines with audit errors
   # @return [Array] an array of hashes with details for each druid provided
   def moab_detail_csv_list(errors_only: false)
-    query = if errors_only
-      moab_storage_root_list_preserved_objects_relation.where.not(complete_moabs: { status: 'ok' })
-    else
-      moab_storage_root_list_preserved_objects_relation
-    end
-
-    detail_array = [['druid', 'from_storage_root', 'storage_root', 'last_checksum_validation', 'last_moab_validation', 'status', 'status_details']]
-    query.each_instance do |preserved_object|
-      preserved_object.complete_moabs.each do |cm|
-        detail_array << [
-          preserved_object.druid, cm.from_moab_storage_root&.name, cm.moab_storage_root.name,
-          cm.last_checksum_validation, cm.last_moab_validation, cm.status, cm.status_details
-        ]
+    query =
+      if errors_only
+        moab_storage_root_list_pres_obj_comp_moabs_relation.where.not(complete_moabs: { status: 'ok' })
+      else
+        moab_storage_root_list_pres_obj_comp_moabs_relation
       end
+
+    header_row = [['druid', 'from_storage_root', 'storage_root', 'last_checksum_validation', 'last_moab_validation', 'status', 'status_details']]
+
+    # cols doesn't include storage_root name (available via storage_root ivar).  also we're not instantiating AR objects, so we have to translate
+    # the underlying status enum
+    cols = ['druid', 'from_moab_storage_root_id', 'last_checksum_validation', 'last_moab_validation', 'status AS status_code', 'status_details']
+    data_rows = query.select(cols).each_row.map do |po_cm_hash|
+      [
+        po_cm_hash['druid'], moab_storage_root_name(po_cm_hash['from_moab_storage_root_id']), storage_root.name,
+        po_cm_hash['last_checksum_validation'], po_cm_hash['last_moab_validation'], status_text_from_code(po_cm_hash['status_code']),
+        po_cm_hash['status_details']
+      ]
     end
-    detail_array
+    header_row + data_rows
+  end
+
+  def moab_storage_root_name(msr_id)
+    return nil unless msr_id.present?
+    @msr_names[msr_id] ||= MoabStorageRoot.find(msr_id).name
+  end
+
+  def status_text_from_code(status_code)
+    # statuses is a hash of the form { 'status_text' => status_code }.  this is just a reverse hash lookup.
+    CompleteMoab.statuses.to_a.find { |s| s[1] == status_code }[0]
   end
 
   # @param [Array] lines - values to output on each line of the csv

--- a/app/services/reporter.rb
+++ b/app/services/reporter.rb
@@ -23,7 +23,7 @@ class Reporter
 
   # @return [Array] an array of druids on the storage root
   def druid_csv_list
-    druid_array = []
+    druid_array = [['druid']]
     moab_storage_root_list_preserved_objects_relation
       .select(:druid)
       .each_row do |po_hash|
@@ -35,7 +35,7 @@ class Reporter
   # @param [Boolean] errors_only (default: false) - optionally only output lines with audit errors
   # @return [Array] an array of hashes with details for each druid provided
   def moab_detail_csv_list(errors_only: false)
-    detail_array = []
+    detail_array = [['druid', 'from_storage_root', 'storage_root', 'last_checksum_validation', 'last_moab_validation', 'status', 'status_details']]
     moab_storage_root_list_preserved_objects_relation.each_instance do |preserved_object|
       preserved_object.complete_moabs.each do |cm|
         next if errors_only && cm.status == 'ok'

--- a/app/services/reporter.rb
+++ b/app/services/reporter.rb
@@ -15,17 +15,10 @@ class Reporter
     @msr_names = {}
   end
 
-  def moab_storage_root_list_pres_obj_comp_moabs_relation
-    PreservedObject
-      .joins(:complete_moabs)
-      .where(complete_moabs: { moab_storage_root: storage_root })
-      .order(:druid)
-  end
-
-  # @return [Array] an array of druids on the storage root
+  # @return [Array<Array>] an array of arrays; each inner array represents a CSV row w/ a druid from the storage root. includes a header row.
   def druid_csv_list
     druid_array = [['druid']]
-    moab_storage_root_list_pres_obj_comp_moabs_relation
+    complete_moabs_and_preserved_objects_in_storage_root
       .select(:druid)
       .each_row do |po_hash|
         druid_array << [po_hash['druid']]
@@ -34,16 +27,18 @@ class Reporter
   end
 
   # @param [Boolean] errors_only (default: false) - optionally only output lines with audit errors
-  # @return [Array] an array of hashes with details for each druid provided
+  # @return [Array<Array>] an array of arrays; each inner array represents a CSV row w/ details for each druid in query result.  includes header row.
   def moab_detail_csv_list(errors_only: false)
     query =
       if errors_only
-        moab_storage_root_list_pres_obj_comp_moabs_relation.where.not(complete_moabs: { status: 'ok' })
+        complete_moabs_and_preserved_objects_in_storage_root.where.not(complete_moabs: { status: 'ok' })
       else
-        moab_storage_root_list_pres_obj_comp_moabs_relation
+        complete_moabs_and_preserved_objects_in_storage_root
       end
 
-    header_row = [['druid', 'from_storage_root', 'storage_root', 'last_checksum_validation', 'last_moab_validation', 'status', 'status_details']]
+    header_row = [
+      ['druid', 'previous storage root', 'current storage root', 'last checksum validation', 'last moab validation', 'status', 'status details']
+    ]
 
     # cols doesn't include storage_root name (available via storage_root ivar).  also we're not instantiating AR objects, so we have to translate
     # the underlying status enum
@@ -58,21 +53,14 @@ class Reporter
     header_row + data_rows
   end
 
-  def moab_storage_root_name(msr_id)
-    return nil unless msr_id.present?
-    @msr_names[msr_id] ||= MoabStorageRoot.find(msr_id).name
-  end
-
-  def status_text_from_code(status_code)
-    # statuses is a hash of the form { 'status_text' => status_code }.  this is just a reverse hash lookup.
-    CompleteMoab.statuses.to_a.find { |s| s[1] == status_code }[0]
-  end
-
-  # @param [Array] lines - values to output on each line of the csv
-  # @param [String] filename - optional filename to override the default
+  # @param [Array<Array>] lines - lines to output to a .csv file.  CSV library expects each line it appends to be Array of cols, hence Array<Array>.
+  # @param [String] report_type - optional report type to use when constructing default filename.  ignored if filename param is provided.
+  # @param [String] filename - optional filename to override the default.
   # @return [String] the name of the CSV file to which the list was written
+  # @raise [ArgumentError] if neither report_type nor filename is provided
+  # @raise [RuntimeError] if the file to be written to already exists
   def write_to_csv(lines, report_type: nil, filename: nil)
-    raise ArgumentError, 'Must specify at least one of report_type or filename' unless report_type.present? || filename.present?
+    raise ArgumentError, 'Must specify at least one of report_type or filename' if report_type.blank? && filename.blank?
 
     filename ||= default_filename(filename_prefix: "MoabStorageRoot_#{storage_root.name}_#{report_type}", filename_suffix: 'csv')
     raise "#{filename} already exists, aborting!" if FileTest.exist?(filename)
@@ -87,12 +75,32 @@ class Reporter
     filename
   end
 
-  def default_filename(filename_prefix:, filename_suffix:)
-    File.join(default_filepath, "#{filename_prefix}_#{DateTime.now.utc.iso8601}.#{filename_suffix}")
-  end
-
   def default_filepath
     File.join(Rails.root, 'log', 'reports')
+  end
+
+  private
+
+  def moab_storage_root_name(msr_id)
+    return nil if msr_id.blank?
+    @msr_names[msr_id] ||= MoabStorageRoot.find(msr_id).name
+  end
+
+  def status_text_from_code(status_code)
+    CompleteMoab.statuses.key(status_code)
+  end
+
+  # @return [ActiveRecord::Relation] an AR Relation listing the CompleteMoabs (and some associated info) on a MoabStorageRoot, sorted by druid.
+  #   we expect druids to be unique across a given storage root.
+  def complete_moabs_and_preserved_objects_in_storage_root
+    PreservedObject
+      .joins(:complete_moabs)
+      .where(complete_moabs: { moab_storage_root: storage_root })
+      .order(:druid)
+  end
+
+  def default_filename(filename_prefix:, filename_suffix:)
+    File.join(default_filepath, "#{filename_prefix}_#{DateTime.now.utc.iso8601}.#{filename_suffix}")
   end
 
   def ensure_containing_dir(filename)

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -17,26 +17,23 @@ namespace :prescat do
     desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
     task :msr_druids, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
       reporter = Reporter.new(storage_root_name: args[:storage_root_name])
-      reporter.moab_storage_root_druid_list
-      csv_loc = reporter.write_to_csv(reporter.druids, args[:csv_filename])
+      csv_loc = reporter.write_to_csv(reporter.druid_csv_list, report_type: 'druids', filename: args[:csv_filename])
       puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
     end
 
     desc 'query for druids on storage root & dump details to CSV (2nd arg optional)'
     task :msr_druid_detail, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
       reporter = Reporter.new(storage_root_name: args[:storage_root_name])
-      reporter.moab_storage_root_druid_list
-      data = reporter.moab_detail_for(reporter.druids)
-      csv_loc = reporter.write_to_csv(data, args[:csv_filename])
+      data = reporter.moab_detail_csv_list
+      csv_loc = reporter.write_to_csv(data, report_type: 'druid_detail', filename: args[:csv_filename])
       puts "druid details for #{args[:storage_root_name]} written to #{csv_loc}"
     end
 
     desc 'query for druids on storage root & dump audit error details to CSV (2nd arg optional)'
     task :msr_audit_errors, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
       reporter = Reporter.new(storage_root_name: args[:storage_root_name])
-      reporter.moab_storage_root_druid_list
-      data = reporter.moab_detail_for(reporter.druids, errors_only: true)
-      csv_loc = reporter.write_to_csv(data, args[:csv_filename])
+      data = reporter.moab_detail_csv_list(errors_only: true)
+      csv_loc = reporter.write_to_csv(data, report_type: 'audit_errors', filename: args[:csv_filename])
       puts "druids with errors details for #{args[:storage_root_name]} written to #{csv_loc}"
     end
   end

--- a/spec/services/reporter_spec.rb
+++ b/spec/services/reporter_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe Reporter do
 
   describe '#moab_detail_csv_list' do
     let(:moab_detail_csv_list) do
-      header_row = [['druid', 'from_storage_root', 'storage_root', 'last_checksum_validation', 'last_moab_validation', 'status', 'status_details']]
+      header_row = [
+        ['druid', 'previous storage root', 'current storage root', 'last checksum validation', 'last moab validation', 'status', 'status details']
+      ]
       data_rows = [complete_moab_1, complete_moab_2, complete_moab_3].map do |cm|
         [cm.preserved_object.druid, nil, cm.moab_storage_root.name, nil, nil, 'ok', nil]
       end


### PR DESCRIPTION
## Why was this change made?

(follow on to #1360)

initially i started in on a minor bit of refactoring so that more could be done in the initial query (which was previously just used to list druids), since that query already collects almost all the data we might want to report.  when a test failed i went to do a bit of manual testing, and noticed that the rake tasks weren't actually working, so i fixed those in addition to getting rid of the need to collect the druid list separately from the loop that collates results.  then i noticed that the reports all used the same default file name no matter the type, so i fixed that by adding a report type param to the csv writing method.

i also finally realized we probably want column headers (after waffling on that when first creating the `Reporter` class), so i added those.

did some refactoring and test fixing along the way to support the above.  more detail in the commit messages (the first one's a bit of a grab bag, but i tried to make the other ones more focused).

in the last commit i finally did the last bit of the query optimization i'd originally set out to do, using the `complete_moabs` info that the main query already provided, and doing away with the need to instantiate lots of ActiveRecord objects.

two other things i'd like to do, but which i deferred because it's late:
1. rename the class to `MoabStorageRootReporter` because it's now very moab specific (i probably should've named it that from the beginning).
2. turn the `Reporter` methods that don't take advantage of internal state back into class methods (open to argument on this -- i get the impression some prefer to avoid class methods entirely? i don't have strong feelings on this, but my inclination is to not make something an instance method if it doesn't need to be)

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a