### PR TITLE
make moab migration method public, document usage

### DIFF
--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -128,6 +128,7 @@ class CompleteMoab < ApplicationRecord
     self.status_details = nil
     self.last_moab_validation = nil
     self.last_checksum_validation = nil
+    self.last_version_audit = nil
     self
   end
 

--- a/app/services/moab_storage_root_reporter.rb
+++ b/app/services/moab_storage_root_reporter.rb
@@ -91,6 +91,7 @@ class MoabStorageRootReporter
     @msr_names[msr_id] ||= MoabStorageRoot.find(msr_id).name
   end
 
+  # TODO: make methods like this and #write_csv that don't leverage internal state into class methods
   def status_text_from_code(status_code)
     CompleteMoab.statuses.key(status_code)
   end

--- a/app/services/storage_root_migration_service.rb
+++ b/app/services/storage_root_migration_service.rb
@@ -11,7 +11,7 @@ class StorageRootMigrationService
   def migrate
     druids = []
     from_root.complete_moabs.find_each do |complete_moab|
-      migrate_moab(complete_moab)
+      complete_moab.migrate_moab(to_root).save!
       druids << complete_moab.preserved_object.druid
     end
     druids
@@ -25,15 +25,5 @@ class StorageRootMigrationService
 
   def to_root
     @to_root ||= MoabStorageRoot.find_by!(name: @to_name)
-  end
-
-  def migrate_moab(moab)
-    moab.from_moab_storage_root = from_root
-    moab.moab_storage_root = to_root
-    moab.status = 'validity_unknown' # This will queue a CV.
-    moab.status_details = nil
-    moab.last_moab_validation = nil
-    moab.last_checksum_validation = nil
-    moab.save!
   end
 end

--- a/spec/services/storage_root_migration_service_spec.rb
+++ b/spec/services/storage_root_migration_service_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe StorageRootMigrationService do
     expect(complete_moab1.last_archive_audit).not_to be_nil
   end
 
+  it 'queues checksum validation jobs' do
+    allow(ChecksumValidationJob).to receive(:perform_later).with(complete_moab1)
+    allow(ChecksumValidationJob).to receive(:perform_later).with(complete_moab2)
+    allow(ChecksumValidationJob).to receive(:perform_later).with(complete_moab3)
+    described_class.new(from_storage_root.name, to_storage_root.name).migrate
+    expect(ChecksumValidationJob).to have_received(:perform_later).with(complete_moab1)
+    expect(ChecksumValidationJob).to have_received(:perform_later).with(complete_moab2)
+    expect(ChecksumValidationJob).not_to have_received(:perform_later).with(complete_moab3)
+  end
+
   it 'does not migrate moabs on other storage roots' do
     # Before migration
     orig_complete_moab3_storage_root = complete_moab3.moab_storage_root


### PR DESCRIPTION
## Why was this change made?

to support manual migration of individual moabs between storage roots.

closes #1447 (per https://github.com/sul-dlss/preservation_catalog/issues/1447#issuecomment-600355906)

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

yes

## Does this change affect how this application integrates with other services?
~~If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.~~

n/a, just makes it easier to leverage functionality from rails console that was previously a private method for a manually run rake task.