### PR TITLE
Enable the new rubocops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,3 +91,42 @@ Style/SymbolProc:
 
 Style/WordArray:
   Enabled: false # Naomi hates this rule;  "precious" ruby syntax
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true

--- a/app/models/druid_version_zip.rb
+++ b/app/models/druid_version_zip.rb
@@ -9,6 +9,7 @@ require 'open3'
 # Just a regular model, not an ActiveRecord-backed model
 class DruidVersionZip
   attr_reader :druid, :version
+
   delegate :base64digest, :hexdigest, to: :md5
 
   # @param [String] druid

--- a/app/models/druid_version_zip_part.rb
+++ b/app/models/druid_version_zip_part.rb
@@ -7,6 +7,7 @@
 # Just a regular model, not an ActiveRecord-backed model
 class DruidVersionZipPart
   attr_reader :dvz, :part_filename
+
   delegate :base64digest, :hexdigest, to: :md5
   delegate :druid, :part_checksum_paths, :part_paths, :hex_to_base64, :zip_command, :zip_version, to: :dvz
 

--- a/app/services/complete_moab_handler.rb
+++ b/app/services/complete_moab_handler.rb
@@ -332,7 +332,7 @@ class CompleteMoabHandler
     result = string_to_int(val)
     return result if result.instance_of?(Integer)
     # accommodate 'vnnn' strings from Moab version directories
-    return val[1..-1].to_i if val.instance_of?(String) && val.match(/^v\d+$/)
+    return val[1..].to_i if val.instance_of?(String) && val.match(/^v\d+$/)
     val
   end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe CatalogController, type: :controller do
       it 'incoming_size absent - errors' do
         patch :create, params: { druid: bare_druid, incoming_version: ver, storage_location: storage_location_param }
         expect(response).to have_http_status(:not_acceptable)
-        expect(response.body).to match(/encountered validation error\(s\)\:.*Incoming size is not a number/)
+        expect(response.body).to match(/encountered validation error\(s\):.*Incoming size is not a number/)
       end
 
       it 'incoming size present - no errors' do

--- a/spec/services/moab_storage_root_reporter_spec.rb
+++ b/spec/services/moab_storage_root_reporter_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe MoabStorageRootReporter do
     it 'creates a default file containing the lines given to it' do
       csv_filename = reporter.write_to_csv(csv_lines, report_type: 'test')
       expect(CSV.read(csv_filename)).to eq(csv_lines)
-      expect(csv_filename).to match(%r{^#{default_filepath}\/storage_#{msr_a.name}_test_.*\.csv$})
+      expect(csv_filename).to match(%r{^#{default_filepath}/storage_#{msr_a.name}_test_.*\.csv$})
       timestamp_str = /storage_#{msr_a.name}_test_(.*)\.csv$/.match(csv_filename).captures[0]
       # yes this lexically compares date strings, sorry. but they're very regular (always
       # the same length), and dropped colons makes DateTime parsing painful.
@@ -78,7 +78,7 @@ RSpec.describe MoabStorageRootReporter do
     it 'allows the caller to specify a tag string, to more easily differentiate report runs' do
       report_tag = 'after_cv'
       csv_filename = reporter.write_to_csv(csv_lines, report_type: 'test', report_tag: report_tag)
-      expect(csv_filename).to match(%r{^#{default_filepath}\/storage_#{msr_a.name}_test_after_cv.*\.csv$})
+      expect(csv_filename).to match(%r{^#{default_filepath}/storage_#{msr_a.name}_test_after_cv.*\.csv$})
       expect(CSV.read(csv_filename)).to eq(csv_lines)
     end
 


### PR DESCRIPTION


## Why was this change made?
Opting-in to new rubocops. This makes it so we don't see a warning about them


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?
n/a


