### PR TITLE
Add a route to get the primary moab for a preserved object

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -87,9 +87,11 @@ class ObjectsController < ApplicationController
   end
 
   # Retrieves the primary complete moabs storage location for a preserved objects and returns the output in plain text
+  # rubocop:disable Layout/LineLength
   def primary_moab_location
-    render plain: MoabStorageRoot.joins(complete_moabs: [:preserved_object, :preserved_objects_primary_moab]).find_by!(preserved_objects: { druid: druid }).storage_location
+    render plain: MoabStorageRoot.joins(complete_moabs: %i[preserved_object preserved_objects_primary_moab]).find_by!(preserved_objects: { druid: druid }).storage_location
   end
+  # rubocop:enable Layout/LineLength
 
   private
 

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -86,6 +86,11 @@ class ObjectsController < ApplicationController
     Honeybadger.notify(e)
   end
 
+  # Retrieves the primary complete moab for a preserved objects and returns the output in JSON format
+  def primary_moab
+    render json: PreservedObject.find_by!(druid: druid).preserved_objects_primary_moab.complete_moab.to_json
+  end
+
   private
 
   def druid

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -86,9 +86,9 @@ class ObjectsController < ApplicationController
     Honeybadger.notify(e)
   end
 
-  # Retrieves the primary complete moab for a preserved objects and returns the output in JSON format
-  def primary_moab
-    render json: PreservedObject.find_by!(druid: druid).preserved_objects_primary_moab.complete_moab.to_json
+  # Retrieves the primary complete moabs storage location for a preserved objects and returns the output in plain text
+  def primary_moab_location
+    render plain: MoabStorageRoot.joins(complete_moabs: [:preserved_object, :preserved_objects_primary_moab]).find_by!(preserved_objects: { druid: druid }).storage_location
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
       member do
         get 'checksum'
         get 'file', format: false # no need to add extension to url
-        get 'primary_moab'
+        get 'primary_moab_location'
         post 'content_diff'
       end
       collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       member do
         get 'checksum'
         get 'file', format: false # no need to add extension to url
+        get 'primary_moab'
         post 'content_diff'
       end
       collection do

--- a/openapi.yml
+++ b/openapi.yml
@@ -339,7 +339,7 @@ paths:
     get:
       tags:
         - objects
-      summary: Return the CompleteMoab information for the primary moab
+      summary: Return the storage location for the primary complete moab for the druid
       responses:
         '200':
           description: Object found

--- a/openapi.yml
+++ b/openapi.yml
@@ -358,6 +358,29 @@ paths:
           example: 'druid:bc123df4567'
           schema:
             $ref: '#/components/schemas/Druid'
+  /v1/objects/{id}/primary_moab.json:
+    get:
+      tags:
+        - objects
+      summary: Return the CompleteMoab information for the primary moab
+      responses:
+        '200':
+          description: Object found
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+        '400':
+          description: Bad request (e.g., malformed druid)
+        '404':
+          description: Object not found
+      parameters:
+        - name: id
+          in: path
+          required: true
+          example: 'druid:bc123df4567'
+          schema:
+            $ref: '#/components/schemas/Druid'          
 components:
   requestBodies:
     CatalogOptions:

--- a/openapi.yml
+++ b/openapi.yml
@@ -335,7 +335,7 @@ paths:
                     - preserve
               required:
                 - content_metadata
-  /v1/objects/{id}/primary_moab:
+  /v1/objects/{id}/primary_moab_location:
     get:
       tags:
         - objects
@@ -344,7 +344,7 @@ paths:
         '200':
           description: Object found
           content:
-            application/octet-stream:
+            text/plain:
               schema:
                 type: string
         '400':
@@ -358,29 +358,6 @@ paths:
           example: 'druid:bc123df4567'
           schema:
             $ref: '#/components/schemas/Druid'
-  /v1/objects/{id}/primary_moab.json:
-    get:
-      tags:
-        - objects
-      summary: Return the CompleteMoab information for the primary moab
-      responses:
-        '200':
-          description: Object found
-          content:
-            application/octet-stream:
-              schema:
-                type: string
-        '400':
-          description: Bad request (e.g., malformed druid)
-        '404':
-          description: Object not found
-      parameters:
-        - name: id
-          in: path
-          required: true
-          example: 'druid:bc123df4567'
-          schema:
-            $ref: '#/components/schemas/Druid'          
 components:
   requestBodies:
     CatalogOptions:

--- a/openapi.yml
+++ b/openapi.yml
@@ -335,6 +335,29 @@ paths:
                     - preserve
               required:
                 - content_metadata
+  /v1/objects/{id}/primary_moab:
+    get:
+      tags:
+        - objects
+      summary: Return the CompleteMoab information for the primary moab
+      responses:
+        '200':
+          description: Object found
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+        '400':
+          description: Bad request (e.g., malformed druid)
+        '404':
+          description: Object not found
+      parameters:
+        - name: id
+          in: path
+          required: true
+          example: 'druid:bc123df4567'
+          schema:
+            $ref: '#/components/schemas/Druid'
 components:
   requestBodies:
     CatalogOptions:

