### PR TITLE
add comments re: why we report audit errors to workflow service

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -156,6 +156,9 @@ class AuditResults
       if r.key?(INVALID_MOAB)
         # This error goes to diff workflow ('moab-valid') than 'preservation-audit'
         # also note that we shorten it because workflow service doesn't like really long strings
+        # NOTE: this approach allows online Moab audit errors to block further accessioning (which is desired)
+        #   - any WF error blocks further accessioning (i.e. can't open a new version)
+        #   - we currently only send WF errors from audits of online moabs (replication audit problems don't show up in WF)
         msg = "#{string_prefix} || #{r.values.first}"
         WorkflowReporter.report_error(druid, actual_version, 'moab-valid', msg)
       elsif status_changed_to_ok?(r)
@@ -191,6 +194,9 @@ class AuditResults
     { code => result_code_msg(code, msg_args) }
   end
 
+  # NOTE: this approach allows online Moab audit errors to block further accessioning (which is desired)
+  #   - any WF error blocks further accessioning (i.e. can't open a new version)
+  #   - we currently only send WF errors from audits of online moabs (replication audit problems don't show up in WF)
   def report_errors_to_workflows(error_results)
     return if error_results.empty?
     WorkflowReporter.report_error(druid, actual_version, 'preservation-audit', results_as_string(error_results))

--- a/app/services/workflow_reporter.rb
+++ b/app/services/workflow_reporter.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 # send errors to preservationAuditWF workflow for an object via ReST calls.
+# NOTE: this approach allows online Moab audit errors to block further accessioning (which is desired)
+#   - any WF error blocks further accessioning (i.e. can't open a new version)
+#   - we currently only send WF errors from audits of online moabs (replication audit problems don't show up in WF)
 class WorkflowReporter
   PRESERVATIONAUDITWF = 'preservationAuditWF'
   NO_WORKFLOW_HOOKUP = 'no workflow hookup - assume you are in test or dev environment'


### PR DESCRIPTION
## Why was this change made?

Requested in post standup discussion -- want to document WHY prescat writes to WF service in the janky way it does.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

no, but code documentation was.