### PR TITLE
Rack upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'postgresql_cursor' # for paging over large result sets efficiently
 gem 'pry-byebug' # call 'binding.pry' anywhere in the code to stop execution and get a pry-byebug console
 gem 'pry-rails' # use pry as the rails console shell instead of IRB
 gem 'puma', '~> 3.12' # app server
-gem 'rack', '~> 2.0.8' # pending https://github.com/sportngin/okcomputer/pull/161
 gem 'rails', '~> 6.0.2'
 gem 'resque', '~> 1.27'
 gem 'resque-lock' # deduplication of worker queue jobs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,7 +286,7 @@ GEM
     psych (3.1.0)
     public_suffix (4.0.3)
     puma (3.12.4)
-    rack (2.0.9)
+    rack (2.2.2)
     rack-protection (2.0.8.1)
       rack
     rack-test (1.1.0)
@@ -438,7 +438,6 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 3.12)
-  rack (~> 2.0.8)
   rails (~> 6.0.2)
   rails-controller-testing
   resque (~> 1.27)


### PR DESCRIPTION
## Why was this change made?

We no longer need to pin the rack gem as the okcomputer fix was merged in and released with okcomputer 1.18.1 (already in use here)

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

na

## Does this change affect how this application integrates with other services?

na