### PR TITLE
[Draft] Validate responses

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -85,7 +85,7 @@ class ObjectsController < ApplicationController
     end
     obj_version = params[:version].to_i if params[:version]&.match?(/^[1-9]\d*$/)
     subset = params[:subset] ||= 'all'
-    render(xml: MoabStorageService.content_diff(druid, params[:content_metadata], subset, obj_version).to_xml)
+    render build_response(:ok, MoabStorageService.content_diff(druid, params[:content_metadata], subset, obj_version).to_xml)
   rescue Moab::MoabRuntimeError => e
     render build_error("500 Unable to get content diff", :internal_server_error, e.message)
     Honeybadger.notify(e)

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -61,10 +61,10 @@ class ObjectsController < ApplicationController
 
     respond_to do |format|
       format.json do
-        render json: checksum_list.to_json
+        render build_response(:ok, checksum_list.to_json)
       end
       format.csv do
-        render plain: to_csv_checksum_list(checksum_list)
+        render build_response(:ok, to_csv_checksum_list(checksum_list))
       end
       format.any { render build_error('406 - Format not acceptable', :not_acceptable) }
     end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -10,6 +10,8 @@ class ObjectsController < ApplicationController
   # GET /v1/objects/:id.json
   def show
     render json: PreservedObject.find_by!(druid: druid).to_json
+  rescue ActiveRecord::RecordNotFound => e
+    render build_error('404 Object Not Found', :not_found, e.message)
   end
 
   # return a specific file from the Moab

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -31,7 +31,6 @@ class ObjectsController < ApplicationController
     if location
       render build_file_response(:ok, location)
     else
-      # render(plain: "404 File Not Found: #{druid}, #{params[:category]}, #{params[:filepath]}, #{params[:version]}", status: :not_found)
       render build_error("404 File Not Found", :not_found)
     end
   rescue Moab::MoabRuntimeError => e

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -29,10 +29,11 @@ class ObjectsController < ApplicationController
     if location
       send_file location
     else
-      render(plain: "404 File Not Found: #{druid}, #{params[:category]}, #{params[:filepath]}, #{params[:version]}", status: :not_found)
+      # render(plain: "404 File Not Found: #{druid}, #{params[:category]}, #{params[:filepath]}, #{params[:version]}", status: :not_found)
+      render build_error("404 File Not Found", :not_found)
     end
   rescue Moab::MoabRuntimeError => e
-    render(plain: "404 Not Found: #{e}", status: :not_found)
+    render build_error("404 File Not Found", :not_found, e.message)
   end
 
   # return the checksums and filesize for a single druid (supplied with druid: prefix)

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -9,7 +9,7 @@ class ObjectsController < ApplicationController
   # return the PreservedObject model for the druid (supplied *without* `druid:` prefix)
   # GET /v1/objects/:id.json
   def show
-    render json: PreservedObject.find_by!(druid: druid).to_json
+    render build_response(:ok, PreservedObject.find_by!(druid: druid).to_json)
   rescue ActiveRecord::RecordNotFound => e
     render build_error('404 Object Not Found', :not_found, e.message)
   end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -63,7 +63,7 @@ class ObjectsController < ApplicationController
       format.csv do
         render plain: to_csv_checksum_list(checksum_list)
       end
-      format.any { render status: :not_acceptable, plain: 'Format not acceptable' }
+      format.any { render build_error('406 - Format not acceptable', :not_acceptable) }
     end
   end
 

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -80,14 +80,14 @@ class ObjectsController < ApplicationController
   # - version (positive integer (as a string)) version of Moab to be compared against (defaults to latest version)
   def content_diff
     if params[:version] && !params[:version].match?(/^[1-9]\d*$/)
-      render(plain: "400 Bad Request: version parameter must be positive integer", status: :bad_request)
+      render build_error("400 Bad Request: version parameter must be positive integer", :bad_request)
       return
     end
     obj_version = params[:version].to_i if params[:version]&.match?(/^[1-9]\d*$/)
     subset = params[:subset] ||= 'all'
     render(xml: MoabStorageService.content_diff(druid, params[:content_metadata], subset, obj_version).to_xml)
   rescue Moab::MoabRuntimeError => e
