### PR TITLE
send current moab version in CV audit results, test adjustment/cleanup

### DIFF
--- a/app/services/checksum_validator.rb
+++ b/app/services/checksum_validator.rb
@@ -20,7 +20,7 @@ class ChecksumValidator
   def initialize(complete_moab)
     @complete_moab = complete_moab
     @bare_druid = complete_moab.preserved_object.druid
-    @results = AuditResults.new(bare_druid, nil, moab_storage_root, 'validate_checksums')
+    @results = AuditResults.new(bare_druid, moab.current_version_id, moab_storage_root, 'validate_checksums')
   end
 
   def validate_checksums

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -26,15 +26,17 @@ RSpec.describe ChecksumValidator do
       expect(cv.bare_druid).to eq druid
       expect(cv.moab_storage_root).to eq ms_root
       expect(cv.results).to be_an_instance_of AuditResults
+      expect(cv.results.actual_version).to eq 3
+    end
+
+    it 'instantiates a Moab::StorageObject from druid and druid_path' do
+      expect(cv.moab).to be_an_instance_of Moab::StorageObject
+      expect(cv.moab.digital_object_id).to eq druid
+      expect(cv.moab.object_pathname.to_s).to eq object_dir
     end
   end
 
   describe '#validate_manifest_inventories' do
-    it 'instantiates a Moab::StorageObject from druid and druid_path' do
-      expect(Moab::StorageObject).to receive(:new).with(cv.bare_druid, a_string_matching(object_dir)).and_call_original
-      cv.validate_manifest_inventories
-    end
-
     it 'calls validate_manifest_inventory for each moab_version' do
       sov1 = instance_double(Moab::StorageObjectVersion)
       sov2 = instance_double(Moab::StorageObjectVersion)
@@ -128,11 +130,6 @@ RSpec.describe ChecksumValidator do
     let(:druid) { 'bj102hs9687' }
     let(:root_name) { 'fixture_sr1' }
     let(:results) { instance_double(AuditResults, report_results: nil, :check_name= => nil) }
-
-    it 'instantiates storage_object from druid and druid_path' do
-      expect(Moab::StorageObject).to receive(:new).with(cv.bare_druid, a_string_matching(object_dir)).and_call_original
-      cv.send(:validate_signature_catalog_listing)
-    end
 
     it 'calls validate_signature_catalog_entry for each signatureCatalog entry' do
       sce01 = instance_double(Moab::SignatureCatalogEntry)
@@ -543,8 +540,8 @@ RSpec.describe ChecksumValidator do
 
     it 'has status changed to OK_STATUS and completes workflow' do
       comp_moab.invalid_moab!
-      expect(WorkflowReporter).to receive(:report_completed).with(druid, nil, 'moab-valid', ms_root)
-      expect(WorkflowReporter).to receive(:report_completed).with(druid, nil, 'preservation-audit', ms_root)
+      expect(WorkflowReporter).to receive(:report_completed).with(druid, 3, 'moab-valid', ms_root)
+      expect(WorkflowReporter).to receive(:report_completed).with(druid, 3, 'preservation-audit', ms_root)
       cv.validate_checksums
     end
 


### PR DESCRIPTION
also

* fix one test to expect moab version to get passed to workflow reporter (for passing along if/when creating workflow, which is the point of this fix)
* take two other tests broken by app code change, consolidate into one test that's more behavior focused and less focused on underlying implementation

## Why was this change made?

connects to #1515 (and hopefully resolves the vast majority of occurrences of that issue)

note there are still some situations where audit won't send a version along
* C2M detects that the `PreservedObject` and `CompleteMoab` record different versions
* no moab is found on disk
* any time `PartReplicationAudit` detects an error that it reports to workflows, though this is rare, and `PartReplicationAudit` doesn't currently concern itself with the on premises moab, so i am hesitant to figure out logic for that now, since we hope to further disentangle from workflows for pres cat reporting anyway.

but i think this should be an improvement over what we have on master now, and should resolve the acute issue of eating up our honeybadger quota with all the workflow server deprecation warnings.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

N/A

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

not really... it does send `version` to workflows for a call where we weren't previously sending it, but that's a thing we already did in other audits, and this usage feels very similar and safe.  that said, happy to test in stage anyway, and/or happy to try a small handful of CV audits on prod before re-queuing the entire remainder.