### PR TITLE
More report fixup

### DIFF
--- a/app/services/moab_storage_root_reporter.rb
+++ b/app/services/moab_storage_root_reporter.rb
@@ -64,10 +64,10 @@ class MoabStorageRootReporter
   # @return [String] the name of the CSV file to which the list was written
   # @raise [ArgumentError] if neither report_type nor filename is provided
   # @raise [RuntimeError] if the file to be written to already exists
-  def write_to_csv(lines, report_type: nil, filename: nil)
+  def write_to_csv(lines, report_type: nil, report_tag: nil, filename: nil)
     raise ArgumentError, 'Must specify at least one of report_type or filename' if report_type.blank? && filename.blank?
 
-    filename ||= default_filename(filename_prefix: "MoabStorageRoot_#{storage_root.name}_#{report_type}")
+    filename ||= default_filename(filename_prefix: "MoabStorageRoot_#{storage_root.name}_#{report_type}", report_tag: report_tag)
     raise "#{filename} already exists, aborting!" if FileTest.exist?(filename)
 
     ensure_containing_dir(filename)
@@ -104,8 +104,10 @@ class MoabStorageRootReporter
       .order(:druid)
   end
 
-  def default_filename(filename_prefix:)
-    File.join(default_filepath, "#{filename_prefix}_#{DateTime.now.utc.iso8601.gsub(':', '')}.csv") # colons are a pain to deal with on CLI
+  def default_filename(filename_prefix:, report_tag: nil)
+    report_tag_str = report_tag.blank? ? nil : "_#{report_tag}"
+    timestamp_str = DateTime.now.utc.iso8601.gsub(':', '') # colons are a pain to deal with on CLI, so just remove them
+    File.join(default_filepath, "#{filename_prefix}#{report_tag_str}_#{timestamp_str}.csv")
   end
 
   def ensure_containing_dir(filename)

--- a/app/services/moab_storage_root_reporter.rb
+++ b/app/services/moab_storage_root_reporter.rb
@@ -67,7 +67,7 @@ class MoabStorageRootReporter
   def write_to_csv(lines, report_type: nil, report_tag: nil, filename: nil)
     raise ArgumentError, 'Must specify at least one of report_type or filename' if report_type.blank? && filename.blank?
 
-    filename ||= default_filename(filename_prefix: "MoabStorageRoot_#{storage_root.name}_#{report_type}", report_tag: report_tag)
+    filename ||= default_filename(filename_prefix: "storage_#{storage_root.name}_#{report_type}", report_tag: report_tag)
     raise "#{filename} already exists, aborting!" if FileTest.exist?(filename)
 
     ensure_containing_dir(filename)

--- a/app/services/moab_storage_root_reporter.rb
+++ b/app/services/moab_storage_root_reporter.rb
@@ -5,11 +5,11 @@ require 'csv'
 ##
 # run queries and produce reports from the results, for consumption
 # by preservation catalog maintainers
-class Reporter
+class MoabStorageRootReporter
   attr_reader :storage_root
 
-  # @params [Hash] params used to initialize the Reporter service
-  # @return [Reporter] the reporter
+  # @params [Hash] params used to initialize the MoabStorageRootReporter service
+  # @return [MoabStorageRootReporter] the reporter
   def initialize(params)
     @storage_root = MoabStorageRoot.find_by!(name: params[:storage_root_name])
     @msr_names = {}
@@ -36,21 +36,26 @@ class Reporter
         complete_moabs_and_preserved_objects_in_storage_root
       end
 
-    header_row = [
-      ['druid', 'previous storage root', 'current storage root', 'last checksum validation', 'last moab validation', 'status', 'status details']
-    ]
+    header_row = ['druid',
+                  'previous storage root',
+                  'current storage root',
+                  'last checksum validation',
+                  'last moab validation',
+                  'status',
+                  'status details']
 
-    # cols doesn't include storage_root name (available via storage_root ivar).  also we're not instantiating AR objects, so we have to translate
-    # the underlying status enum
+    # cols doesn't include storage_root name (available via storage_root ivar)
     cols = ['druid', 'from_moab_storage_root_id', 'last_checksum_validation', 'last_moab_validation', 'status AS status_code', 'status_details']
     data_rows = query.select(cols).each_row.map do |po_cm_hash|