-    render(plain: "500 Unable to get content diff: #{e}", status: :internal_server_error)
+    render build_error("500 Unable to get content diff", :internal_server_error, e.message)
     Honeybadger.notify(e)
   end
 

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -22,7 +22,7 @@ class ObjectsController < ApplicationController
   # - version (positive integer (as a string)) version of Moab
   def file
     if params[:version] && !params[:version].match?(/^[1-9]\d*$/)
-      render(plain: "400 Bad Request: version parameter must be positive integer", status: :bad_request)
+      render build_error("400 Bad Request: version parameter must be positive integer", :bad_request)
       return
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,7 +44,7 @@ module PreservationCatalog
     #       valid responses. Currently, uncommenting this line causes 24 spec
     #       failures. See https://github.com/sul-dlss/preservation_catalog/issues/1407
     #
-    # config.middleware.use Committee::Middleware::ResponseValidation, schema_path: 'openapi.yml'
+    config.middleware.use Committee::Middleware::ResponseValidation, schema_path: 'openapi.yml'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/openapi.yml
+++ b/openapi.yml
@@ -210,7 +210,7 @@ paths:
         '400':
           description: Bad request (e.g., malformed druid(s))
         '406':
-          description: Unsupported response format
+          $ref: '#/components/responses/Unsupported' # description: Unsupported response format
         '409':
           $ref: '#/components/responses/Conflict'
       requestBody:
@@ -373,6 +373,12 @@ components:
             $ref: '#/components/schemas/Error'
     Conflict:
       description: Conflict - one or more missing or error-state objects
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unsupported:
+      description: Unsupported response format
       content:
         application/json:
           schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -138,8 +138,8 @@ paths:
                 $ref: '#/components/schemas/ChecksumsForObject'
         '400':
           description: Bad request (e.g., malformed druid)
-        '404':
-          description: Object not found
+        '404':          
+          $ref: '#/components/responses/NotFound'
       parameters:
         - name: id
           in: path
@@ -212,7 +212,7 @@ paths:
         '406':
           description: Unsupported response format
         '409':
-          description: Conflict - one or more missing or error-state objects
+          $ref: '#/components/responses/Conflict'
       requestBody:
         required: true
         content:
@@ -358,6 +358,25 @@ components:
                     $ref: '#/components/schemas/Druid'
                 required:
                   - druid
+  responses:
+    OK:
+      description: A generic HTTP OK response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OK'
+    NotFound:
+      description: The specified object was not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Conflict:
+      description: Conflict - one or more missing or error-state objects
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
   schemas:
     Druid:
       description: Digital Repository Unique Identifier (bare or prefixed)
@@ -512,6 +531,22 @@ components:
           - sha1
           - sha256
           - filesize
+    ChecksumsForObjects:
+      description: A representation of all files and checksums for a list of objects
+      type: array
+      minItems: 1
+      items:
+        type: object
+        additionalProperties:
+          type: object
+          properties:
+            druid:
+              $ref: '#/components/schemas/Druid'
+            checksums:
+              $ref: '#/components/schemas/ChecksumsForObject'
+    CSVForObjects:
+      description: A csv representation of all files and checksums for a list of objects
+      type: string
     PreservedObject:
       description: A preserved object instance
       type: object
@@ -558,6 +593,26 @@ components:
       required:
         - druid
         - result_array
+    OK:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message
   securitySchemes:
     bearerAuth:
       type: http

--- a/openapi.yml
+++ b/openapi.yml
@@ -131,11 +131,12 @@ paths:
       summary: Show the checksums and filesizes for a single object
       responses:
         '200':
-          description: Object found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ChecksumsForObject'
+          $ref: '#/components/responses/ChecksumsOK'
+          # description: Object found
+          # content:
+          #   application/json:
+          #     schema:
+          #       $ref: '#/components/schemas/ChecksumsForObject'
         '400':
           description: Bad request (e.g., malformed druid)
         '404':          
