### PR TITLE
Expect shelve diff endpoint to receive JSON not www-form

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -312,7 +312,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/x-www-form-urlencoded:
+          application/json:
             schema:
               type: object
               properties:


### PR DESCRIPTION
This is a case of drift between preservation_catalog (where tests assumed a request body with x-www-form-urlencoded args) and preservation-client (which was sending JSON). Since upstream code is using the client to access this endpoint, the openapi spec (and the tests) should reflect this expectation.

Should resolve https://app.honeybadger.io/projects/50568/faults/59300637

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

Yes

## Does this change affect how this application integrates with other services?

I have run the integration tests and there are no prescat-related errors.