### PR TITLE
PreservedObjectsPrimaryMoab populated in CompleteMoabHandler

### DIFF
--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -22,6 +22,9 @@ class CompleteMoab < ApplicationRecord
   belongs_to :moab_storage_root, inverse_of: :complete_moabs
   belongs_to :from_moab_storage_root, class_name: 'MoabStorageRoot', required: false
 
+  # NOTE: we'd like to check if there is a different complete_moab for the preserved_object and
+  #  assign the other complete_moab to preserved_objects_primary_moab
+  has_one :preserved_objects_primary_moab, dependent: :destroy
   has_many :zipped_moab_versions, dependent: :restrict_with_exception, inverse_of: :complete_moab
 
   delegate :s3_key, to: :druid_version_zip

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -9,6 +9,8 @@ class PreservedObject < ApplicationRecord
   PREFIX_RE = /druid:/i.freeze
   belongs_to :preservation_policy
   has_many :complete_moabs, dependent: :restrict_with_exception, autosave: true
+  has_one :preserved_objects_primary_moab, dependent: :restrict_with_exception
+
   validates :druid,
             presence: true,
             uniqueness: true,

--- a/app/models/preserved_object_primary_moab.rb
+++ b/app/models/preserved_object_primary_moab.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-# thin join table to contain a primary CompleteMoab for each PreservedObject
-class PreservedObjectPrimaryMoab < ApplicationRecord
-  belongs_to :preserved_object, inverse_of: :preserved_objects_primary_moabs
-  belongs_to :complete_moab, inverse_of: :preserved_objects_primary_moabs
-end

--- a/app/models/preserved_objects_primary_moab.rb
+++ b/app/models/preserved_objects_primary_moab.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# thin join table to contain a primary CompleteMoab for each PreservedObject
+#  if nothing else, this model class provides us a way to access timestamps for these records
+class PreservedObjectsPrimaryMoab < ApplicationRecord
+  belongs_to :preserved_object, inverse_of: :preserved_objects_primary_moab
+  belongs_to :complete_moab, inverse_of: :preserved_objects_primary_moab
+end

--- a/spec/services/complete_moab_handler_create_spec.rb
+++ b/spec/services/complete_moab_handler_create_spec.rb
@@ -24,13 +24,14 @@ RSpec.describe CompleteMoabHandler do
   end
 
   describe '#create' do
-    it 'creates PreservedObject and CompleteMoab in database' do
+    it 'creates PreservedObject and CompleteMoab and PreservedObjectsPrimaryMoab in database' do
       complete_moab_handler.create
       new_po = PreservedObject.find_by(druid: druid)
       new_cm = new_po.complete_moabs.find_by(version: incoming_version)
       expect(new_po.current_version).to eq incoming_version
       expect(new_cm.moab_storage_root).to eq ms_root
       expect(new_cm.size).to eq incoming_size
+      expect(new_po.preserved_objects_primary_moab.complete_moab_id).to eq new_cm.id
     end
 
     it 'creates the CompleteMoab with "ok" status and validation timestamps if caller ran CV' do
@@ -115,7 +116,7 @@ RSpec.describe CompleteMoabHandler do
       end
     end
 
-    it 'creates PreservedObject and CompleteMoab in database when there are no validation errors' do
+    it 'creates PreservedObject and CompleteMoab and PreservedObjectsPrimaryMoab in database when there are no validation errors' do
       complete_moab_handler = described_class.new(valid_druid, incoming_version, incoming_size, ms_root)
       complete_moab_handler.create_after_validation
       new_po = PreservedObject.find_by(druid: valid_druid, current_version: incoming_version)
@@ -123,6 +124,7 @@ RSpec.describe CompleteMoabHandler do
       new_cm = new_po.complete_moabs.find_by(moab_storage_root: ms_root, version: incoming_version)
       expect(new_cm).not_to be_nil
       expect(new_cm.status).to eq 'validity_unknown'
+      expect(new_po.preserved_objects_primary_moab.complete_moab_id).to eq new_cm.id
     end
 
     it 'creates CompleteMoab with "ok" status and validation timestamps if no validation errors and caller ran CV' do
@@ -157,7 +159,7 @@ RSpec.describe CompleteMoabHandler do
         end
       end
 
-      it 'creates PreservedObject, and CompleteMoab with "invalid_moab" status in database' do
+      it 'creates PreservedObject, and CompleteMoab with "invalid_moab" status, and PreservedObjectsPrimaryMoab in database' do
         complete_moab_handler.create_after_validation
         new_po = PreservedObject.find_by(druid: invalid_druid, current_version: incoming_version)
         expect(new_po).not_to be_nil
@@ -166,6 +168,7 @@ RSpec.describe CompleteMoabHandler do
         expect(new_cm.status).to eq 'invalid_moab'
         expect(new_cm.last_moab_validation).to be_a ActiveSupport::TimeWithZone
         expect(new_cm.last_version_audit).to be_a ActiveSupport::TimeWithZone
+        expect(new_po.preserved_objects_primary_moab.complete_moab_id).to eq new_cm.id
       end
 
       it 'creates CompleteMoab with "invalid_moab" status in database even if caller ran CV' do


### PR DESCRIPTION
## Why was this change made?

When we create a new CompleteMoab, populate the PreservedObjectsPrimaryMoab join table

Closes #1583

## How was this change tested?

unit tests - which sufficiently kicked my behind

## Which documentation and/or configurations were updated?

n/a

