### PR TITLE
migration checklist: more details on checking errors after migration;…

### DIFF
--- a/.github/ISSUE_TEMPLATE/storage-migration-checklist.md
+++ b/.github/ISSUE_TEMPLATE/storage-migration-checklist.md
@@ -218,12 +218,12 @@ Ops will now perform such tasks as the following:
       - [ ] if files are NOT "the same" in the old and new location
         - [ ] Work with Ops to perhaps do a manual re-copy of the Moab's files from the source to the target storage
         - [ ] Re-run CV on this object (see README) to see if status changes to match cv_b4 report.
-          - [ ] If not, PANIC.  (don't know what to do with these yet)
+          - [ ] If not, PANIC.  (don't know what to do with these yet - will update this doc soon.)
 
     - [ ] is it a NEW error?  (the object did NOT have the same error before migration)
       - [ ] Work with Ops to perhaps do a manual re-copy of the Moab's files from the source to the target storage
       - [ ] Re-run CV on this object (see README) to see if status changes to 'ok'.
-        - [ ] If not, PANIC.  (don't know what to do with these yet)
+        - [ ] If not, PANIC.  (don't know what to do with these yet - will update this doc soon.)
 
   **IS ANYTHING TOO SCARY TO CONTINUE WITH MIGRATION?**  (e.g. lots of new errors)
 
@@ -249,7 +249,7 @@ Do check for honeybadger errors while audit validations are running
     - [ ] is it a NEW error?  (check the appropriate m2c_b4 error report)
       - [ ] Work with Ops to perhaps do a manual re-copy of the Moab's files from the source to the target storage
       - [ ] Re-run M2C on this object (see README) to see if status changes to 'ok'.
-        - [ ] If not, PANIC.  (don't know what to do with these yet)
+        - [ ] If not, PANIC.  (don't know what to do with these yet - will update this doc soon.)
 
     - [ ] is it an EXISTING error (did this object have the same error before migration?  Check the appropriate m2c_b4 error report)
         Make sure the files contained in the source moab directories are the same as the files contained in the target moab directories (e.g. the list of enumerated files is the same, and the file contents on both sides produce the same respective md5 values)
@@ -259,7 +259,7 @@ Do check for honeybadger errors while audit validations are running
       - [ ] if files are NOT "the same" in the old and new location
         - [ ] Work with Ops to perhaps do a manual re-copy of the Moab's files from the source to the target storage
         - [ ] Re-run M2C on this object (see README) to see if status changes to match cv_b4 report.
-          - [ ] If not, PANIC.  (don't know what to do with these yet)
+          - [ ] If not, PANIC.  (don't know what to do with these yet - will update this doc soon.)
 
 ### After Migration Success
 

--- a/.github/ISSUE_TEMPLATE/storage-migration-checklist.md
+++ b/.github/ISSUE_TEMPLATE/storage-migration-checklist.md
@@ -245,6 +245,7 @@ Do **CHECK FOR M2C ERRORS while it's running** (run audit report) to see if anyt
 Do check for honeybadger errors while audit validations are running
 
   - [ ] after M2C finishes, generate report for objects with error status ```RAILS_ENV=production bundle exec rake prescat:reports:msr_moab_audit_errors[stor_root_name,m2c_after]```
+  - [ ] diff m2c_b4 report with m2c_after report - the druids and statuses should match.
   - [ ] examine each existing M2C error (from report in /opt/app/pres/preservation_catalog/current/log/reports)
     - [ ] is it a NEW error?  (check the appropriate m2c_b4 error report)
       - [ ] Work with Ops to perhaps do a manual re-copy of the Moab's files from the source to the target storage

--- a/.github/ISSUE_TEMPLATE/storage-migration-checklist.md
+++ b/.github/ISSUE_TEMPLATE/storage-migration-checklist.md
@@ -26,21 +26,21 @@ Run all validation checks on Moabs and generate reports.  Note that error detail
   - [ ] requeue failed jobs / ensure no jobs failed via resque GUI https://preservation-catalog-prod-01.stanford.edu/resque/overview
 - [ ] after M2C finishes, generate report for objects with error status ```RAILS_ENV=production bundle exec rake prescat:reports:msr_moab_audit_errors[stor_root_name,m2c_b4]```
 - [ ] note druids for each existing M2C error (from report in /opt/app/pres/preservation_catalog/current/log/reports)
-  - [ ] Ensure there is a github issue for the error/object in preservation_catalog
+  - [ ] Ensure there is a github issue in preservation_catalog for each error/object (mult objects with same error can be in same github issue.)
 
 #### C2M
 - [ ] run on storage root ```RAILS_ENV=production bundle exec rake prescat:audit:c2m[stor_root_name]```
   - [ ] requeue failed jobs / ensure no jobs failed via resque GUI https://preservation-catalog-prod-01.stanford.edu/resque/overview
 - [ ] after C2M finishes, generate report for objects with error status ```RAILS_ENV=production bundle exec rake prescat:reports:msr_moab_audit_errors[stor_root_name,c2m_b4]```
 - [ ] note druids for each existing C2M error (from report in /opt/app/pres/preservation_catalog/current/log/reports)
-  - [ ] Ensure there is a github issue for the error/object in preservation_catalog
+  - [ ] Ensure there is a github issue in preservation_catalog for each error/object (mult objects with same error can be in same github issue.)
 
 #### CV
 - [ ] run on storage root ```RAILS_ENV=production bundle exec rake prescat:audit:cv[stor_root_name]```
   - [ ] requeue failed jobs / ensure no jobs failed via resque GUI https://preservation-catalog-prod-01.stanford.edu/resque/overview
 - [ ] after CV finishes, generate report for objects with error status ```RAILS_ENV=production bundle exec rake prescat:reports:msr_moab_audit_errors[stor_root_name,cv_b4]```
 - [ ] note druids for each existing CV error (from report in /opt/app/pres/preservation_catalog/current/log/reports)
-  - [ ] Ensure there is a github issue for the error/object in preservation_catalog
+  - [ ] Ensure there is a github issue in preservation_catalog for each error/object (mult objects with same error can be in same github issue.)
 
 
 ##  During Cutover Weekend
@@ -199,12 +199,12 @@ Ops will now perform such tasks as the following:
 
     If you're not confident that CV can finish by Sunday evening, give it more resque workers via shared_configs PR https://github.com/sul-dlss/shared_configs/blob/preservation-catalog-stage/config/resque-pool.yml
 
-    NOTE: if we have to trigger CV audits manually (i.e. the above doesn't automatically kick off workers), we will need to run CV for the list of druids on the new root, NOT the entire new storage brick (when there is more tan one old root migrated to a single new storage brick.)  The list of druids is the 'druids_b4' report for the old storage root in /opt/app/pres/preservation_catalog/current/log/reports.
+    NOTE: if we have to trigger CV audits manually (i.e. the above doesn't automatically kick off workers), we will need to run CV for the list of druids on the new root, NOT the entire new storage brick (when there is more tan one old root migrated to a single new storage brick.)  The list of druids is the 'druids_b4' report for the old storage root in /opt/app/pres/preservation_catalog/current/log/reports.  Running CV for a list of druids is documented in the prescat README.
 
   - [ ] requeue failed jobs / ensure no jobs failed via resque GUI https://preservation-catalog-prod-01.stanford.edu/resque/overview
   - [ ] watch for errors in Honeybadger
   - [ ] after CV finishes, generate report for objects with error status ```RAILS_ENV=production bundle exec rake prescat:reports:msr_moab_audit_errors[stor_root_name,cv_after]```
-  - [ ] diff cv_b4 report with cv_after report before content migrated - the druids and statuses should match.
+  - [ ] diff cv_b4 report with cv_after report - the druids and statuses should match.
   - [ ] examine each existing CV_after error (from report in /opt/app/pres/preservation_catalog/current/log/reports)
     - [ ] is it an EXISTING error (did this object have the same error before migration?  Check the appropriate cv_b4 error report)
       - [ ] Did moab validation run?  If not: manual check at os level to compare files on new and old.
@@ -214,7 +214,7 @@ Ops will now perform such tasks as the following:
         If not: work with Ops to perhaps do a manual re-copy of any Moabs on the target storage with new errors, compared to the source storage.
 
       - [ ] if files are "the same" in the old and new location, then this error can be ignored until after migration.
-        - [ ] Ensure there is a github issue for the error/object in preservation_catalog (there should be, from previous step!)
+        - [ ] Ensure there is a github issue for the error/object in preservation_catalog (there should be, from a previous step!)
       - [ ] if files are NOT "the same" in the old and new location
         - [ ] Work with Ops to perhaps do a manual re-copy of the Moab's files from the source to the target storage
         - [ ] Re-run CV on this object (see README) to see if status changes to match cv_b4 report.
@@ -255,7 +255,7 @@ Do check for honeybadger errors while audit validations are running
         Make sure the files contained in the source moab directories are the same as the files contained in the target moab directories (e.g. the list of enumerated files is the same, and the file contents on both sides produce the same respective md5 values)
 
       - [ ] if files are "the same" in the old and new location, then this error can be ignored until after migration.
-        - [ ] Ensure there is a github issue for the error/object in preservation_catalog (there should be, from previous step!)
+        - [ ] Ensure there is a github issue in preservation_catalog for the error/object (there should be, from previous step!)
       - [ ] if files are NOT "the same" in the old and new location
         - [ ] Work with Ops to perhaps do a manual re-copy of the Moab's files from the source to the target storage
         - [ ] Re-run M2C on this object (see README) to see if status changes to match cv_b4 report.


### PR DESCRIPTION
… take out 'fix' problems

Would like @jmartin-sul to review, AND other reviewers input also useful.

## Why was this change made?

- To address mistakes (it's CPU, not RAM)
- To remove the notion of fixing validation errors during migration weekend
- To add 'PANIC' to the checklist for the sections we don't have a procedure for yet.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
