### PR TITLE
Correct code comment in ObjectsController

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -6,7 +6,7 @@ require 'csv'
 # ObjectsController allows consumers to interact with preserved objects
 #  (Note: methods will eventually be ported from sdr-services-app)
 class ObjectsController < ApplicationController
-  # return the PreservedObject model for the druid (supplied with druid: prefix)
+  # return the PreservedObject model for the druid (supplied *without* `druid:` prefix)
   # GET /v1/objects/:druid
   def show
     render json: PreservedObject.find_by!(druid: druid).to_json


### PR DESCRIPTION
Spotted by @ndushay here: https://github.com/sul-dlss/preservation_catalog/pull/1389#discussion_r384666534

## Why was this change made?

Inaccurate documentation is misleading.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

Yes, a code comment.

## Does this change affect how this application integrates with other services?

No.