### PR TITLE
[DRAFT] Safely update a preserved objects primary moab

### DIFF
--- a/app/services/primary_moab_service.rb
+++ b/app/services/primary_moab_service.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Primary Moab service for safely updating the primary moab of a preserved object
+class PrimaryMoabService
+  def initialize(preserved_object)
+    @preserved_object = preserved_object
+  end
+
+  def update_primary_moab(new_primary_moab)
+    return unless @preserved_object.complete_moabs.include? new_primary_moab
+    return unless new_primary_moab.version == @preserved_object.current_version
+    return unless new_primary_moab.stats == 'ok'
+
+    @preserved_objects.preserved_objects_primary_moab = new_primary_moab
+  end
+end


### PR DESCRIPTION
Fixes #1599 

## Why was this change made?

This adds a PrimaryMoabService object to safely update the primary moab of a preserved objects based on the constrains outlined in #1599.

## How was this change tested?

TODO: unit tests and integration test run.


## Which documentation and/or configurations were updated?

TODO: Update readme if appropriate

