### PR TITLE
Mark version and subset request body args as nullable

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -322,10 +322,12 @@ paths:
                 version:
                   example: '9'
                   type: string
+                  nullable: true
                 subset:
                   example: 'publish'
                   description: "subset of files to diff (default: 'all')"
                   type: string
+                  nullable: true
                   enum:
                     - all
                     - shelve


### PR DESCRIPTION
## Why was this change made?

This is the expected behavior in the controller. This bug is blocking integration testing.


## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

openapi.yml, yes.

## Does this change affect how this application integrates with other services?

This will be integration tested.