### PR TITLE
loosen overly specific find when setting default primary moab

### DIFF
--- a/app/services/complete_moab_handler.rb
+++ b/app/services/complete_moab_handler.rb
@@ -212,7 +212,7 @@ class CompleteMoabHandler
                 end
       this_cm = this_po.complete_moabs.create!(cm_attrs)
       # add to join table unless there is already a primary moab
-      PreservedObjectsPrimaryMoab.find_or_create_by!(preserved_object: this_po, complete_moab: this_cm)
+      PreservedObjectsPrimaryMoab.find_or_create_by!(preserved_object: this_po) { |popm| popm.complete_moab = this_cm }
     end
     results.add_result(AuditResults::CREATED_NEW_OBJECT) if transaction_ok
   end


### PR DESCRIPTION
## Why was this change made?

i suggested too exact a find condition when discussing #1587 w/ @ndushay.  we just want to check whether there's a primary moab for the _druid_ (`PreservedObject`), not whether there's an entry in the table that maps primary for the `PreservedObject`/`CompleteMoab` combo (which there won't be, since the specific `CompleteMoab` instance was just created in the code above the `PreservedObjectsPrimaryMoab` insertion).

## How was this change tested?

existing unit tests.  #1591 should also shore up testing around this functionality.

## Which documentation and/or configurations were updated?



