### PR TITLE
add preserved_objects_primary_moab table

### DIFF
--- a/app/models/preserved_object_primary_moab.rb
+++ b/app/models/preserved_object_primary_moab.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# thin join table to contain a primary CompleteMoab for each PreservedObject
+class PreservedObjectPrimaryMoab < ApplicationRecord
+  belongs_to :preserved_object, inverse_of: :preserved_objects_primary_moabs
+  belongs_to :complete_moab, inverse_of: :preserved_objects_primary_moabs
+end

--- a/db/migrate/20200616220804_create_preserved_objects_primary_moabs.rb
+++ b/db/migrate/20200616220804_create_preserved_objects_primary_moabs.rb
@@ -1,0 +1,9 @@
+class CreatePreservedObjectsPrimaryMoabs < ActiveRecord::Migration[6.0]
+  def change
+    create_table :preserved_objects_primary_moabs do |t|
+      t.references :preserved_object, foreign_key: true, null: false, index: { unique: true }
+      t.references :complete_moab, foreign_key: true, null: false, index: { unique: true }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_22_144007) do
+ActiveRecord::Schema.define(version: 2020_06_16_220804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,15 @@ ActiveRecord::Schema.define(version: 2020_05_22_144007) do
     t.index ["updated_at"], name: "index_preserved_objects_on_updated_at"
   end
 
+  create_table "preserved_objects_primary_moabs", force: :cascade do |t|
+    t.bigint "preserved_object_id", null: false
+    t.bigint "complete_moab_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["complete_moab_id"], name: "index_preserved_objects_primary_moabs_on_complete_moab_id", unique: true
+    t.index ["preserved_object_id"], name: "index_preserved_objects_primary_moabs_on_preserved_object_id", unique: true
+  end
+
   create_table "zip_endpoints", force: :cascade do |t|
     t.string "endpoint_name", null: false
     t.integer "delivery_class", null: false
@@ -129,6 +138,8 @@ ActiveRecord::Schema.define(version: 2020_05_22_144007) do
   add_foreign_key "preservation_policies_zip_endpoints", "preservation_policies"
   add_foreign_key "preservation_policies_zip_endpoints", "zip_endpoints"
   add_foreign_key "preserved_objects", "preservation_policies"
+  add_foreign_key "preserved_objects_primary_moabs", "complete_moabs"
+  add_foreign_key "preserved_objects_primary_moabs", "preserved_objects"
   add_foreign_key "zip_parts", "zipped_moab_versions"
   add_foreign_key "zipped_moab_versions", "complete_moabs"
   add_foreign_key "zipped_moab_versions", "zip_endpoints"


### PR DESCRIPTION
## Why was this change made?

Part of #1528 (John - perhaps this is all of what you intended for #1528 ?)

To allow multiple CompleteMoab objects to be associated with a PreservedObject, we need for a single CompleteMoab to be "primary."   This PR adds a thin join table to accomplish this.

## How was this change tested?



## Which documentation and/or configurations were updated?