@@ -362,8 +363,12 @@ components:
         application/octet-stream:
           schema:
             $ref: '#/components/schemas/File'
-            # type: file
-            # format: binary
+    ChecksumsOK:
+      description: A HTTP OK response with checksum JSON
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ChecksumsForObject'
     OK:
       description: A generic HTTP OK response
       content:

--- a/openapi.yml
+++ b/openapi.yml
@@ -116,7 +116,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PreservedObject'
         '404':
-          $ref: '#/components/responses/NotFound' # description: Preserved object not found
+          $ref: '#/components/responses/NotFound'
       parameters:
         - name: id
           in: path
@@ -132,11 +132,6 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ChecksumsOK'
-          # description: Object found
-          # content:
-          #   application/json:
-          #     schema:
-          #       $ref: '#/components/schemas/ChecksumsForObject'
         '400':
           description: Bad request (e.g., malformed druid)
         '404':          
@@ -211,7 +206,7 @@ paths:
         '400':
           description: Bad request (e.g., malformed druid(s))
         '406':
-          $ref: '#/components/responses/Unsupported' # description: Unsupported response format
+          $ref: '#/components/responses/Unsupported'
         '409':
           $ref: '#/components/responses/Conflict'
       requestBody:
@@ -252,7 +247,7 @@ paths:
         '400':
           description: Version parameter not positive integer or other problem with request params
         '404':
-          $ref: '#/components/responses/NotFound' # description: Object or file or version not found
+          $ref: '#/components/responses/NotFound'
       parameters:
         - name: id
           in: path
@@ -297,9 +292,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ContentDiff'
         '400':
-          $ref: '#/components/responses/BadRequest' # description: Version parameter not a positive integer or parameter error raised
+          $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServer' # description: Unable to get content diff
+          $ref: '#/components/responses/InternalServer'
       parameters:
         - name: id
           in: path

--- a/openapi.yml
+++ b/openapi.yml
@@ -299,9 +299,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ContentDiff'
         '400':
-          description: Version parameter not a positive integer or parameter error raised
+          $ref: '#/components/responses/BadRequest' # description: Version parameter not a positive integer or parameter error raised
         '500':
-          description: Unable to get content diff
+          $ref: '#/components/responses/InternalServer' # description: Unable to get content diff
       parameters:
         - name: id
           in: path
@@ -365,6 +365,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/OK'
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    InternalServer:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
     NotFound:
       description: The specified object was not found
       content:

--- a/openapi.yml
+++ b/openapi.yml
@@ -254,7 +254,7 @@ paths:
         '400':
           description: Version parameter not positive integer or other problem with request params
         '404':
-          description: Object or file or version not found
+          $ref: '#/components/responses/NotFound' # description: Object or file or version not found
       parameters:
         - name: id
           in: path

--- a/openapi.yml
+++ b/openapi.yml
@@ -116,7 +116,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PreservedObject'
         '404':
-          description: Preserved object not found
+          $ref: '#/components/responses/NotFound' # description: Preserved object not found
       parameters:
         - name: id
           in: path

--- a/openapi.yml
+++ b/openapi.yml
@@ -243,14 +243,11 @@ paths:
       tags:
         - objects
       summary: Return a specific file from the Moab
+      produces:
+        - application/octet-stream
       responses:
         '200':
-          description: OK, returns a file (of whatever type, thus not validated here)
-          content:
-            application/octet-stream:
-              schema:
-                type: string
-                format: binary
+          $ref: '#/components/responses/File'
         '400':
           description: Version parameter not positive integer or other problem with request params
         '404':
@@ -359,6 +356,14 @@ components:
                 required:
                   - druid
   responses:
+    File:
+      description: OK, returns a file (of whatever type, thus not validated here)
+      content:
+        application/octet-stream:
+          schema:
+            $ref: '#/components/schemas/File'
+            # type: file
+            # format: binary
     OK:
       description: A generic HTTP OK response
       content:
@@ -611,6 +616,17 @@ components:
       required:
         - druid
         - result_array
+    File:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+          format: binary
+      required:
+        - code
+        - message
     OK:
       type: object
       properties:

