### PR TITLE
a few small part audit touchups

### DIFF
--- a/app/lib/preservation_catalog/s3_audit.rb
+++ b/app/lib/preservation_catalog/s3_audit.rb
@@ -3,7 +3,7 @@
 module PreservationCatalog
   # Base class for AWS and IBM audit classes
   class S3Audit
-    delegate :bucket_name, to: :s3_provider
+    delegate :bucket, :bucket_name, to: :s3_provider
 
     attr_reader :zmv, :results
 
@@ -45,10 +45,6 @@ module PreservationCatalog
     end
 
     private
-
-    def bucket
-      s3_provider.bucket
-    end
 
     # NOTE: no checksum computation is happening here (neither on our side, nor on cloud provider's).  we're just comparing
     # the checksum we have stored with the checksum we asked the cloud provider to store.  we really don't expect any drift, but

--- a/spec/lib/preservation_catalog/aws_provider_spec.rb
+++ b/spec/lib/preservation_catalog/aws_provider_spec.rb
@@ -59,7 +59,7 @@ describe PreservationCatalog::AwsProvider do
     describe '::Aws::S3::Object#upload_file' do
       subject(:s3_object) { bucket.object("test_key_#{test_key_id}") }
 
-      let(:test_key_id) { ENV.fetch('TRAVIS_JOB_ID', '000') }
+      let(:test_key_id) { ENV.fetch('CIRCLE_SHA1', '000')[0..6] }
       let(:dvz) { DruidVersionZip.new('bj102hs9687', 2) }
       let(:dvz_part) { DruidVersionZipPart.new(dvz, dvz.s3_key('.zip')) }
       let(:digest) { dvz_part.base64digest }

--- a/spec/lib/preservation_catalog/ibm_provider_spec.rb
+++ b/spec/lib/preservation_catalog/ibm_provider_spec.rb
@@ -66,7 +66,7 @@ describe PreservationCatalog::IbmProvider do
     describe '::Aws::S3::Object#upload_file' do
       subject(:s3_object) { bucket.object("test_key_#{test_key_id}") }
 
-      let(:test_key_id) { ENV.fetch('TRAVIS_JOB_ID', '000') }
+      let(:test_key_id) { ENV.fetch('CIRCLE_SHA1', '000')[0..6] }
       let(:dvz) { DruidVersionZip.new('bj102hs9687', 2) }
       let(:dvz_part) { DruidVersionZipPart.new(dvz, dvz.s3_key('.zip')) }
       let(:digest) { dvz_part.base64digest }

--- a/spec/lib/preservation_catalog/shared_examples_s3_audit.rb
+++ b/spec/lib/preservation_catalog/shared_examples_s3_audit.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 's3 audit' do |klass, bucket_name, check_name, endpoint_name, region|
+RSpec.shared_examples 's3 audit' do |provider_class, bucket_name, check_name, endpoint_name, region|
   let(:zip_endpoint) do
     ZipEndpoint.find_by(endpoint_name: endpoint_name)
   end
@@ -14,11 +14,11 @@ RSpec.shared_examples 's3 audit' do |klass, bucket_name, check_name, endpoint_na
   let(:non_matching_md5) { 'asdfasdfb43t347l;x5px54xx6549;f4' }
   let(:results) { AuditResults.new(cm.preserved_object.druid, nil, cm.moab_storage_root, check_name) }
   let(:endpoint_name) { zmv.zip_endpoint.endpoint_name }
-  let(:provider) { instance_double(klass) }
+  let(:provider) { instance_double(provider_class) }
 
   before do
     allow(AuditResults).to receive(:new).and_return(results)
-    allow(klass).to receive(:new).and_return(provider)
+    allow(provider_class).to receive(:new).and_return(provider)
     allow(provider).to receive(:bucket).and_return(bucket)
     allow(provider).to receive(:bucket_name).and_return(bucket_name)
   end
@@ -54,9 +54,9 @@ RSpec.shared_examples 's3 audit' do |klass, bucket_name, check_name, endpoint_na
     it 'configures S3' do
       described_class.check_replicated_zipped_moab_version(zmv, results)
       # Note that access_key_id and secret_access_key are provided by env variable in CI.
-      expect(klass).to have_received(:new).with(region: region,
-                                                access_key_id: Settings.zip_endpoints[endpoint_name].access_key_id,
-                                                secret_access_key: Settings.zip_endpoints[endpoint_name].secret_access_key)
+      expect(provider_class).to have_received(:new).with(region: region,
+                                                         access_key_id: Settings.zip_endpoints[endpoint_name].access_key_id,
+                                                         secret_access_key: Settings.zip_endpoints[endpoint_name].secret_access_key)
     end
   end
 


### PR DESCRIPTION
* more descriptive param name for shared_examples 's3 audit'
* replace TRAVIS_JOB_ID usage in s3 upload integration test with truncated CIRCLE_SHA1 (since we moved from travis to circle)
* S3Audit#bucket can use method delegation since that's all the current method is doing

## Why was this change made?

noticed a few small rough edges while reviewing 862dd017936b6a0687bb9ffb30cddf79bdcd4a3d, but only the third thing in the list was actually changed in that commit.

## How was this change tested?

unit tests


## Which documentation and/or configurations were updated?

n/a