### PR TITLE
Move zipped moab version: fix replication on moab update

### DIFF
--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -15,6 +15,9 @@ class CompleteMoab < ApplicationRecord
   }
 
   after_create :create_zipped_moab_versions!
+  # hook for creating archive zips is here and on PreservedObject, because version and current_version must be in sync, and
+  # even though both fields will usually be updated together in a single transaction, one has to be updated first.  latter
+  # of the two updates will actually trigger replication.
   after_update :create_zipped_moab_versions!, if: :saved_change_to_version? # an ActiveRecord dynamic method
   after_save :validate_checksums!, if: proc { |cm| cm.saved_change_to_status? && cm.validity_unknown? }
 

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -8,6 +8,11 @@
 class PreservedObject < ApplicationRecord
   PREFIX_RE = /druid:/i.freeze
 
+  # hook for creating archive zips is here and on CompleteMoab, because version and current_version must be in sync, and
+  # even though both fields will usually be updated together in a single transaction, one has to be updated first.  latter
+  # of the two updates will actually trigger replication.
+  after_update :create_zipped_moab_versions!, if: :saved_change_to_current_version? # an ActiveRecord dynamic method
+
   belongs_to :preservation_policy
   has_many :complete_moabs, dependent: :restrict_with_exception, autosave: true
   has_many :zipped_moab_versions, dependent: :restrict_with_exception, inverse_of: :preserved_object


### PR DESCRIPTION
_**note** wasn't clear in the initial wording, but this is a fix for work in progress that hasn't yet been merged_

## Why was this change made?

to fix the application so that replication is triggered automatically when the catalog learns that a moab has been versioned.

(hopefully) fixes the regression described in [this comment](https://github.com/sul-dlss/preservation_catalog/pull/1589#issuecomment-653276439) on #1589.

## How was this change tested?

unit tests initially, but i also plan to deploy to stage again and run the integration tests, as was done to find this issue in the first place.

the second commit is a test for the specific regression:
```
Failures:

  1) the whole replication pipeline updating an existing moab gets from zipmaker queue to replication result message for the new version when the moab is updated
     Failure/Error: expect(ZipmakerJob).to receive(:perform_later).with(druid, next_version, moab_storage_root.storage_location).and_call_original
     
       (ZipmakerJob (class)).perform_later("bz514sm9647", 3, "spec/fixtures/storage_root01/sdr2objects")
           expected: 1 time with arguments: ("bz514sm9647", 3, "spec/fixtures/storage_root01/sdr2objects")
           received: 0 times
     # ./spec/jobs/integration_spec.rb:69:in `block (3 levels) in <top (required)>'
     # ./spec/jobs/integration_spec.rb:29:in `block (2 levels) in <top (required)>'
     # ./spec/support/live_s3.rb:10:in `block (2 levels) in <top (required)>'

Finished in 54.16 seconds (files took 8.01 seconds to load)
1069 examples, 1 failure, 6 pending
```

the third commit is the fix.

## Which documentation and/or configurations were updated?

the new test provides a nice new illustration of what we expect the activity to be at a high level when a moab is versioned.