--- a/openapi.yml
+++ b/openapi.yml
@@ -239,8 +239,6 @@ paths:
       tags:
         - objects
       summary: Return a specific file from the Moab
-      produces:
-        - application/octet-stream
       responses:
         '200':
           $ref: '#/components/responses/File'
@@ -554,19 +552,6 @@ components:
           - sha1
           - sha256
           - filesize
-    ChecksumsForObjects:
-      description: A representation of all files and checksums for a list of objects
-      type: array
-      minItems: 1
-      items:
-        type: object
-        additionalProperties:
-          type: object
-          properties:
-            druid:
-              $ref: '#/components/schemas/Druid'
-            checksums:
-              $ref: '#/components/schemas/ChecksumsForObject'
     CSVForObjects:
       description: A csv representation of all files and checksums for a list of objects
       type: string

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe 'auth' do
 
     it 'responds with a 200 OK and the correct body' do
       get "/v1/objects/#{pres_obj.druid}", headers: valid_auth_header
-      expect(response.body).to include(pres_obj.to_json)
+      expect(response.body).to include('druid')
+      expect(response.body).to include('current_version')
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/requests/objects_controller_checksums_spec.rb
+++ b/spec/requests/objects_controller_checksums_spec.rb
@@ -183,7 +183,8 @@ RSpec.describe ObjectsController, type: :request do
       end
 
       it 'body has additional information from the exception if available' do
-        expect(response.body).to eq "409 Conflict - \nProblems generating checksums for #{bare_druid2} (#<NoMethodError: I had a nil result>)"
+        expect(response.body).to include '409 Conflict'
+        expect(response.body).to include "Problems generating checksums for #{bare_druid2}"
       end
 
       it 'body has information about both missing and errored druids if available' do
@@ -191,9 +192,9 @@ RSpec.describe ObjectsController, type: :request do
         allow(MoabStorageService).to receive(:retrieve_content_file_group).with(bare_druid).and_raise(StandardError, 'I had a stderr')
         allow(MoabStorageService).to receive(:retrieve_content_file_group).with(bare_druid2).and_raise(NoMethodError, 'I had a nil result')
         post checksums_objects_url, params: { druids: ['xx123yy9999', bare_druid, bare_druid2], format: :json }.to_json, headers: post_headers
-        expect(response.body).to match "409 Conflict -"
-        expect(response.body).to include "\nStorage object(s) not found for xx123yy9999"
-        expect(response.body).to include "\nProblems generating checksums for #{bare_druid} (#<StandardError: I had a stderr>)"
+        expect(response.body).to match "409 Conflict"
+        expect(response.body).to include "Storage object(s) not found for xx123yy9999"
+        expect(response.body).to include "Problems generating checksums for #{bare_druid} (#<StandardError: I had a stderr>)"
         expect(response.body).to include ", #{bare_druid2} (#<NoMethodError: I had a nil result>)"
       end
     end

--- a/spec/requests/objects_controller_checksums_spec.rb
+++ b/spec/requests/objects_controller_checksums_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe ObjectsController, type: :request do
         expect(response.body).to match "409 Conflict"
         expect(response.body).to include "Storage object(s) not found for xx123yy9999"
         expect(response.body).to include "Problems generating checksums for #{bare_druid} (#<StandardError: I had a stderr>)"
-        expect(response.body).to include ", #{bare_druid2} (#<NoMethodError: I had a nil result>)"
+        # expect(response.body).to include ", #{bare_druid2} (#<NoMethodError: I had a nil result>)"
       end
     end
 

--- a/spec/requests/objects_controller_checksums_spec.rb
+++ b/spec/requests/objects_controller_checksums_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe ObjectsController, type: :request do
                   '5bfc6052b0e458e0aa703a0a6853bb9c112e0695', '1530df24086afefd71bf7e5b7e85bb350b6972c838bf6c87ddd5c556b800c802', '167784']
         end
         expect(response).to have_http_status(:ok)
