### PR TITLE
Remove OKComputerController logger bespoke configuration

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -5,7 +5,9 @@ require Rails.root.join('config', 'initializers', 'resque.rb').to_s
 
 OkComputer.mount_at = 'status' # use /status or /status/all or /status/<name-of-check>
 OkComputer.check_in_parallel = true
-OkComputer::OkComputerController.logger = ActiveSupport::Logger.new(File.join('log', 'ok_computer_controller.log'))
+Rails.configuration.to_prepare do
+  OkComputer::OkComputerController.logger = ActiveSupport::Logger.new(File.join('log', 'ok_computer_controller.log'))
+end
 
 # check models to see if at least they have some data
 class TablesHaveDataCheck < OkComputer::Check

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -5,9 +5,6 @@ require Rails.root.join('config', 'initializers', 'resque.rb').to_s
 
 OkComputer.mount_at = 'status' # use /status or /status/all or /status/<name-of-check>
 OkComputer.check_in_parallel = true
-Rails.configuration.to_prepare do
-  OkComputer::OkComputerController.logger = ActiveSupport::Logger.new(File.join('log', 'ok_computer_controller.log'))
-end
 
 # check models to see if at least they have some data
 class TablesHaveDataCheck < OkComputer::Check


### PR DESCRIPTION
Should fix #1371. Thanks @mjgiarlo for pointing to this [stackoverflow](https://stackoverflow.com/questions/56402093/how-can-i-preload-concerns-in-a-rails-initializer-using-rails-6-zeitwerk/59971682#59971682)  article.

## Why was this change made?
The current method generates a depreciation warning.


## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
n/a