### PR TITLE
ChecksumValidator#validate_checksums should check existence of moab dir first

### DIFF
--- a/app/services/moab_validation_handler.rb
+++ b/app/services/moab_validation_handler.rb
@@ -64,6 +64,13 @@ module MoabValidationHandler
     complete_moab.status_details = results.results_as_string(results.result_array)
   end
 
+  def mark_moab_not_found
+    results.add_result(AuditResults::MOAB_NOT_FOUND,
+                       db_created_at: complete_moab.created_at.iso8601,
+                       db_updated_at: complete_moab.updated_at.iso8601)
+    update_status('online_moab_not_found')
+  end
+
   # found_expected_version is a boolean indicating whether the latest version of the moab
   # on disk is the expected version according to the catalog.  NOTE: in the case of an update
   # this might mean the on disk version is one higher than the catalog version, if the
@@ -74,10 +81,7 @@ module MoabValidationHandler
     begin
       return update_status('invalid_moab') if moab_validation_errors.any?
     rescue Errno::ENOENT
-      results.add_result(AuditResults::MOAB_NOT_FOUND,
-                         db_created_at: complete_moab.created_at.iso8601,
-                         db_updated_at: complete_moab.updated_at.iso8601)
-      return update_status('online_moab_not_found')
+      return mark_moab_not_found
     end
 
     return update_status('unexpected_version_on_storage') unless found_expected_version

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe ChecksumValidator do
     context 'moab is missing from storage' do
       before do
         # fake a moab gone missing by updating the preserved object to use a non-existent druid
-        comp_moab.preserved_object.update(druid: 'tr808sl1200')
+        comp_moab.preserved_object.update(druid: 'tr808sp1200')
       end
 
       it 'sets status to online_moab_not_found and adds corresponding audit result' do

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -207,6 +207,24 @@ RSpec.describe ChecksumValidator do
   end
 
   describe '#validate_checksums' do
+    context 'moab is missing from storage' do
+      before do
+        # fake a moab gone missing by updating the preserved object to use a non-existent druid
+        comp_moab.preserved_object.update(druid: 'tr808sl1200')
+      end
+
+      it 'sets status to online_moab_not_found and adds corresponding audit result' do
+        expect { cv.validate_checksums }.to change(comp_moab, :status).to 'online_moab_not_found'
+        expect(comp_moab.reload.status).to eq 'online_moab_not_found'
+        expect(cv.results.result_array.first).to have_key(:moab_not_found)
+      end
+
+      it 'calls AuditResults.report_results' do
+        expect(cv.results).to receive(:report_results)
+        cv.validate_checksums
+      end
+    end
+
     context 'passes checksum validation' do
       let(:druid) { 'bz514sm9647' }
       let(:root_name) { 'fixture_sr1' }


### PR DESCRIPTION
## Why was this change made?

to make handling of wholly missing moab directories more robust when CV encounters druids like that (so we get an appropriate `status` change on the `CompleteMoab` instead of just a honeybadger error).

when first making the test changes (without the app changes in this PR), i was able to reproduce the backtrace seen in #1480.

when testing this app code change on pres cat's migrate instance, the `ChecksumValidator#validate_checksums` method now correctly updates `CompleteMoab#status` to `online_moab_not_found` if the combo of `druid` (via related `PreservedObject`) and `storage_location` (via related `MoabStorageRoot`) points to a moab directory that doesn't exist on the file system.  previously, this scenario would result in the uncaught error noted in #1480.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

n/a

connects with #1480