### PR TITLE
circleci config updated for code climate test coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,6 @@ jobs:
           echo $result
           exit 1
           }
-    - store_test_results:
-        path: test_results
 
   build-image:
     executor: docker-publisher

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,50 +27,44 @@ jobs:
     steps:
     - checkout
 
-    # Upgrade bundler
     - run:
-        name: Install Bundler
+        name: Install/Upgrade Bundler
         command: gem install bundler
-
-    # Which version of bundler?
     - run:
         name: Which bundler?
         command: bundle -v
-
-    # Restore bundle cache
     - restore_cache:
         keys:
         - preservation-catalog-bundle-v2-{{ checksum "Gemfile.lock" }}
         - preservation-catalog-bundle-v2-
-
     - run:
         name: Bundle Install
         command: bundle check || bundle install
-
-    # Store bundle cache
     - save_cache:
         key: preservation-catalog-bundle-v2-{{ checksum "Gemfile.lock" }}
         paths:
         - vendor/bundle
-
-    - run:
-        name: Wait for DB
-        command: dockerize -wait tcp://localhost:5432 -timeout 1m
-
-    - run:
-        name: Test prepare
-        command: bin/rails db:reset
-
     - run:
         name: Check styles using rubocop
         command: bundle exec rubocop
-
-    # Run rspec in parallel
     - run:
-        name: Run rspec in parallel
+        name: Wait for DB
+        command: dockerize -wait tcp://localhost:5432 -timeout 1m
+    - run:
+        name: Prepare DB for tests
+        command: bin/rails db:reset
+    - run:
+        name: Setup Code Climate test-reporter
         command: |
-          bundle exec rspec
-
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+    - run:
+        name: Run rspec
+        command: bundle exec rspec
+    - run:
+        name: upload test coverage report to Code Climate
+        command: ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
     - run:
         name: Validate API specification
         command: |
@@ -83,7 +77,6 @@ jobs:
           echo $result
           exit 1
           }
-    # Save test results for timing analysis
     - store_test_results:
         path: test_results
 

--- a/.simplecov
+++ b/.simplecov
@@ -1,7 +1,0 @@
-require 'simplecov'
-require 'coveralls'
-
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start do
-  add_filter 'lib/tasks'
-end

--- a/Gemfile
+++ b/Gemfile
@@ -37,10 +37,11 @@ gem 'druid-tools' # for druid validation and druid-tree parsing
 group :development, :test do
   gem 'rspec-rails', '~> 3.6'
   gem 'rails-controller-testing'
-  gem 'coveralls'
   # Ruby static code analyzer http://rubocop.readthedocs.io/en/latest/
   gem 'rubocop', '~> 0.73.0'
   gem 'rubocop-rspec'
+  # Codeclimate is not compatible with 0.18+. See https://github.com/codeclimate/test-reporter/issues/413
+  gem 'simplecov', '~> 0.17.1'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,12 +126,6 @@ GEM
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -366,7 +360,7 @@ GEM
     ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
-    simplecov (0.16.1)
+    simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -386,14 +380,9 @@ GEM
     sshkit (1.21.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    sync (0.5.0)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tins (1.24.1)
-      sync
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
@@ -420,7 +409,6 @@ DEPENDENCIES
   capistrano-resque-pool
   committee
   config
-  coveralls
   dlss-capistrano
   dor-services-client (~> 4.13)
   dor-workflow-client (~> 3.8)
@@ -449,8 +437,9 @@ DEPENDENCIES
   rubocop-rspec
   ruby-prof
   shoulda-matchers!
+  simplecov (~> 0.17.1)
   webmock
   whenever
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CircleCI](https://circleci.com/gh/sul-dlss/preservation_catalog.svg?style=svg)](https://circleci.com/gh/sul-dlss/preservation_catalog)
-[![Coverage Status](https://coveralls.io/repos/github/sul-dlss/preservation_catalog/badge.svg?branch=master)](https://coveralls.io/github/sul-dlss/preservation_catalog?branch=master)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/96b330db62f304b786cb/test_coverage)](https://codeclimate.com/github/sul-dlss/preservation_catalog/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/96b330db62f304b786cb/maintainability)](https://codeclimate.com/github/sul-dlss/preservation_catalog/maintainability)
 [![GitHub version](https://badge.fury.io/gh/sul-dlss%2Fpreservation_catalog.svg)](https://badge.fury.io/gh/sul-dlss%2Fpreservation_catalog)
 [![Docker image](https://images.microbadger.com/badges/image/suldlss/preservation_catalog.svg)](https://microbadger.com/images/suldlss/preservation_catalog "Get your own image badge on microbadger.com")
 [![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/preservation_catalog/master/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/preservation_catalog/master/openapi.yml)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,12 @@
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-require 'coveralls'
+require 'simplecov'
 require 'webmock/rspec'
-Coveralls.wear!('rails')
+SimpleCov.start :rails do
+  add_filter '/spec/'
+  add_filter '/vendor/'
+end
 
 RSpec.configure do |config|
   config.filter_run_excluding(:live_aws, :live_ibm) unless ENV['CI'] == 'true' # default exclude unless on CI


### PR DESCRIPTION
## Why was this change made?

Fixes #1429

Adds code coverage back after we broke it when the switch was made from travis to CI (PR #1427).

I'm also moving coverage to CodeClimate.

Here's some proof it's working:  https://codeclimate.com/repos/5e680d9fbfd72e014c000fef/settings/test_reports/5e681b9cde48f40162009bf8

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

badge updated in README

## Does this change affect how this application integrates with other services?

no