### PR TITLE
Add cap stage for storage migration instance

### DIFF
--- a/config/deploy/migrate.rb
+++ b/config/deploy/migrate.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+server 'preservation-catalog-migrate.stanford.edu', user: 'pres', roles: %w[app db web resque queue_populator]
+
+Capistrano::OneTimeKey.generate_one_time_key!
+set :rails_env, 'production'
+set :bundle_without, 'deploy test'
+set :deploy_to, '/opt/app/pres/preservation_catalog'
+set :whenever_roles, [:queue_populator]


### PR DESCRIPTION
## Why was this change made?

To deploy to the instance of prescat we will be using in the storage migration

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a -- this is a transient instance that will go away once the migration is complete

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

no