### PR TITLE
remove unnecessary conditional from code that namespaces druid

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -222,11 +222,7 @@ class AuditResults
   end
 
   def events_client
-    Dor::Services::Client.object(namespaced_druid).events
-  end
-
-  def namespaced_druid
-    druid.start_with?('druid:') ? druid : "druid:#{druid}"
+    Dor::Services::Client.object("druid:#{druid}").events # dor-services-app wants the namespaced druid
   end
 
   def result_code_msg(code, addl=nil)

--- a/app/services/workflow_reporter.rb
+++ b/app/services/workflow_reporter.rb
@@ -105,8 +105,10 @@ class WorkflowReporter
     workflow_client.create_workflow_by_name(namespaced_druid, PRESERVATIONAUDITWF, version: version)
   end
 
+  # prefixes the bare druid with the namespace, since dor-services-app and workflow server both
+  # want the namespaced version
   def namespaced_druid
-    druid.start_with?('druid:') ? druid : "druid:#{druid}"
+    "druid:#{druid}"
   end
 
   def workflow_client

--- a/spec/services/workflow_reporter_spec.rb
+++ b/spec/services/workflow_reporter_spec.rb
@@ -60,18 +60,6 @@ RSpec.describe WorkflowReporter do
   end
 
   describe '#create_workflow' do
-    context 'when passed a namespaced druid' do
-      let(:druid) { "druid:jj925bx9565" }
-
-      it 'passes the supplied druid along to the workflow client' do
-        reporter.send(:create_workflow)
-
-        expect(stub_wf_client).to have_received(:create_workflow_by_name)
-          .once
-          .with(druid, described_class::PRESERVATIONAUDITWF, version: version)
-      end
-    end
-
     context 'when passed a bare druid' do
       it 'adds a namespace to the druid and sends it to the workflow client' do
         reporter.send(:create_workflow)


### PR DESCRIPTION
preservation catalog consistently uses the bare druid in the code and in the DB, so there's no need to safeguard against the prefix already being there when providing a namespaced druid string to other services.

remove the superfluous conditional, and a test that exercised it in a way that'd never be used IRL.

## Why was this change made?

@jcoyne [asked if we could fix the code](https://github.com/sul-dlss/preservation_catalog/pull/1415#pullrequestreview-368207372) to not need the conditional that was removed here, but it was already unnecessary, so this just removes it.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a

## Does this change affect how this application integrates with other services?

no.  or at least, it doesn't intend to, though it does touch code that is used for interacting with other services.  happy to test on stage before this is merged or deployed to prod, if people want.


fwiw, i double-checked, and indeed, no druids on prod that begin with the `druid:` prefix:
```ruby
[6] pry(main)> PreservedObject.where("druid like 'druid%'").count
=> 0
[7] pry(main)> PreservedObject.where.not("druid like 'druid%'").count
=> 1774918
```

a couple of grep attempts also turn up no conditional prefixing similar to what this PR removes (`git grep "druid:" app/` returns results, but nothing like what's in this PR, and `git grep 'druid.start_with'` returns nothing but what's removed in this PR).