### PR TITLE
Cleanup zip cache using parameterized directory and expiry time

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -8,14 +8,17 @@ every :tuesday, roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/m2c-err.log'
   runner 'MoabStorageRoot.find_each(&:m2c_check!)'
 end
+
 every :wednesday, roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/c2a-err.log'
   runner 'CompleteMoab.archive_check_expired.find_each(&:audit_moab_version_replication!)'
 end
+
 every :friday, roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/c2m-err.log'
   runner 'MoabStorageRoot.find_each(&:c2m_check!)'
 end
+
 every :sunday, at: '1am', roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/cv-err.log'
   runner 'MoabStorageRoot.find_each(&:validate_expired_checksums!)'
@@ -23,14 +26,10 @@ end
 
 every :hour, roles: [:cache_cleaner] do
   set :output, standard: '/var/log/preservation_catalog/zip_cache_cleanup.log'
-  command <<-'END_OF_COMMAND'
-    find /sdr-transfers -mindepth 5 -type f -name "*.md5" -mtime +2 -exec bash -c 'TARGET="{}"; rm -v ${TARGET%md5}*' \;
-  END_OF_COMMAND
+  rake 'prescat:cache_cleaner:stale_files'
 end
 
 every :day, at: '1:15am', roles: [:cache_cleaner] do
   set :output, standard: '/var/log/preservation_catalog/zip_cache_cleanup.log'
-  command <<-'END_OF_COMMAND'
-    find /sdr-transfers/ -not -path "*/\.*" -type d -empty -delete
-  END_OF_COMMAND
+  rake 'prescat:cache_cleaner:empty_directories'
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,7 @@ workflow_services_url: 'https://workflows.example.org/workflow/'
 
 checksum_algos: ['md5'] # 'sha1' 'sha256'
 
+zip_cache_expiry_time: '+10080' # this is UNIX `find` speak for "greater than seven days"
 zip_storage: '/tmp' # override in #{RAILS_ENV}.yml
 
 resque_dashboard_hostnames: # tells the router where to mount the resque dashboard

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -3,6 +3,18 @@
 require 'csv'
 
 namespace :prescat do
+  namespace :cache_cleaner do
+    desc 'Clean zip storage cache of empty directories'
+    task empty_directories: :environment do
+      `find #{Settings.zip_storage} -not -path "*/\.*" -type d -empty -delete`
+    end
+
+    desc 'Clean zip storage cache of stale checksum & zip files'
+    task stale_files: :environment do
+      `find #{Settings.zip_storage} -mindepth 3 -type f -amin #{Settings.zip_cache_expiry_time} -delete`
+    end
+  end
+
   desc 'Migrate storage root, returning druids of all migrated moabs'
   task :migrate_storage_root, [:from, :to] => :environment do |_task, args|
     puts 'This will move all complete_moabs from the old storage root to a new storage root.'


### PR DESCRIPTION
Fixes #1576

## Why was this change made?

Because without it, we are not purging the cache correctly, which results in running out of space.

## How was this change tested?

Ran the rake tasks locally and they cleaned out `/tmp` as expected.

## Which documentation and/or configurations were updated?

Added a new configuration. Does not require shared_configs work or clean-up.