-      [
-        po_cm_hash['druid'], moab_storage_root_name(po_cm_hash['from_moab_storage_root_id']), storage_root.name,
-        po_cm_hash['last_checksum_validation'], po_cm_hash['last_moab_validation'], status_text_from_code(po_cm_hash['status_code']),
-        po_cm_hash['status_details']
-      ]
+      [po_cm_hash['druid'],
+       moab_storage_root_name(po_cm_hash['from_moab_storage_root_id']),
+       storage_root.name,
+       po_cm_hash['last_checksum_validation'],
+       po_cm_hash['last_moab_validation'],
+       status_text_from_code(po_cm_hash['status_code']), # must translate underlying status enum value since we're not instantiating AR objects
+       po_cm_hash['status_details']]
     end
-    header_row + data_rows
+    [header_row] + data_rows # wrap header_row in a list to combine with data_rows list
   end
 
   # @param [Array<Array>] lines - lines to output to a .csv file.  CSV library expects each line it appends to be Array of cols, hence Array<Array>.
@@ -62,7 +67,7 @@ class Reporter
   def write_to_csv(lines, report_type: nil, filename: nil)
     raise ArgumentError, 'Must specify at least one of report_type or filename' if report_type.blank? && filename.blank?
 
-    filename ||= default_filename(filename_prefix: "MoabStorageRoot_#{storage_root.name}_#{report_type}", filename_suffix: 'csv')
+    filename ||= default_filename(filename_prefix: "MoabStorageRoot_#{storage_root.name}_#{report_type}")
     raise "#{filename} already exists, aborting!" if FileTest.exist?(filename)
 
     ensure_containing_dir(filename)
@@ -75,11 +80,11 @@ class Reporter
     filename
   end
 
+  private
+
   def default_filepath
     File.join(Rails.root, 'log', 'reports')
   end
-
-  private
 
   def moab_storage_root_name(msr_id)
     return nil if msr_id.blank?
@@ -99,8 +104,8 @@ class Reporter
       .order(:druid)
   end
 
-  def default_filename(filename_prefix:, filename_suffix:)
-    File.join(default_filepath, "#{filename_prefix}_#{DateTime.now.utc.iso8601}.#{filename_suffix}")
+  def default_filename(filename_prefix:)
+    File.join(default_filepath, "#{filename_prefix}_#{DateTime.now.utc.iso8601}.csv")
   end
 
   def ensure_containing_dir(filename)

--- a/app/services/moab_storage_root_reporter.rb
+++ b/app/services/moab_storage_root_reporter.rb
@@ -105,7 +105,7 @@ class MoabStorageRootReporter
   end
 
   def default_filename(filename_prefix:)
-    File.join(default_filepath, "#{filename_prefix}_#{DateTime.now.utc.iso8601}.csv")
+    File.join(default_filepath, "#{filename_prefix}_#{DateTime.now.utc.iso8601.gsub(':', '')}.csv") # colons are a pain to deal with on CLI
   end
 
   def ensure_containing_dir(filename)

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -14,26 +14,26 @@ namespace :prescat do
   end
 
   namespace :reports do
-    desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
-    task :msr_druids, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
+    desc 'query for druids on storage root & dump to CSV (2nd & 3rd arg optional)'
+    task :msr_druids, [:storage_root_name, :report_tag, :csv_filename] => [:environment] do |_task, args|
       reporter = MoabStorageRootReporter.new(storage_root_name: args[:storage_root_name])
-      csv_loc = reporter.write_to_csv(reporter.druid_csv_list, report_type: 'druids', filename: args[:csv_filename])
+      csv_loc = reporter.write_to_csv(reporter.druid_csv_list, report_type: 'druids', report_tag: args[:report_tag], filename: args[:csv_filename])
       puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
     end
 
-    desc 'query for druids on storage root & dump details to CSV (2nd arg optional)'
-    task :msr_moab_status_details, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
+    desc 'query for druids on storage root & dump details to CSV (2nd & 3rd arg optional)'
+    task :msr_moab_status_details, [:storage_root_name, :report_tag, :csv_filename] => [:environment] do |_task, args|
       reporter = MoabStorageRootReporter.new(storage_root_name: args[:storage_root_name])
       data = reporter.moab_detail_csv_list
