### PR TITLE
Prefer `chdir:` arg to Open3 method over `Dir.chdir`

### DIFF
--- a/app/models/druid_version_zip.rb
+++ b/app/models/druid_version_zip.rb
@@ -29,10 +29,9 @@ class DruidVersionZip
   # not 'ab/123/cd/4567/ab123cd4567/...'
   def create_zip!
     ensure_zip_directory!
-    Dir.chdir(work_dir.to_s) do
-      combined, status = Open3.capture2e(zip_command)
-      raise "zipmaker failure #{combined}" unless status.success?
-    end
+    combined, status = Open3.capture2e(zip_command, chdir: work_dir.to_s)
+    raise "zipmaker failure #{combined}" unless status.success?
+
     part_keys.each do |part_key|
       DruidVersionZipPart.new(self, part_key).write_md5
     end


### PR DESCRIPTION
Fixes #1519

I briefly looked into testing this change but I don't think we get much value out of essentially testing a dependency. I suspect the test suite as currently written suffices as this is a refactoring.

## Why was this change made?

Why? Because `Dir.chdir` is not thread-safe, and that will be a problem when we switch to using Sidekiq for background jobs.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

No.

## Does this change affect how this application integrates with other services?

No.