### PR TITLE
add bug_report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: File a bug report
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**User Impact**
+A description of the impact of this bug on, e.g. accessioning throughput or your own work or long term preservation.
+
+**Object(s) In This Error State**
+
+Some druids of objects with this problem, and information on what recent changes might have brought the objects to this state (e.g. "added file x in a new version", "tweaked signatureCatalog.xml for v4 manually to fix XXX (not that anyone would ever do this), ...)
+
+Steps to Reproduce, if Known:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
## Why was this change made?

To have more than the storage-migration-checklist template;  want to make sure the repo doesn't make it hard for non-migration issues to be reported during the next few months.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a