### PR TITLE
re-enable read-only routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,18 +7,18 @@ Rails.application.routes.draw do
         at: '/resque',
         constraints: ->(req) { Settings.resque_dashboard_hostnames.include?(req.host) }
 
-  # scope 'v1' do
-  #   resources :catalog, param: :druid, only: %i[create update]
-  #
-  #   resources :objects, only: %i[show] do
-  #     member do
-  #       get 'checksum'
-  #       get 'file', format: false # no need to add extension to url
-  #       post 'content_diff'
-  #     end
-  #     collection do
-  #       match 'checksums', via: %i[get post]
-  #     end
-  #   end
-  # end
+  scope 'v1' do
+    # resources :catalog, param: :druid, only: %i[create update]
+
+    resources :objects, only: %i[show] do
+      member do
+        get 'checksum'
+        get 'file', format: false # no need to add extension to url
+        post 'content_diff'
+      end
+      collection do
+        match 'checksums', via: %i[get post]
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

per https://github.com/sul-dlss/preservation_catalog/issues/1439#issuecomment-600759173 we won't shut down accessioning robots for migration, which means that we'll need to enable the routes that allow accessioning robots to talk to pres cat for their read-only requests.

we'll leave disabled the create and update endpoints, but only the preservation robots should use those (and the preservation robots will still be disabled).

connects to #1439

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

yes, see #1452

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

we didn't shut down the accessioning robots in the [run through on stage](#1420) (the instructions removed here were added after that).  and we plan to test this again in a dry run the week of april 3.  so this has been tested and should get tested again soon.