### PR TITLE
Try to avoid db connection timeout when validating.

### DIFF
--- a/app/services/checksum_validator.rb
+++ b/app/services/checksum_validator.rb
@@ -27,6 +27,9 @@ class ChecksumValidator
     validate_manifest_inventories
     validate_signature_catalog
 
+    # This is to deal with db connection timeouts.
+    ActiveRecord::Base.clear_active_connections!
+
     transaction_ok = ActiveRecordUtils.with_transaction_and_rescue(results) do
       complete_moab.last_checksum_validation = Time.current
       if results.result_array.empty?


### PR DESCRIPTION
refs #1430

## Why was this change made?
To attempt to avoid a db timeout.

Since this is an intermittent problem, this is a wild guess.


## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No.