-      csv_loc = reporter.write_to_csv(data, report_type: 'moab_status_details', filename: args[:csv_filename])
+      csv_loc = reporter.write_to_csv(data, report_type: 'moab_status_details', report_tag: args[:report_tag], filename: args[:csv_filename])
       puts "druid details for #{args[:storage_root_name]} written to #{csv_loc}"
     end
 
-    desc 'query for druids on storage root & dump audit error details to CSV (2nd arg optional)'
-    task :msr_moab_audit_errors, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
+    desc 'query for druids on storage root & dump audit error details to CSV (2nd & 3rd arg optional)'
+    task :msr_moab_audit_errors, [:storage_root_name, :report_tag, :csv_filename] => [:environment] do |_task, args|
       reporter = MoabStorageRootReporter.new(storage_root_name: args[:storage_root_name])
       data = reporter.moab_detail_csv_list(errors_only: true)
-      csv_loc = reporter.write_to_csv(data, report_type: 'moab_audit_errors', filename: args[:csv_filename])
+      csv_loc = reporter.write_to_csv(data, report_type: 'moab_audit_errors', report_tag: args[:report_tag], filename: args[:csv_filename])
       puts "druids with errors details for #{args[:storage_root_name]} written to #{csv_loc}"
     end
   end

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -16,24 +16,24 @@ namespace :prescat do
   namespace :reports do
     desc 'query for druids on storage root & dump to CSV (2nd arg optional)'
     task :msr_druids, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
-      reporter = Reporter.new(storage_root_name: args[:storage_root_name])
+      reporter = MoabStorageRootReporter.new(storage_root_name: args[:storage_root_name])
       csv_loc = reporter.write_to_csv(reporter.druid_csv_list, report_type: 'druids', filename: args[:csv_filename])
       puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
     end
 
     desc 'query for druids on storage root & dump details to CSV (2nd arg optional)'
-    task :msr_druid_detail, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
-      reporter = Reporter.new(storage_root_name: args[:storage_root_name])
+    task :msr_moab_status_details, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
+      reporter = MoabStorageRootReporter.new(storage_root_name: args[:storage_root_name])
       data = reporter.moab_detail_csv_list
-      csv_loc = reporter.write_to_csv(data, report_type: 'druid_detail', filename: args[:csv_filename])
+      csv_loc = reporter.write_to_csv(data, report_type: 'moab_status_details', filename: args[:csv_filename])
       puts "druid details for #{args[:storage_root_name]} written to #{csv_loc}"
     end
 
     desc 'query for druids on storage root & dump audit error details to CSV (2nd arg optional)'
-    task :msr_audit_errors, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
-      reporter = Reporter.new(storage_root_name: args[:storage_root_name])
+    task :msr_moab_audit_errors, [:storage_root_name, :csv_filename] => [:environment] do |_task, args|
+      reporter = MoabStorageRootReporter.new(storage_root_name: args[:storage_root_name])
       data = reporter.moab_detail_csv_list(errors_only: true)
-      csv_loc = reporter.write_to_csv(data, report_type: 'audit_errors', filename: args[:csv_filename])
+      csv_loc = reporter.write_to_csv(data, report_type: 'moab_audit_errors', filename: args[:csv_filename])
       puts "druids with errors details for #{args[:storage_root_name]} written to #{csv_loc}"
     end
   end

--- a/spec/services/moab_storage_root_reporter_spec.rb
+++ b/spec/services/moab_storage_root_reporter_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe MoabStorageRootReporter do
     end
   end
 
