### PR TITLE
[HOLD] Add OpenAPI spec and validate requests against it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ rvm:
   - 2.5.3
 before_install:
   - yes | gem update --system
+  - nvm install node
+  - npm install -g openapi-enforcer-cli
 cache: bundler
 services:
   - postgresql
   - redis-server
 before_script:
   - bundle exec rake db:reset
+script:
+  - ./scripts/validate-openapi.bash
+  - bundle exec rake
 bundler_args: "--without 'production development deploy'"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 before_script:
   - bundle exec rake db:reset
 script:
-  - ./scripts/validate-openapi.bash
+  - ./scripts/validate-openapi.bash || travis_terminate 1
   - bundle exec rake
 bundler_args: "--without 'production development deploy'"
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ end
 
 # general Ruby/Rails gems
 gem 'aws-sdk-s3', '~> 1.17'
+gem 'committee' # Validates HTTP requests/responses per OpenAPI specification
 gem 'config' # Settings to manage configs on different instances
 gem 'dor-services-client', '~> 4.13'
 gem 'dor-workflow-client', '~> 3.8' # audit errors are reported to the workflow service

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,10 @@ GEM
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
     coderay (1.1.2)
+    committee (3.3.0)
+      json_schema (~> 0.14, >= 0.14.3)
+      openapi_parser (>= 0.6.1)
+      rack (>= 1.5)
     concurrent-ruby (1.1.6)
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -224,6 +228,7 @@ GEM
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
     json (2.3.0)
