### PR TITLE
Populates preserved_objects_primary_moabs table.

### DIFF
--- a/db/migrate/20200624144318_populate_preserved_objects_primary_moabs.rb
+++ b/db/migrate/20200624144318_populate_preserved_objects_primary_moabs.rb
@@ -1,0 +1,9 @@
+class PopulatePreservedObjectsPrimaryMoabs < ActiveRecord::Migration[6.0]
+  def change
+    execute <<-SQL
+      INSERT INTO preserved_objects_primary_moabs (preserved_object_id, complete_moab_id, created_at, updated_at)
+        SELECT preserved_object_id, id, created_at, updated_at FROM complete_moabs ORDER BY created_at desc
+        ON CONFLICT DO NOTHING;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_16_220804) do
+ActiveRecord::Schema.define(version: 2020_06_24_144318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
closes https://github.com/sul-dlss/preservation_catalog/issues/1585

## Why was this change made?
Provide initial population of primary moabs.


## How was this change tested?
Local.


## Which documentation and/or configurations were updated?
No.

