### PR TITLE
set moab-valid step to completed when a moab is determined to be ok

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -161,6 +161,7 @@ class AuditResults
         msg = "#{string_prefix} || #{r.values.first}"
         WorkflowReporter.report_error(druid, actual_version, 'moab-valid', moab_storage_root, msg)
       elsif status_changed_to_ok?(r)
+        WorkflowReporter.report_completed(druid, actual_version, 'moab-valid', moab_storage_root)
         WorkflowReporter.report_completed(druid, actual_version, 'preservation-audit', moab_storage_root)
       elsif WORKFLOW_REPORT_CODES.include?(r.keys.first)
         workflow_results << r

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -267,6 +267,7 @@ RSpec.describe AuditResults do
         result_code = AuditResults::CM_STATUS_CHANGED
         addl_hash = { old_status: 'invalid_checksum', new_status: 'ok' }
         audit_results.add_result(result_code, addl_hash)
+        expect(WorkflowReporter).to receive(:report_completed).with(druid, actual_version, 'moab-valid', ms_root)
         expect(WorkflowReporter).to receive(:report_completed).with(druid, actual_version, 'preservation-audit', ms_root)
         audit_results.report_results
       end

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -550,7 +550,7 @@ RSpec.describe ChecksumValidator do
 
     it 'has status that does not change and does not complete workflow' do
       comp_moab.ok!
-      expect(WorkflowReporter).not_to receive(:report_completed).with(druid, nil, 'preservation-audit', ms_root)
+      expect(WorkflowReporter).not_to receive(:report_completed)
       cv.validate_checksums
     end
 
@@ -562,7 +562,7 @@ RSpec.describe ChecksumValidator do
 
       it "does not complete workflow" do
         comp_moab.ok!
-        expect(WorkflowReporter).not_to receive(:report_completed).with(druid, nil, 'preservation-audit', ms_root)
+        expect(WorkflowReporter).not_to receive(:report_completed)
         cv.validate_checksums
       end
     end
@@ -577,7 +577,7 @@ RSpec.describe ChecksumValidator do
       end
 
       it 'does not complete workflow' do
-        expect(WorkflowReporter).not_to receive(:report_completed).with(druid, nil, 'preservation-audit', ms_root)
+        expect(WorkflowReporter).not_to receive(:report_completed)
         cv.validate_checksums
       end
     end

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -543,6 +543,7 @@ RSpec.describe ChecksumValidator do
 
     it 'has status changed to OK_STATUS and completes workflow' do
       comp_moab.invalid_moab!
+      expect(WorkflowReporter).to receive(:report_completed).with(druid, nil, 'moab-valid', ms_root)
       expect(WorkflowReporter).to receive(:report_completed).with(druid, nil, 'preservation-audit', ms_root)
       cv.validate_checksums
     end


### PR DESCRIPTION
## Why was this change made?

we were never setting the `moab-valid` step in `preservationAuditWF` to `complete`, even when we determined that a moab had gone back to being `ok` (pres cat maps its notion of `ok` to the workflow service's notion of `complete`).  as such, we'd add this workflow step if it didn't previously exist, but it would always be set to `waiting` unless it was remediated manually (usually by @andrewjbtw), which was erroneously preventing further versioning work on such objects.  this was recently exacerbated by the preservation storage migration, since we queued up all of the recently moved objects for audit, adding this workflow step anew to many of our repository objects.

i ran this fix by @ndushay, and she agreed that it is sensible to set `moab-valid` to `complete` whenever we set the `preservation-audit` step to complete, which is (pretty much) all this PR does.  objects that already have an erroneous `waiting` status for `moab-valid` will need to be remediated manually, which @andrewjbtw has graciously offered to do.

i paired w/ @jermnelson on this, since he's first responder this week.  he pointed out the overly specific `expect` `not_to` `receive` tests that are fixed in the second commit (which @ndushay also agreed were a reasonable change).

once this is merged, we'll deploy it to prod, and if things work as expected, the number of `moab-valid` steps that are in `waiting` should stop growing.  we hope.

connects to #1488 (hesitant to say this fixes it till we see it in prod)


## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

N/A


## Does this change affect how this application integrates with other services?
> If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

i think this is very unlikely to make things worse or to break things, but it does affect how pres cat integrates with workflow service, so i'm happy to test in stage if reviewers would prefer that.