### PR TITLE
Test ruby 2.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 jobs:
   test:
     docker:
-    - image: circleci/ruby:2.5.3-node
+    - image: circleci/ruby:2.7.1
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 jobs:
   test:
     docker:
-    - image: circleci/ruby:2.7.1
+    - image: circleci/ruby:2.7.1-node
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3-alpine
+FROM ruby:2.7.1-alpine
 
 # postgresql-client is required for invoke.sh
 RUN apk --no-cache add \

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,5 @@
 source 'https://rubygems.org'
 
-git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-  "https://github.com/#{repo_name}.git"
-end
-
 # general Ruby/Rails gems
 gem 'aws-sdk-s3', '~> 1.17'
 gem 'committee' # Validates HTTP requests/responses per OpenAPI specification
@@ -47,7 +42,7 @@ group :test do
   gem "factory_bot_rails", "~> 4.0"
   gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 3.6'
-  gem 'shoulda-matchers', git: 'https://github.com/thoughtbot/shoulda-matchers.git', branch: 'rails-5'
+  gem 'shoulda-matchers'
   # Codeclimate is not compatible with 0.18+. See https://github.com/codeclimate/test-reporter/issues/413
   gem 'simplecov', '~> 0.17.1'
   gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'rails', '~> 6.0.2'
 gem 'resque', '~> 1.27'
 gem 'resque-lock' # deduplication of worker queue jobs
 gem 'resque-pool'
-# gem 'ruby-prof' # to profile methods
 gem 'whenever' # manage cron for audit checks
 
 # Stanford gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/thoughtbot/shoulda-matchers.git
-  revision: 4b160bd19ecca7f97d7ac22dccd5fde9b0da5a9f
-  branch: rails-5
-  specs:
-    shoulda-matchers (3.1.2)
-      activesupport (>= 4.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -371,6 +363,8 @@ GEM
     ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
+    shoulda-matchers (4.3.0)
+      activesupport (>= 4.2.0)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -445,7 +439,7 @@ DEPENDENCIES
   rspec-rails (~> 3.6)
   rubocop (~> 0.73.0)
   rubocop-rspec
-  shoulda-matchers!
+  shoulda-matchers
   simplecov (~> 0.17.1)
   webmock
   whenever

--- a/app/lib/audit.rb
+++ b/app/lib/audit.rb
@@ -2,7 +2,6 @@
 
 require 'active_record_utils'
 require 'druid-tools'
-require 'profiler'
 require 'csv'
 
 require_relative 'audit/catalog_to_moab'

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CompleteMoab, type: :model do
   end
 
   it 'defines a status enum with the expected values' do
-    is_expected.to define_enum_for(:status).with(
+    is_expected.to define_enum_for(:status).with_values(
       'ok' => 0,
       'invalid_moab' => 1,
       'invalid_checksum' => 2,

--- a/spec/models/zip_part_spec.rb
+++ b/spec/models/zip_part_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ZipPart, type: :model do
   let(:args) { attributes_for(:zip_part).merge(zipped_moab_version: zmv) }
 
   it 'defines a status enum with the expected values' do
-    is_expected.to define_enum_for(:status).with(
+    is_expected.to define_enum_for(:status).with_values(
       'ok' => 0,
       'unreplicated' => 1,
       'not_found' => 2,


### PR DESCRIPTION
## Why was this change made?

update CI to test on current latest ruby (and make some other changes to address deprecation warnings and to clean up other cruft).

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

N/A

## Does this change affect how this application integrates with other services?
~~If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.~~

N/A