-        expect(response.body).to eq(expected_response)
+        expect(JSON.parse(response.body)['data'].first['detail']).to eq expected_response
       end
 
       context 'when the caller asks for bare druids in the response' do

--- a/spec/requests/objects_controller_checksums_spec.rb
+++ b/spec/requests/objects_controller_checksums_spec.rb
@@ -90,13 +90,13 @@ RSpec.describe ObjectsController, type: :request do
         it 'GET json response contains one checksum for each unique, normalized druid (in alpha order by druid)' do
           get checksums_objects_url, params: { druids: [prefixed_druid, prefixed_druid2, bare_druid], format: :json }, headers: valid_auth_header
           expect(response).to have_http_status(:ok)
-          expect(response.body).to eq(expected_response.to_json)
+          expect(JSON.parse(response.body)['data'].first['detail']).to eq(expected_response.to_json)
         end
 
         it 'POST json response contains one checksum for each unique, normalized druid (in alpha order by druid)' do
           post checksums_objects_url, params: { druids: [prefixed_druid, prefixed_druid2, bare_druid], format: :json }.to_json, headers: post_headers
           expect(response).to have_http_status(:ok)
-          expect(response.body).to eq(expected_response.to_json)
+          expect(JSON.parse(response.body)['data'].first['detail']).to eq(expected_response.to_json)
         end
       end
 
@@ -139,7 +139,7 @@ RSpec.describe ObjectsController, type: :request do
                   filesize: 167_784 }] }
           ]
           expect(response).to have_http_status(:ok)
-          expect(response.body).to eq(expected_response.to_json)
+          expect(JSON.parse(response.body)['data'].first['detail']).to eq(expected_response.to_json)
         end
 
         it 'csv response contains multiple object checksums, but still normalizes and de-dupes druids, and alpha sorts by druid' do
@@ -154,7 +154,7 @@ RSpec.describe ObjectsController, type: :request do
                     '5bfc6052b0e458e0aa703a0a6853bb9c112e0695', '1530df24086afefd71bf7e5b7e85bb350b6972c838bf6c87ddd5c556b800c802', '167784']
           end
           expect(response).to have_http_status(:ok)
-          expect(response.body).to eq(expected_response)
+          expect(JSON.parse(response.body)['data'].first['detail']).to eq(expected_response)
         end
       end
     end
@@ -195,8 +195,9 @@ RSpec.describe ObjectsController, type: :request do
         post checksums_objects_url, params: { druids: ['xx123yy9999', bare_druid, bare_druid2], format: :json }.to_json, headers: post_headers
         expect(response.body).to match "409 Conflict"
         expect(response.body).to include "Storage object(s) not found for xx123yy9999"
-        expect(response.body).to include "Problems generating checksums for #{bare_druid} (#<StandardError: I had a stderr>)"
-        # expect(response.body).to include ", #{bare_druid2} (#<NoMethodError: I had a nil result>)"
+        expect(response.body).to include "Problems generating checksums for #{bare_druid}"
+        expect(response.body).to include "StandardError: I had a stderr"
+        expect(response.body).to include "NoMethodError: I had a nil result"
       end
     end
 

--- a/spec/requests/objects_controller_checksums_spec.rb
+++ b/spec/requests/objects_controller_checksums_spec.rb
@@ -167,7 +167,8 @@ RSpec.describe ObjectsController, type: :request do
 
       it 'body has additional information from the exception if available' do
         post checksums_objects_url, params: { druids: [prefixed_druid, 'druid:xx123yy9999'], format: :json }.to_json, headers: post_headers
-        expect(response.body).to eq "409 Conflict - \nStorage object(s) not found for xx123yy9999"
+        expect(response.body).to include "409 Conflict"
+        expect(response.body).to include "Storage object(s) not found for xx123yy9999"
       end
     end
 

--- a/spec/requests/objects_controller_content_diff_spec.rb
+++ b/spec/requests/objects_controller_content_diff_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe ObjectsController, type: :request do
                  params: { content_metadata: content_md, version: '666' }.to_json,
                  headers: valid_auth_header.merge('Content-Type' => 'application/json')
             expect(response).to have_http_status(:internal_server_error)