+    json_schema (0.20.8)
     jwt (2.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -260,6 +265,7 @@ GEM
     nokogiri-happymapper (0.8.1)
       nokogiri (~> 1.5)
     okcomputer (1.18.1)
+    openapi_parser (0.8.0)
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
@@ -412,6 +418,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-resque-pool
+  committee
   config
   coveralls
   dlss-capistrano

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![Build Status](https://travis-ci.org/sul-dlss/preservation_catalog.svg?branch=master)](https://travis-ci.org/sul-dlss/preservation_catalog)
 [![Coverage Status](https://coveralls.io/repos/github/sul-dlss/preservation_catalog/badge.svg?branch=master)](https://coveralls.io/github/sul-dlss/preservation_catalog?branch=master)
 [![GitHub version](https://badge.fury.io/gh/sul-dlss%2Fpreservation_catalog.svg)](https://badge.fury.io/gh/sul-dlss%2Fpreservation_catalog)
+[![Docker image](https://images.microbadger.com/badges/image/suldlss/preservation_catalog.svg)](https://microbadger.com/images/suldlss/preservation_catalog "Get your own image badge on microbadger.com")
+[![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/preservation_catalog/master/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/preservation_catalog/master/openapi.yml)
 
 # README
 
@@ -357,6 +359,16 @@ curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' http://lo
   "updated_at":"2019-12-20T15:04:56.854Z",
   "preservation_policy_id":1
 }
+```
+
+Build image:
+```
+docker build -t suldlss/preservation_catalog:latest .
+```
+
+Publish:
+```
+docker push suldlss/preservation_catalog:latest
 ```
 
 ## Deploying

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,12 +51,6 @@ class ApplicationController < ActionController::API
     id&.split(':', 2)&.last
   end
 
-  def bad_request(exception)
-    msg = '400 bad request'
-    msg = "#{msg}: #{exception.message}" if exception
-    render plain: msg, status: :bad_request
-  end
-
   def not_found(exception)
     msg = '404 Not Found'
     msg = "#{msg}: #{exception.message}" if exception

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -25,7 +25,7 @@ class CatalogController < ApplicationController
     render status: status_code, json: poh.results.to_json
   end
 
-  # PATCH /v1/catalog/:id
+  # PUT/PATCH /v1/catalog/:id
   # User can only update a partial record (application controls what can be updated)
   def update
     @poh = PreservedObjectHandler.new(bare_druid, incoming_version, incoming_size, moab_storage_root)

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,10 +12,39 @@ require 'active_job/railtie'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+class JSONAPIError < Committee::ValidationError
+  def error_body
+    {
+      errors: [
+        { status: id, detail: message }
+      ]
+    }
+  end
+
+  def render
+    [
+      status,
+      { 'Content-Type' => 'application/vnd.api+json' },
+      [JSON.generate(error_body)]
+    ]
+  end
+end
+
 module PreservationCatalog
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
+
+    # accept_request_filter omits OKComputer & Resque routes
+    accept_proc = proc { |request| request.path.start_with?('/v1') }
+    config.middleware.use Committee::Middleware::RequestValidation, schema_path: 'openapi.yml',
+                                                                    strict: true, error_class: JSONAPIError,
+                                                                    accept_request_filter: accept_proc
+    # TODO: we can uncomment this at a later date to ensure we are passing back
+    #       valid responses. Currently, uncommenting this line causes 24 spec
+    #       failures. See https://github.com/sul-dlss/preservation_catalog/issues/1407
+    #
+    # config.middleware.use Committee::Middleware::ResponseValidation, schema_path: 'openapi.yml'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>API documentation</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>
+         body {
+             margin: 0;
+             padding: 0;
+         }
+        </style>
+    </head>
+    <body>
+        <redoc spec-url='https://raw.githubusercontent.com/sul-dlss/preservation_catalog/master/openapi.yml'></redoc>
+        <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js"> </script>
+    </body>
+</html>

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,564 @@
+openapi: 3.0.0
+info:
+  description: Preservation Catalog HTTP API
+  version: 1.0.0
+  title: Preservation Catalog HTTP API
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+servers:
+  - url: 'https://preservation-catalog-{env}-01.stanford.edu'
+    description: Production service
+    variables:
+      env:
+        default: prod
+  - url: 'https://preservation-catalog-{env}-01.stanford.edu'
+    description: Staging service
+    variables:
+      env:
+        default: stage
+  - url: 'https://preservation-catalog-{env}-01.stanford.edu'
+    description: QA service
+    variables:
+      env:
+        default: qa
+tags:
+  - name: catalog
+    description: Add and update Moabs in the catalog
+  - name: objects
+    description: Preserved Objects
+paths:
+  /v1/catalog:
+    post:
+      tags:
+        - catalog
+      summary: Add a new Moab to the catalog
+      responses:
+        '201':
+          description: Created new Moab
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditResultsResponse'
+        '409':
+          description: Conflict - Moab already exists
+        '406':
+          description: Invalid arguments passed
+        '500':
+          description: Internal server error
+      requestBody:
+        $ref: '#/components/requestBodies/CatalogOptionsWithDruid'
+  /v1/catalog/{druid}:
+    put:
+      tags:
+        - catalog
+      summary: Update a Moab in the catalog
+      responses:
+        '200':
+          description: Updated Moab
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditResultsResponse'
+        '404':
+          description: Moab not found
+        '406':
+          description: Invalid arguments passed
+        '400':
+          description: Moab version less than what is in catalog
+        '500':
+          description: Internal server error
+      parameters:
+        - name: druid
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
+      requestBody:
+        $ref: '#/components/requestBodies/CatalogOptions'
+    patch:
+      tags:
+        - catalog
+      summary: Update a Moab in the catalog
+      responses:
+        '200':
+          description: Updated Moab
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditResultsResponse'
+        '404':
+          description: Moab not found
+        '406':
+          description: Invalid arguments passed
+        '400':
+          description: Moab version less than what is in catalog
+        '500':
+          description: Internal server error
+      parameters:
+        - name: druid
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
+      requestBody:
+        $ref: '#/components/requestBodies/CatalogOptions'
+  /v1/objects/{id}:
+    get:
+      tags:
+        - objects
+      summary: Render a single preserved object as JSON
+      responses:
+        '200':
+          description: Preserved object found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PreservedObject'
+        '404':
+          description: Preserved object not found
+      parameters:
+        - name: id
+          in: path
+          required: true
+          example: 'druid:bc123df4567.json'
+          schema:
+            $ref: '#/components/schemas/DruidWithOptionalFormat'
+  /v1/objects/{id}/checksum.json:
+    get:
+      tags:
+        - objects
+      summary: Show the checksums and filesizes for a single object
+      responses:
+        '200':
+          description: Object found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChecksumsForObject'
+        '400':
+          description: Bad request (e.g., malformed druid)
+        '404':
+          description: Object not found
+      parameters:
+        - name: id
+          in: path
+          required: true
+          example: 'druid:bc123df4567'
+          schema:
+            $ref: '#/components/schemas/Druid'
+  /v1/objects/checksums:
+    get:
+      tags:
+        - objects
+      summary: Return checksums for a list of druids
+      responses:
+        '200':
+          description: Objects found for given druids
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChecksumsForObjects'
+            text/csv:
+              schema:
+                type: string # AFAICT, OpenAPI does not allow us to model CSV data
+        '400':
+          description: Bad request (e.g., malformed druid(s))
+        '406':
+          description: Unsupported response format
+        '409':
+          description: Conflict - one or more missing or error-state objects
+      parameters:
+        - name: druids
+          in: query
+          required: true
+          example: ['druid:bc123df4567', 'druid:bc123df4568', 'druid:bc123df4569']
+          schema:
+            type: array
+            minItems: 1
+            items:
+              $ref: '#/components/schemas/Druid'
+        - name: format
+          in: query
+          required: true
+          example: 'json'
+          schema:
+            type: string
+        - name: return_bare_druids
+          in: query
+          required: false
+          example: 'true'
+          schema:
+            type: string
+            enum:
+              - 'false'
+              - 'true'
+    post:
+      tags:
+        - objects
+      summary: Return checksums for a list of druids
+      responses:
+        '200':
+          description: Objects found for given druids
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChecksumsForObjects'
+            text/csv:
+              schema:
+                type: string # AFAICT, OpenAPI does not allow us to model CSV data
+        '400':
+          description: Bad request (e.g., malformed druid(s))
+        '406':
+          description: Unsupported response format
+        '409':
+          description: Conflict - one or more missing or error-state objects
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                druids:
+                  example: ['druid:bc123df4567', 'druid:bc123df4568', 'druid:bc123df4569']
+                  type: array
+                  minItems: 1
+                  items:
+                    $ref: '#/components/schemas/Druid'
+                format:
+                  example: 'json'
+                  type: string
+                return_bare_druids:
+                  example: 'true'
+                  type: string
+                  enum:
+                    - 'false'
+                    - 'true'
+              required:
+                - druids
+                - format
+  /v1/objects/{id}/file:
+    get:
+      tags:
+        - objects
+      summary: Return a specific file from the Moab
+      responses:
+        '200':
+          description: OK, returns a file (of whatever type, thus not validated here)
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Version parameter not positive integer or other problem with request params
+        '404':
+          description: Object or file or version not found
+      parameters:
+        - name: id
+          in: path
+          required: true
+          example: 'druid:bc123df4567'
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: filepath
+          description: filepath relative to given `category` query argument, which is a directory in the Moab
+          in: query
+          required: true
+          example: 'manifestInventory.xml'
+          schema:
+            type: string
+        - name: category
+          in: query
+          required: true
+          example: 'manifest'
+          schema:
+            type: string
+            enum:
+              - content
+              - manifest
+              - metadata
+        - name: version
+          in: query
+          required: false
+          example: '9'
+          schema:
+            type: string
+  /v1/objects/{id}/content_diff:
+    post:
+      tags:
+        - objects
+      summary: Return a Moab::FileInventoryDifference for contentMetadata (specific to the Moab)
+      responses:
+        '200':
+          description: OK
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ContentDiff'
+        '400':
+          description: Version parameter not a positive integer or parameter error raised
+        '500':
+          description: Unable to get content diff
+      parameters:
+        - name: id
+          in: path
+          required: true
+          example: 'druid:bc123df4567'
+          schema:
+            $ref: '#/components/schemas/Druid'
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                content_metadata:
+                  type: string
+                  description: an XML representation of content metadata
+                version:
+                  example: '9'
+                  type: string
+                subset:
+                  example: 'publish'
+                  description: "subset of files to diff (default: 'all')"
+                  type: string
+                  enum:
+                    - all
+                    - shelve
+                    - publish
+                    - preserve
+              required:
+                - content_metadata
+components:
+  requestBodies:
+    CatalogOptions:
+      description: Common options for PUT/POST/PATCH operations to the catalog controller
+      required: true
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            $ref: '#/components/schemas/CatalogOptions'
+    CatalogOptionsWithDruid:
+      description: Common options (plus druid) for PUT/POST/PATCH operations to the catalog controller
+      required: true
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/CatalogOptions'
+              - type: object
+                properties:
+                  druid:
+                    $ref: '#/components/schemas/Druid'
+                required:
+                  - druid
+  schemas:
+    Druid:
+      description: Digital Repository Unique Identifier (bare or prefixed)
+      type: string
+      pattern: '^(druid:)?[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
+      example: 'druid:bc123df4567'
+    DruidWithOptionalFormat:
+      description: Digital Repository Unique Identifier (bare or prefixed), with a file extension
+      type: string
+      pattern: '^(druid:)?[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}(\.json)?$'
+      example: 'druid:bc123df4567.json'
+    CatalogOptions:
+      description: Options for catalog controller endpoint
+      type: object
+      properties:
+        incoming_version:
+          type: integer
+        incoming_size:
+          type: integer
+        storage_location:
+          description: Must correspond to a real MoabStorageRoot
+          type: string
+        checksums_validated:
+          type: string
+          enum:
+            - 'true'
+            - 'True'
+            - 'TRUE'
+            - 'nil'
+            - '1'
+            - 'on'
+            - 'false'
+            - 'False'
+            - 'FALSE'
+      required:
+        - incoming_version
+        - incoming_size
+        - storage_location
+    ContentDiff:
+      description: A diff between given and existing content metadata (XML)
+      type: object
+      properties:
+        objectId:
+          $ref: '#/components/schemas/Druid'
+        differenceCount:
+          type: string
+          example: '2'
+        basis:
+          type: string
+          example: "v1-contentMetadata-all"
+        other:
+          type: string
+          example: "new-contentMetadata-all"
+        reportDatetime:
+          type: string
+          format: date-time
+        fileGroupDifference:
+          type: object
+          properties:
+            groupId:
+              type: string
+            differenceCount:
+              type: string
+            identical:
+              type: string
+            copyadded:
+              type: string
+            copydeleted:
+              type: string
+            renamed:
+              type: string
+            modified:
+              type: string
+            added:
+              type: string
+            deleted:
+              type: string
+            subset:
+              type: array
+              items:
+                type: object
+                properties:
+                  change:
+                    type: string
+                  count:
+                    type: string
+                  file:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        change:
+                          type: string
+                        basisPath:
+                          type: string
+                        otherPath:
+                          type: string
+                        fileSignature:
+                          type: object
+                          properties:
+                            size:
+                              type: string
+                            md5:
+                              type: string
+                            sha1:
+                              type: string
+                            sha256:
+                              type: string
+      required: # really not sure how much of the above is required or not
+        - object_id
+        - difference_count
+        - basis
+        - other
+        - report_datetime
+    ChecksumsForObjects:
+      description: A representation of all files and checksums for a list of objects
+      type: array
+      minItems: 1
+      items:
+        type: object
+        additionalProperties:
+          type: object
+          properties:
+            druid:
+              $ref: '#/components/schemas/Druid'
+            checksums:
+              $ref: '#/components/schemas/ChecksumsForObject'
+    ChecksumsForObject:
+      description: A representation of all files and checksums for a single object
+      type: array
+      items:
+        type: object
+        properties:
+          filename:
+            type: string
+            example: 'eric-smith-dissertation.pdf'
+          md5:
+            type: string
+            example: 'aead2f6f734355c59af2d5b2689e4fb3'
+          sha1:
+            type: string
+            example: '22dc6464e25dc9a7d600b1de6e3848bf63970595'
+          sha256:
+            type: string
+            example: 'e49957d53fb2a46e3652f4d399bd14d019600cf496b98d11ebcdf2d10a8ffd2f'
+          filesize:
+            type: integer
+            example: 1000217
+        required:
+          - filename
+          - md5
+          - sha1
+          - sha256
+          - filesize
+    PreservedObject:
+      description: A preserved object instance
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 123
+        druid:
+          $ref: '#/components/schemas/Druid'
+        current_version:
+          type: integer
+          example: 13
+        created_at:
+          type: string
+          format: date-time
+          example: '2020-02-20T06:34:16.148Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2020-02-21T16:36:28.075Z'
+        preservation_policy_id:
+          type: integer
+          example: 5
+      required:
+        - id
+        - druid
+        - current_version
+        - created_at
+        - updated_at
+        - preservation_policy_id
+    AuditResult:
+      description: A single audit result
+      type: object
+    AuditResultsResponse:
+      description: Audit results response
+      type: object
+      properties:
+        druid:
+          $ref: '#/components/schemas/Druid'
+        result_array:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditResult'
+      required:
+        - druid
+        - result_array
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+security:
+  - bearerAuth: []

--- a/scripts/validate-openapi.bash
+++ b/scripts/validate-openapi.bash
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ev
+
+result=$(openapi-enforcer validate openapi.yml)
+[[ $result =~ "Document is valid" ]] && {
+    echo "Validation good"
+    exit 0
+} || {
+    echo $result
+    exit 1
+}

--- a/spec/requests/objects_controller_checksums_spec.rb
+++ b/spec/requests/objects_controller_checksums_spec.rb
@@ -201,7 +201,8 @@ RSpec.describe ObjectsController, type: :request do
         it 'body has additional information from the exception if available' do
           post checksums_objects_url, params: { druids: [], format: :json }, headers: valid_auth_header
           expect(response).to have_http_status(:bad_request)
-          expect(response.body).to eq '400 Bad Request: Identifier has invalid suri syntax:  nil or empty'
+          error_response = JSON.parse(response.body)['errors'].first
+          expect(error_response['detail']).to include('does not match value: , example: druid:bc123df4567')
         end
       end
 
@@ -209,7 +210,8 @@ RSpec.describe ObjectsController, type: :request do
         it 'body has additional information from the exception if available' do
           post checksums_objects_url, params: { format: :json }, headers: valid_auth_header
           expect(response).to have_http_status(:bad_request)
-          expect(response.body).to eq '400 Bad Request - druids param must be populated with valid druids'
+          error_response = JSON.parse(response.body)['errors'].first
+          expect(error_response['detail']).to include('schema missing required parameters: druids')
         end
       end
     end
@@ -218,7 +220,8 @@ RSpec.describe ObjectsController, type: :request do
       it 'returns 400 response code' do
         post checksums_objects_url, params: { druids: [prefixed_druid, 'foobar'], format: :json }, headers: valid_auth_header
         expect(response).to have_http_status(:bad_request)
-        expect(response.body).to eq '400 Bad Request: Identifier has invalid suri syntax: foobar'
+        error_response = JSON.parse(response.body)['errors'].first
+        expect(error_response['detail']).to include('does not match value: foobar, example: druid:bc123df4567')
       end
     end
 

--- a/spec/requests/objects_controller_file_spec.rb
+++ b/spec/requests/objects_controller_file_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe ObjectsController, type: :request do
         it 'returns 400 response code with details' do
           get file_object_url(id: prefixed_druid), params: { category: 'metadata' }, headers: valid_auth_header
           expect(response).to have_http_status(:bad_request)
-          expect(response.body).to eq '400 Bad Request: No filename provided to MoabStorageService.filepath for druid bj102hs9687'
+          error_response = JSON.parse(response.body)['errors'].first
+          expect(error_response['detail']).to include('missing required parameters: filepath')
         end
       end
     end
@@ -77,10 +78,11 @@ RSpec.describe ObjectsController, type: :request do
 
     context 'when no id param' do
       context 'when id param is empty' do
-        it "returns 404 with 'Couldn't find PreservedObject'" do
+        it "returns 400 error" do
           get file_object_url(id: ''), params: { category: 'manifest', filepath: 'manifestInventory.xml' }, headers: valid_auth_header
-          expect(response).to have_http_status(:not_found)
-          expect(response.body).to eq "404 Not Found: Couldn't find PreservedObject"
+          expect(response).to have_http_status(:bad_request)
+          error_response = JSON.parse(response.body)['errors'].first
+          expect(error_response['detail']).to include('does not match value: , example: druid:bc123df4567')
         end
       end
 
@@ -94,10 +96,11 @@ RSpec.describe ObjectsController, type: :request do
     end
 
     context 'when druid invalid' do
-      it 'returns 404 response code with "Identifier has invalid suri syntax"' do
+      it 'returns 400 error' do
         get file_object_url(id: 'foobar'), params: { category: 'manifest', filepath: 'manifestInventory.xml' }, headers: valid_auth_header
-        expect(response).to have_http_status(:not_found)
-        expect(response.body).to eq '404 Not Found: Identifier has invalid suri syntax: foobar'
+        expect(response).to have_http_status(:bad_request)
+        error_response = JSON.parse(response.body)['errors'].first
+        expect(error_response['detail']).to include('does not match value: foobar, example: druid:bc123df4567')
       end
     end
   end

--- a/spec/requests/objects_controller_object_spec.rb
+++ b/spec/requests/objects_controller_object_spec.rb
@@ -20,13 +20,9 @@ RSpec.describe ObjectsController, type: :request do
     end
 
     context 'when object not found' do
-      it 'returns a 404 response code' do
-        get object_url('druid:garbage', format: :json), headers: valid_auth_header
+      it 'returns a 404 response code and informative body' do
+        get object_url('druid:bc123df4567', format: :json), headers: valid_auth_header
         expect(response).to have_http_status(:not_found)
-      end
-
-      it 'returns useful info in the body' do
-        get object_url('druid:garbage', format: :json), headers: valid_auth_header
         expect(response.body).to eq "404 Not Found: Couldn't find PreservedObject"
       end
     end


### PR DESCRIPTION
Fixes #1216

## Why was this change made?

Includes:
* Add OpenAPI specification (in YAML format)
* Use Committee gem to validate requests (but not yet responses)
* Validate the OpenAPI specification in CI
* Align ObjectsController documentation with implementation
* Adjust specs now that committee is doing some error handling

This PR could go farther by validating responses in addition to requests, and also by removing some error-checking/validation code paths in the controllers that may now effectively be dead by virtue of the work Committee is doing for us, but I opted to get this PR submitted instead due to its size and complexity.

Note that the [drop in coverage](https://coveralls.io/builds/28888801) is related to :point_up:. I'd like to hear what folks think about this.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

yes