--- a/spec/requests/objects_controller_primary_moab_spec.rb
+++ b/spec/requests/objects_controller_primary_moab_spec.rb
@@ -9,17 +9,13 @@ RSpec.describe ObjectsController, type: :request do
 
   describe 'GET #primary_moab_location' do
     context 'when object found' do
-      before do
-        allow(pres_obj.preserved_objects_primary_moab).to receive(:complete_moab).and_return(primary_moab)
-      end
-
-      it 'response contains the primary moab of the given prefixed druid' do
+      it 'response contains the locaiton of primary moab of the given prefixed druid' do
         get primary_moab_location_object_url("druid:#{pres_obj.druid}"), headers: valid_auth_header
         expect(response.body).to eq(primary_moab.moab_storage_root.storage_location)
         expect(response).to have_http_status(:ok)
       end
 
-      it 'response contains the object when given bare druid' do
+      it 'response contains the location of the primary moab when given bare druid' do
         get primary_moab_location_object_url(pres_obj.druid), headers: valid_auth_header
         expect(response.body).to eq(primary_moab.moab_storage_root.storage_location)
         expect(response).to have_http_status(:ok)

--- a/spec/requests/objects_controller_primary_moab_spec.rb
+++ b/spec/requests/objects_controller_primary_moab_spec.rb
@@ -2,33 +2,35 @@
 
 require 'rails_helper'
 RSpec.describe ObjectsController, type: :request do
-  let(:pres_obj) { create(:preserved_object) }
-  let(:primary_moab) { create(:complete_moab) }
+  let(:primary_moab) do
+    create(:complete_moab).tap { |cm| PreservedObjectsPrimaryMoab.create(complete_moab: cm, preserved_object: cm.preserved_object) }
+  end
+  let(:pres_obj) { primary_moab.preserved_object }
 
-  describe 'GET #primary_moab' do
+  describe 'GET #primary_moab_location' do
     context 'when object found' do
       before do
         allow(pres_obj.preserved_objects_primary_moab).to receive(:complete_moab).and_return(primary_moab)
       end
 
       it 'response contains the primary moab of the given prefixed druid' do
-        get primary_moab_object_url("druid:#{pres_obj.druid}", format: :json), headers: valid_auth_header
-        expect(response.body).to include(primary_moab.to_json)
+        get primary_moab_location_object_url("druid:#{pres_obj.druid}"), headers: valid_auth_header
+        expect(response.body).to eq(primary_moab.moab_storage_root.storage_location)
         expect(response).to have_http_status(:ok)
       end
 
       it 'response contains the object when given bare druid' do
-        get primary_moab_object_url(pres_obj.druid, format: :json), headers: valid_auth_header
-        expect(response.body).to include(primary_moab.to_json)
+        get primary_moab_location_object_url(pres_obj.druid), headers: valid_auth_header
+        expect(response.body).to eq(primary_moab.moab_storage_root.storage_location)
         expect(response).to have_http_status(:ok)
       end
     end
 
     context 'when object not found' do
       it 'returns a 404 response code and informative body' do
-        get primary_moab_object_url('druid:bc123df4567', format: :json), headers: valid_auth_header
+        get primary_moab_location_object_url('druid:bc123df4567'), headers: valid_auth_header
         expect(response).to have_http_status(:not_found)
-        expect(response.body).to eq "404 Not Found: Couldn't find PreservedObject"
+        expect(response.body).to include "404 Not Found: Couldn't find MoabStorageRoot"
       end
     end
   end

--- a/spec/requests/objects_controller_primary_moab_spec.rb
+++ b/spec/requests/objects_controller_primary_moab_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe ObjectsController, type: :request do
+  let(:pres_obj) { create(:preserved_object) }
+  let(:primary_moab) { create(:complete_moab) }
+
+  describe 'GET #primary_moab' do
+    context 'when object found' do
+      before do
+        allow(pres_obj.preserved_objects_primary_moab).to receive(:complete_moab).and_return(primary_moab)
+      end
+
+      it 'response contains the primary moab of the given prefixed druid' do
+        get primary_moab_object_url("druid:#{pres_obj.druid}", format: :json), headers: valid_auth_header
+        expect(response.body).to include(primary_moab.to_json)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'response contains the object when given bare druid' do
+        get primary_moab_object_url(pres_obj.druid, format: :json), headers: valid_auth_header
+        expect(response.body).to include(primary_moab.to_json)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when object not found' do
+      it 'returns a 404 response code and informative body' do
+        get primary_moab_object_url('druid:bc123df4567', format: :json), headers: valid_auth_header
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to eq "404 Not Found: Couldn't find PreservedObject"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Fixes #1529 by adding a get route for an objects primary moab.

## How was this change tested?

Unit test added

## Which documentation and/or configurations were updated?

OpenAPI doc