+  describe '#initialize' do
+    it 'lets the DB error bubble up if the given storage root does not exist' do
+      expect { described_class.new(storage_root_name: 'nonexistent') }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
   describe '#write_to_csv' do
     let(:csv_lines) do
       [
@@ -76,10 +82,6 @@ RSpec.describe MoabStorageRootReporter do
       expect(CSV.read(csv_filename)).to eq(csv_lines)
     ensure
       File.unlink(alternate_filename) if FileTest.exist?(alternate_filename)
-    end
-
-    it 'lets the DB error bubble up if the given storage root does not exist' do
-      expect { described_class.new(storage_root_name: 'nonexistent') }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'raises an error if the intended file name is already in use' do

--- a/spec/services/moab_storage_root_reporter_spec.rb
+++ b/spec/services/moab_storage_root_reporter_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe MoabStorageRootReporter do
       expect(timestamp_str).to be >= test_start_time.to_s.gsub(':', '')
     end
 
+    it 'allows the caller to specify a tag string, to more easily differentiate report runs' do
+      report_tag = 'after_cv'
+      csv_filename = reporter.write_to_csv(csv_lines, report_type: 'test', report_tag: report_tag)
+      expect(csv_filename).to match(%r{^#{default_filepath}\/MoabStorageRoot_#{msr_a.name}_test_after_cv.*\.csv$})
+      expect(CSV.read(csv_filename)).to eq(csv_lines)
+    end
+
     it 'allows the caller to specify an alternate filename, including full path' do
       alternate_filename = '/tmp/my_cool_druid_export.csv'
       csv_filename = reporter.write_to_csv(csv_lines, filename: alternate_filename)

--- a/spec/services/moab_storage_root_reporter_spec.rb
+++ b/spec/services/moab_storage_root_reporter_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe MoabStorageRootReporter do
       expect(CSV.read(csv_filename)).to eq(csv_lines)
       expect(csv_filename).to match(%r{^#{default_filepath}\/MoabStorageRoot_#{msr_a.name}_test_.*\.csv$})
       timestamp_str = /MoabStorageRoot_#{msr_a.name}_test_(.*)\.csv$/.match(csv_filename).captures[0]
-      expect(DateTime.parse(timestamp_str)).to be >= test_start_time
+      # yes this lexically compares date strings, sorry. but they're very regular (always
+      # the same length), and dropped colons makes DateTime parsing painful.
+      expect(timestamp_str).to be >= test_start_time.to_s.gsub(':', '')
     end
 
     it 'allows the caller to specify an alternate filename, including full path' do

--- a/spec/services/moab_storage_root_reporter_spec.rb
+++ b/spec/services/moab_storage_root_reporter_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe MoabStorageRootReporter do
     it 'creates a default file containing the lines given to it' do
       csv_filename = reporter.write_to_csv(csv_lines, report_type: 'test')
       expect(CSV.read(csv_filename)).to eq(csv_lines)
-      expect(csv_filename).to match(%r{^#{default_filepath}\/MoabStorageRoot_#{msr_a.name}_test_.*\.csv$})
-      timestamp_str = /MoabStorageRoot_#{msr_a.name}_test_(.*)\.csv$/.match(csv_filename).captures[0]
+      expect(csv_filename).to match(%r{^#{default_filepath}\/storage_#{msr_a.name}_test_.*\.csv$})
+      timestamp_str = /storage_#{msr_a.name}_test_(.*)\.csv$/.match(csv_filename).captures[0]
       # yes this lexically compares date strings, sorry. but they're very regular (always
       # the same length), and dropped colons makes DateTime parsing painful.
       expect(timestamp_str).to be >= test_start_time.to_s.gsub(':', '')
@@ -78,7 +78,7 @@ RSpec.describe MoabStorageRootReporter do
     it 'allows the caller to specify a tag string, to more easily differentiate report runs' do
       report_tag = 'after_cv'
       csv_filename = reporter.write_to_csv(csv_lines, report_type: 'test', report_tag: report_tag)
-      expect(csv_filename).to match(%r{^#{default_filepath}\/MoabStorageRoot_#{msr_a.name}_test_after_cv.*\.csv$})
+      expect(csv_filename).to match(%r{^#{default_filepath}\/storage_#{msr_a.name}_test_after_cv.*\.csv$})
       expect(CSV.read(csv_filename)).to eq(csv_lines)
     end
 


### PR DESCRIPTION
## Why was this change made?

closes #1367

* better rake task names
* remove colons in default output file names
* shorten default output file names
  * i kept `storage_` as a prefix because i'd prefer _some_ namespacing/grouping in the event that we add other reports.  easy enough to totally remove if you feel strongly that it should go.
* user entered "tag" for easier visual differentiation of report runs
* slop from #1365

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

will update in a subsequent PR, since the changes i had on that front need a little tweaking, and may conflict with changes in (as-yet unmerged) #1372.