### PR TITLE
improve error message for MOAB_FILE_CHECKSUM_MISMATCH

### DIFF
--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -59,7 +59,7 @@ class AuditResults
     INVALID_MOAB => 'Invalid Moab, validation errors: %{addl}',
     MANIFEST_NOT_IN_MOAB => '%{manifest_file_path} not found in Moab',
     MOAB_CHECKSUM_VALID => 'checksum(s) match',
-    MOAB_FILE_CHECKSUM_MISMATCH => 'checksums for %{file_path} version %{version} do not match.',
+    MOAB_FILE_CHECKSUM_MISMATCH => 'checksums or size for %{file_path} version %{version} do not match entry in latest signatureCatalog.xml.',
     MOAB_NOT_FOUND => 'db CompleteMoab (created %{db_created_at}; last updated %{db_updated_at}) exists but Moab not found',
     SIGNATURE_CATALOG_NOT_IN_MOAB => '%{signature_catalog_path} not found in Moab',
     UNABLE_TO_CHECK_STATUS => 'unable to validate when CompleteMoab status is %{current_status}',

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -298,8 +298,9 @@ RSpec.describe AuditResults do
         code = AuditResults::MOAB_FILE_CHECKSUM_MISMATCH
         addl_hash = { file_path: 'path/to/file', version: 1 }
         audit_results.add_result(code, addl_hash)
+        expected_err_msg = 'checksums or size for path/to/file version 1 do not match entry in latest signatureCatalog.xml.'
         expect(Honeybadger).to receive(:notify).with(
-          '(ab123cd4567, fixture_sr1) checksums for path/to/file version 1 do not match.'
+          "(ab123cd4567, fixture_sr1) #{expected_err_msg}"
         )
         expect(events_client).to receive(:create).once.with(
           type: 'preservation_audit_failure',
@@ -309,7 +310,7 @@ RSpec.describe AuditResults do
             storage_root: ms_root.name,
             actual_version: actual_version,
             check_name: nil,
-            error_result: { moab_file_checksum_mismatch: 'checksums for path/to/file version 1 do not match.' }
+            error_result: { moab_file_checksum_mismatch: expected_err_msg }
           }
         )
         audit_results.report_results


### PR DESCRIPTION
## Why was this change made?

While @andrewjbtw worked on #1520, he was confused because he didn't know which signatureCatalog.xml file was being used, and also because the mismatch was about the file size, not a checksum.

## How was this change tested?

test suite

## Which documentation and/or configurations were updated?

n/a

