### PR TITLE
remove reference to disabling accessioning workers for storage migrations

### DIFF
--- a/.github/ISSUE_TEMPLATE/storage-migration-checklist.md
+++ b/.github/ISSUE_TEMPLATE/storage-migration-checklist.md
@@ -94,12 +94,6 @@ Run all validation checks on Moabs and generate reports.  Note that error detail
     ```
   - [ ] ensure there are no running preservation robots workers in the resque GUI:  https://robot-console-prod.stanford.edu/workers
 
-- [ ] (Ops) turn off nagios alerts for accessioning workers
-
-- **Shut Down Accessioning Robots Worker**
-  - [ ] @suntzu or some other not-naomi person should document how to do this.
-  - [ ] affected:  versioning of objects, creating contentMetadata, creating technicalMetadata, ...
-
 - [ ] (Ops) turn off nagios alerts for preservation_catalog prod boxes
 
 - **Shut Down Preservation Catalog Archival Workers, ReST API and weekend crons**


### PR DESCRIPTION
## Why was this change made?

turns out we don't think we need to do that, see https://github.com/sul-dlss/preservation_catalog/issues/1439#issuecomment-600759173

just to be extra safe, i'd appreciate it if someone familiar with how the robots pick up work would review what i found in this comment before merging this, to make sure my understanding is correct:  https://github.com/sul-dlss/preservation_catalog/issues/1439#issuecomment-603078033

connects to #1439

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

documentation only

## Does this change affect how this application integrates with other services?
~~If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.~~

n/a