### PR TITLE
add audit:m2c, audit:c2m and audit:cv rake tasks

### DIFF
--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -44,5 +44,11 @@ namespace :prescat do
       msr = MoabStorageRoot.find_by!(name: args[:storage_root_name])
       msr.m2c_check!
     end
+
+    desc "run C2M (catalog to moab) validation on a storage root"
+    task :c2m, [:storage_root_name] => [:environment] do |_task, args|
+      msr = MoabStorageRoot.find_by!(name: args[:storage_root_name])
+      msr.c2m_check!
+    end
   end
 end

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -37,4 +37,12 @@ namespace :prescat do
       puts "druids with errors details for #{args[:storage_root_name]} written to #{csv_loc}"
     end
   end
+
+  namespace :audit do
+    desc "run M2C (moab to catalog) validation on a storage root"
+    task :m2c, [:storage_root_name] => [:environment] do |_task, args|
+      msr = MoabStorageRoot.find_by!(name: args[:storage_root_name])
+      msr.m2c_check!
+    end
+  end
 end

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -50,5 +50,10 @@ namespace :prescat do
       msr = MoabStorageRoot.find_by!(name: args[:storage_root_name])
       msr.c2m_check!
     end
+
+    desc "run CV (checksum validation) for all druids on a storage root"
+    task :cv, [:storage_root_name] => [:environment] do |_task, args|
+      MoabStorageRoot.find_by!(name: args[:storage_root_name]).complete_moabs.find_each(&:validate_checksums!)
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #1368 
Fixes #1369
Fixes #1370

For preservation storage migration, it will be convenient to have rake tasks to run validations (m2c, c2m, cv) on a particular storage root.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

the rake tasks added have descriptions.
README has been updated