### PR TITLE
Unique constraint on Preservation Object id and Moab Storage Root Id

### DIFF
--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -27,6 +27,7 @@ class CompleteMoab < ApplicationRecord
   delegate :s3_key, to: :druid_version_zip
 
   validates :moab_storage_root, :preserved_object, :status, :version, presence: true
+  validates_uniqueness_of :preserved_object_id, scope: [:moab_storage_root_id]
   # NOTE: size here is approximate and not used for fixity checking
   validates :size, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
 

--- a/db/migrate/20200507153050_add_index_unique_constraint_druid_moab_storage_root_to_complete_moab.rb
+++ b/db/migrate/20200507153050_add_index_unique_constraint_druid_moab_storage_root_to_complete_moab.rb
@@ -1,0 +1,5 @@
+class AddIndexUniqueConstraintDruidMoabStorageRootToCompleteMoab < ActiveRecord::Migration[6.0]
+  def change
+    add_index :complete_moabs, [:preserved_object_id, :moab_storage_root_id], :unique => true, :name => 'index_complete_moab_on_po_and_storage_root_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_04_194352) do
+ActiveRecord::Schema.define(version: 2020_05_07_153050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2020_05_04_194352) do
     t.index ["last_version_audit"], name: "index_complete_moabs_on_last_version_audit"
     t.index ["moab_storage_root_id"], name: "index_complete_moabs_on_moab_storage_root_id"
     t.index ["preserved_object_id", "moab_storage_root_id", "version"], name: "index_preserved_copies_on_po_and_storage_root_and_version", unique: true
+    t.index ["preserved_object_id", "moab_storage_root_id"], name: "index_complete_moab_on_po_and_storage_root_id", unique: true
     t.index ["preserved_object_id"], name: "index_complete_moabs_on_preserved_object_id"
     t.index ["status"], name: "index_complete_moabs_on_status"
     t.index ["updated_at"], name: "index_complete_moabs_on_updated_at"


### PR DESCRIPTION
## Why was this change made?
Fixes #1498 


## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?
n/a


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