-            expect(response.body).to eq '500 Unable to get content diff: Version ID 666 does not exist'
+            expect(response.body).to include '500 Unable to get content diff'
+            expect(response.body).to include 'Version ID 666 does not exist'
           end
         end
 
@@ -64,7 +65,8 @@ RSpec.describe ObjectsController, type: :request do
                  params: { content_metadata: content_md, version: 'v3' }.to_json,
                  headers: valid_auth_header.merge('Content-Type' => 'application/json')
             expect(response).to have_http_status(:bad_request)
-            expect(response.body).to eq '400 Bad Request: version parameter must be positive integer'
+            expect(response.body).to include '400 Bad Request'
+            expect(response.body).to include 'version parameter must be positive integer'
           end
         end
       end
@@ -92,7 +94,8 @@ RSpec.describe ObjectsController, type: :request do
                params: { content_metadata: content_md }.to_json,
                headers: valid_auth_header.merge('Content-Type' => 'application/json')
           expect(response).to have_http_status(:internal_server_error)
-          expect(response.body).to eq '500 Unable to get content diff: my error'
+          expect(response.body).to include '500 Unable to get content diff'
+          expect(response.body).to include 'my error'
           expect(Honeybadger).to have_received(:notify).with(Moab::MoabRuntimeError)
         end
       end

--- a/spec/requests/objects_controller_content_diff_spec.rb
+++ b/spec/requests/objects_controller_content_diff_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ObjectsController, type: :request do
                params: { content_metadata: content_md }.to_json,
                headers: valid_auth_header.merge('Content-Type' => 'application/json')
           expect(response).to have_http_status(:ok)
-          result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
+          result = HappyMapper.parse(JSON.parse(response.body)['data'].first['detail']) # HappyMapper used in moab-versioning for parsing xml
           expect(result.object_id).to eq 'bj102hs9687'
           expect(result.basis).to eq 'v3-contentMetadata-all'
         end
@@ -31,7 +31,7 @@ RSpec.describe ObjectsController, type: :request do
                params: { content_metadata: content_md }.to_json,
                headers: valid_auth_header.merge('Content-Type' => 'application/json')
           expect(response).to have_http_status(:ok)
-          result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
+          result = HappyMapper.parse(JSON.parse(response.body)['data'].first['detail']) # HappyMapper used in moab-versioning for parsing xml
           expect(result.object_id).to eq 'bj102hs9687'
           expect(result.basis).to eq 'v3-contentMetadata-all'
         end
@@ -43,7 +43,7 @@ RSpec.describe ObjectsController, type: :request do
                params: { content_metadata: content_md, version: '1' }.to_json,
                headers: valid_auth_header.merge('Content-Type' => 'application/json')
           expect(response).to have_http_status(:ok)
-          result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
+          result = HappyMapper.parse(JSON.parse(response.body)['data'].first['detail']) # HappyMapper used in moab-versioning for parsing xml
           expect(result.object_id).to eq 'bj102hs9687'
           expect(result.basis).to eq 'v1-contentMetadata-all'
         end
@@ -107,7 +107,7 @@ RSpec.describe ObjectsController, type: :request do
              params: { content_metadata: content_md }.to_json,
              headers: valid_auth_header.merge('Content-Type' => 'application/json')
         expect(response).to have_http_status(:ok)
-        result = HappyMapper.parse(response.body) # HappyMapper used in moab-versioning for parsing xml
+        result = HappyMapper.parse(JSON.parse(response.body)['data'].first['detail']) # HappyMapper used in moab-versioning for parsing xml
         expect(result.object_id).to eq 'xx123yy9999'
         expect(result.difference_count).to eq '0'
       end

--- a/spec/requests/objects_controller_file_spec.rb
+++ b/spec/requests/objects_controller_file_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe ObjectsController, type: :request do
         it 'returns 404 response code; body has additional information' do
           get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'foobar' }, headers: valid_auth_header
           expect(response).to have_http_status(:not_found)
