### PR TITLE
standardize on a single place to specify archive endpoint bucket name

### DIFF
--- a/app/lib/preservation_catalog/aws_provider.rb
+++ b/app/lib/preservation_catalog/aws_provider.rb
@@ -21,7 +21,7 @@ module PreservationCatalog
 
     # @return [String]
     def bucket_name
-      ENV['AWS_BUCKET_NAME'] || Settings.zip_endpoints[region_config_section].storage_location || Settings.aws.bucket_name
+      Settings.zip_endpoints[region_config_section].storage_location
     end
 
     # @return [::Aws::S3::Resource]

--- a/app/lib/preservation_catalog/ibm_provider.rb
+++ b/app/lib/preservation_catalog/ibm_provider.rb
@@ -22,7 +22,7 @@ module PreservationCatalog
 
     # @return [String]
     def bucket_name
-      ENV['AWS_BUCKET_NAME'] || Settings.zip_endpoints.ibm_us_south.storage_location || Settings.ibm.bucket_name
+      Settings.zip_endpoints.ibm_us_south.storage_location
     end
 
     # @return [::Aws::S3::Resource]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,12 +2,6 @@ dor_services:
   url: 'https://dor-services-app.example.edu'
   token: 'not-a-real-token'
 
-aws:
-  bucket_name: 'sul-sdr-aws-us-west-2-test' # override in prod
-
-ibm:
-  bucket_name: 'sul-sdr-ibm-us-south-1-test' # override in prod
-
 # named storage roots are in the storage_root_map (see config/settings/xxx.yml for examples).
 # the storage_root_map contains lookups of storage roots per host.
 # see sul-dlss/shared_configs for the storage_root_map of all hosts we deploy to.

--- a/spec/lib/preservation_catalog/aws_provider_spec.rb
+++ b/spec/lib/preservation_catalog/aws_provider_spec.rb
@@ -5,7 +5,7 @@ require 'lib/preservation_catalog/shared_examples_provider'
 
 describe PreservationCatalog::AwsProvider do
   it_behaves_like 'provider', described_class,
-                  Settings.aws.bucket_name,
+                  Settings.zip_endpoints.aws_s3_west_2.storage_location,
                   Settings.zip_endpoints.aws_s3_west_2.region,
                   Settings.zip_endpoints.aws_s3_west_2.access_key_id,
                   Settings.zip_endpoints.aws_s3_west_2.secret_access_key

--- a/spec/lib/preservation_catalog/ibm_provider_spec.rb
+++ b/spec/lib/preservation_catalog/ibm_provider_spec.rb
@@ -5,7 +5,7 @@ require 'lib/preservation_catalog/shared_examples_provider'
 
 describe PreservationCatalog::IbmProvider do
   it_behaves_like 'provider', described_class,
-                  Settings.ibm.bucket_name,
+                  Settings.zip_endpoints.ibm_us_south.storage_location,
                   Settings.zip_endpoints.ibm_us_south.region,
                   Settings.zip_endpoints.ibm_us_south.access_key_id,
                   Settings.zip_endpoints.ibm_us_south.secret_access_key

--- a/spec/lib/preservation_catalog/shared_examples_provider.rb
+++ b/spec/lib/preservation_catalog/shared_examples_provider.rb
@@ -12,23 +12,8 @@ RSpec.shared_examples 'provider' do |provider_class, bucket_name, region, access
   end
 
   describe '.bucket_name' do
-    context 'without ENV variable' do
-      it 'returns value from Settings' do
-        expect(provider.bucket_name).to eq bucket_name
-      end
-    end
-
-    context 'with ENV variable AWS_BUCKET_NAME' do
-      around do |example|
-        old_val = ENV['AWS_BUCKET_NAME']
-        ENV['AWS_BUCKET_NAME'] = 'bucket_44'
-        example.run
-        ENV['AWS_BUCKET_NAME'] = old_val
-      end
-
-      it 'returns the ENV value' do
-        expect(provider.bucket_name).to eq 'bucket_44'
-      end
+    it 'returns value from Settings' do
+      expect(provider.bucket_name).to eq bucket_name
     end
   end
 

--- a/spec/lib/preservation_catalog/shared_examples_s3_audit.rb
+++ b/spec/lib/preservation_catalog/shared_examples_s3_audit.rb
@@ -53,7 +53,8 @@ RSpec.shared_examples 's3 audit' do |provider_class, bucket_name, check_name, en
 
     it 'configures S3' do
       described_class.check_replicated_zipped_moab_version(zmv, results)
-      # Note that access_key_id and secret_access_key are provided by env variable in CI.
+      # Note that access_key_id and secret_access_key are provided by env variables in CI, via the usual config gem
+      # override naming convention, e.g. SETTINGS__zip_endpoints__aws_s3_west_2__access_key_id
       expect(provider_class).to have_received(:new).with(region: region,
                                                          access_key_id: Settings.zip_endpoints[endpoint_name].access_key_id,
                                                          secret_access_key: Settings.zip_endpoints[endpoint_name].secret_access_key)


### PR DESCRIPTION
* get rid of AWS_BUCKET_NAME -- the codebase only referenced this in a test, our CI env doesn't make use of it, and none of our deployed envs make use of it (searching puppet for it turns up nothing).  additionally, the config gem allows override of any setting value via env var already (which our CI env does take advantage of).
* get rid of Settings.aws.bucket_name and Settings.ibm.bucket_name.  these were only leveraged in test code, were never overridden from the defaults, and were duplicative of the values specified in Settings.zip_endpoints.<endpoint_name>.storage_location.  standardize on that setting throughout the codebase.
* clarify a comment in shared_examples_s3_audit.rb

## Why was this change made?

to make the code easier to understand by reducing complexity.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

clarification of a code comment, default settings cleanup