### PR TITLE
AuditResults#events_client now uses namespaced druid

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -222,7 +222,11 @@ class AuditResults
   end
 
   def events_client
-    Dor::Services::Client.object(druid).events
+    Dor::Services::Client.object(namespaced_druid).events
+  end
+
+  def namespaced_druid
+    druid.start_with?('druid:') ? druid : "druid:#{druid}"
   end
 
   def result_code_msg(code, addl=nil)


### PR DESCRIPTION
also refine specs so they'd have caught that and the equivalent issue in WorkflowReporter

see #1414, #1388

## Why was this change made?

fixes #1414 (same issue as #1388, but in the one other spot that sort of call is made)

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a

## Does this change affect how this application integrates with other services?

If so, please confirm:
- [x] change was tested on stage    and/or
- [ ] ~~test added to sul-dlss/infrastructure-integration-test~~