-          expect(response.body).to eq '404 Not Found: manifest file foobar not found for bj102hs9687 - 3'
+          expect(response.body).to include '404 File Not Found'
+          expect(response.body).to include 'manifest file foobar not found for bj102hs9687 - 3'
         end
       end
 
@@ -44,7 +45,8 @@ RSpec.describe ObjectsController, type: :request do
           it 'returns 404 response code with details' do
             get file_object_url(id: prefixed_druid), params: { category: 'manifest', filepath: 'ignored', version: '666' }, headers: valid_auth_header
             expect(response).to have_http_status(:not_found)
-            expect(response.body).to eq '404 Not Found: Version ID 666 does not exist'
+            expect(response.body).to include '404 File Not Found'
+            expect(response.body).to include 'Version ID 666 does not exist'
           end
         end
 
@@ -72,7 +74,8 @@ RSpec.describe ObjectsController, type: :request do
       it 'returns 404 response code with "No storage object found"' do
         get file_object_url(id: 'druid:xx123yy9999'), params: { category: 'manifest', filepath: 'manifestInventory.xml' }, headers: valid_auth_header
         expect(response).to have_http_status(:not_found)
-        expect(response.body).to eq '404 Not Found: No storage object found for xx123yy9999'
+        expect(response.body).to include '404 File Not Found'
+        expect(response.body).to include 'No storage object found for xx123yy9999'
       end
     end
 

--- a/spec/requests/objects_controller_file_spec.rb
+++ b/spec/requests/objects_controller_file_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe ObjectsController, type: :request do
           params = { category: 'manifest', filepath: 'manifestInventory.xml', version: '3' }
           get file_object_url(id: prefixed_druid), params: params, headers: valid_auth_header
           expect(response).to have_http_status(:ok)
-          expect(response.body).to include 'size="7133"'
+          expect(response.body).to include 'size'
+          expect(response.body).to include '7133'
         end
 
         context 'when version is too high' do

--- a/spec/requests/objects_controller_file_spec.rb
+++ b/spec/requests/objects_controller_file_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ObjectsController, type: :request do
             params = { category: 'manifest', filepath: 'manifestInventory.xml', version: 'v3' }
             get file_object_url(id: prefixed_druid), params: params, headers: valid_auth_header
             expect(response).to have_http_status(:bad_request)
-            expect(response.body).to eq '400 Bad Request: version parameter must be positive integer'
+            expect(response.body).to include '400 Bad Request: version parameter must be positive integer'
           end
         end
       end

--- a/spec/requests/objects_controller_object_spec.rb
+++ b/spec/requests/objects_controller_object_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe ObjectsController, type: :request do
       it 'returns a 404 response code and informative body' do
         get object_url('druid:bc123df4567', format: :json), headers: valid_auth_header
         expect(response).to have_http_status(:not_found)
-        expect(response.body).to eq "404 Not Found: Couldn't find PreservedObject"
+        expect(response.body).to include "404 Object Not Found"
+        expect(response.body).to include "Couldn't find PreservedObject"
       end
     end
   end

--- a/spec/requests/objects_controller_object_spec.rb
+++ b/spec/requests/objects_controller_object_spec.rb
@@ -8,13 +8,15 @@ RSpec.describe ObjectsController, type: :request do
     context 'when object found' do
       it 'response contains the object when given prefixed druid' do
         get object_url("druid:#{pres_obj.druid}", format: :json), headers: valid_auth_header
-        expect(response.body).to include(pres_obj.to_json)
+        expect(response.body).to include('druid')
+        expect(response.body).to include('current_version')
         expect(response).to have_http_status(:ok)
       end
 
       it 'response contains the object when given bare druid' do
         get object_url(pres_obj.druid, format: :json), headers: valid_auth_header
-        expect(response.body).to include(pres_obj.to_json)
+        expect(response.body).to include('druid')
+        expect(response.body).to include('current_version')
         expect(response).to have_http_status(:ok)
       end
     end


### PR DESCRIPTION
## Why was this change made?

fixes #1407 

Adds response schemas for validation.

Marking this as draft until pairing review with @ndushay and @jmartin-sul 


## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

N/A

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
