### PR TITLE
Only update PreservedObject#current version if CompleteMoab being checked/updated is primary

### DIFF
--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -69,6 +69,10 @@ class CompleteMoab < ApplicationRecord
     ok?
   end
 
+  def primary?
+    PreservedObjectsPrimaryMoab.where(preserved_object: preserved_object, complete_moab: self).exists?
+  end
+
   def update_audit_timestamps(moab_validated, version_audited)
     t = Time.current
     self.last_moab_validation = t if moab_validated

--- a/app/services/complete_moab_handler.rb
+++ b/app/services/complete_moab_handler.rb
@@ -228,6 +228,8 @@ class CompleteMoabHandler
       raise_rollback_if_cm_po_version_mismatch
 
       # FIXME: what if there is more than one associated complete_moab?
+      # TODO: is the complete_moab.matches_po_current_version? even useful, since we should've raised an error with
+      # the call to raise_rollback_if_cm_po_version_mismatch if that condition weren't met?
       if incoming_version > complete_moab.version && complete_moab.matches_po_current_version?
         # add results without db updates
         code = AuditResults::ACTUAL_VERS_GT_DB_OBJ

--- a/app/services/complete_moab_handler.rb
+++ b/app/services/complete_moab_handler.rb
@@ -186,6 +186,10 @@ class CompleteMoabHandler
     @moab_validator ||= MoabValidator.new(druid: druid, storage_location: storage_location, results: results)
   end
 
+  def primary_moab?
+    @primary_moab ||= complete_moab.primary?
+  end
+
   # Note that this may be called by running M2C on a storage root and discovering a second copy of a Moab,
   #   or maybe by calling #create_after_validation directly after copying a Moab
   def create_db_objects(status, checksums_validated = false)
@@ -207,7 +211,7 @@ class CompleteMoabHandler
     transaction_ok = with_active_record_transaction_and_rescue do
       this_po = PreservedObject
                 .find_or_create_by!(druid: druid) do |po|
-                  po.current_version = incoming_version
+                  po.current_version = incoming_version # init to match version of the first moab for the druid
                   po.preservation_policy_id = ppid
                 end
       this_cm = this_po.complete_moabs.create!(cm_attrs)
@@ -233,7 +237,7 @@ class CompleteMoabHandler
         complete_moab.last_checksum_validation = Time.current if checksums_validated && complete_moab.last_checksum_validation
         update_status(status) if status
         complete_moab.save!
-        pres_object.current_version = incoming_version
+        pres_object.current_version = incoming_version if primary_moab? # we only want to track highest seen version based on primary
         pres_object.save!
       else
         status = 'unexpected_version_on_storage' if set_status_to_unexp_version
@@ -247,7 +251,7 @@ class CompleteMoabHandler
   def update_cm_po_set_status
     if moab_validation_errors.empty?
       complete_moab.upd_audstamps_version_size(ran_moab_validation?, incoming_version, incoming_size)
-      pres_object.current_version = incoming_version
+      pres_object.current_version = incoming_version if primary_moab? # we only want to track highest seen version based on primary
       pres_object.save!
     else
       update_status('invalid_moab')
@@ -255,6 +259,8 @@ class CompleteMoabHandler
   end
 
   def raise_rollback_if_cm_po_version_mismatch
+    return unless primary_moab?
+
     unless complete_moab.matches_po_current_version?
       cm_version = complete_moab.version
       po_version = complete_moab.preserved_object.current_version

--- a/app/services/complete_moab_handler.rb
+++ b/app/services/complete_moab_handler.rb
@@ -227,10 +227,7 @@ class CompleteMoabHandler
     transaction_ok = with_active_record_transaction_and_rescue do
       raise_rollback_if_cm_po_version_mismatch
 
-      # FIXME: what if there is more than one associated complete_moab?
-      # TODO: is the complete_moab.matches_po_current_version? even useful, since we should've raised an error with
-      # the call to raise_rollback_if_cm_po_version_mismatch if that condition weren't met?
-      if incoming_version > complete_moab.version && complete_moab.matches_po_current_version?
+      if incoming_version > complete_moab.version
         # add results without db updates
         code = AuditResults::ACTUAL_VERS_GT_DB_OBJ
         results.add_result(code, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)

--- a/spec/factories/preserved_object.rb
+++ b/spec/factories/preserved_object.rb
@@ -7,7 +7,9 @@ FactoryBot.define do
     preservation_policy { PreservationPolicy.default_policy }
   end
 
-  # searches through fixture dirs to find the druid, creates a complete moab for the PO
+  # searches through fixture dirs to find the druid, creates a complete moab for the PO.
+  # if there is more than one moab among the storage roots for the druid, the one from the
+  # storage root listed first in the configs will be used.
   factory :preserved_object_fixture, parent: :preserved_object do
     current_version { Stanford::StorageServices.current_version(druid) }
 

--- a/spec/jobs/catalog_to_moab_job_spec.rb
+++ b/spec/jobs/catalog_to_moab_job_spec.rb
@@ -14,5 +14,48 @@ describe CatalogToMoabJob, type: :job do
       expect(Audit::CatalogToMoab).to receive(:new).with(cm).and_return(validator)
       job.perform(cm)
     end
+
+    context 'there are two moabs for the druid' do
+      let(:druid) { 'bz514sm9647' }
+      let(:msr_1) { MoabStorageRoot.find_by!(name: 'fixture_sr1') }
+      let(:msr_a) { MoabStorageRoot.find_by!(name: 'fixture_srA') }
+      let(:po) { create(:preserved_object, druid: druid, current_version: 1) }
+      let(:cm_1) { create(:complete_moab, preserved_object: po, version: 1, moab_storage_root: msr_1) } # this catalog entry lags disk to start test
+      let(:cm_a) { create(:complete_moab, preserved_object: po, version: 1, moab_storage_root: msr_a) }
+
+      context 'the one with the lower version is the primary' do
+        before do
+          PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: cm_1) # version that's ahead, on 01, is primary
+          job.perform(cm_1)
+          job.perform(cm_a)
+        end
+
+        it 'sets CompleteMoab#version to the version of the moab on that storage root' do
+          expect(cm_1.reload.version).to eq 3
+          expect(cm_a.reload.version).to eq 1
+        end
+
+        it 'sets PreservedObject#current_version to the highest version seen for the primary CompleteMoab' do
+          expect(po.reload.current_version).to eq 3
+        end
+      end
+
+      context 'the one with the higher version is the primary' do
+        before do
+          PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: cm_a) # version that's behind, on A, is primary
+          job.perform(cm_a)
+          job.perform(cm_1)
+        end
+
+        it 'sets CompleteMoab#version to the version of the moab on that storage root' do
+          expect(cm_1.reload.version).to eq 3
+          expect(cm_a.reload.version).to eq 1
+        end
+
+        it 'sets PreservedObject#current_version to the highest version seen for the primary CompleteMoab' do
+          expect(po.reload.current_version).to eq 1 # the copy that's behind is the primary -- this would be unusual, but just to define the behavior
+        end
+      end
+    end
   end
 end

--- a/spec/jobs/integration_spec.rb
+++ b/spec/jobs/integration_spec.rb
@@ -64,7 +64,9 @@ describe 'the whole replication pipeline', type: :job do
 
     it 'gets from zipmaker queue to replication result message for the new version when the moab is updated' do
       # pretend catalog is on version 2 before update call from robots
-      create(:complete_moab, preserved_object: preserved_object, version: version, moab_storage_root: moab_storage_root)
+      create(:complete_moab, preserved_object: preserved_object, version: version, moab_storage_root: moab_storage_root) do |cm|
+        PreservedObjectsPrimaryMoab.create!(preserved_object: preserved_object, complete_moab: cm)
+      end
 
       expect(ZipmakerJob).to receive(:perform_later).with(druid, next_version, moab_storage_root.storage_location).and_call_original
       expect(PlexerJob).to receive(:perform_later).with(druid, next_version, s3_key, Hash).and_call_original

--- a/spec/jobs/moab_to_catalog_job_spec.rb
+++ b/spec/jobs/moab_to_catalog_job_spec.rb
@@ -20,4 +20,45 @@ describe MoabToCatalogJob, type: :job do
       job.perform(msr, druid)
     end
   end
+
+  context 'there are two moabs for the druid' do
+    let(:druid) { 'bz514sm9647' }
+    let(:msr_1) { MoabStorageRoot.find_by!(name: 'fixture_sr1') }
+    let(:msr_a) { MoabStorageRoot.find_by!(name: 'fixture_srA') }
+    let(:cm_1) { CompleteMoab.by_druid(druid).find_by!(moab_storage_root: msr_1) }
+    let(:cm_a) { CompleteMoab.by_druid(druid).find_by!(moab_storage_root: msr_a) }
+    let(:po) { PreservedObject.find_by!(druid: druid) }
+
+    context 'the one with the lower version is the primary' do
+      before do
+        job.perform(msr_1, druid) # first added is primary by default
+        job.perform(msr_a, druid)
+      end
+
+      it 'sets CompleteMoab#version to the version of the moab on that storage root' do
+        expect(cm_1.version).to eq 3
+        expect(cm_a.version).to eq 1
+      end
+
+      it 'sets PreservedObject#current_version to the highest version seen for the primary CompleteMoab' do
+        expect(po.current_version).to eq 3
+      end
+    end
+
+    context 'the one with the higher version is the primary' do
+      before do
+        job.perform(msr_a, druid) # first added is primary by default
+        job.perform(msr_1, druid)
+      end
+
+      it 'sets CompleteMoab#version to the version of the moab on that storage root' do
+        expect(cm_1.version).to eq 3
+        expect(cm_a.version).to eq 1
+      end
+
+      it 'sets PreservedObject#current_version to the highest version seen for the primary CompleteMoab' do
+        expect(po.current_version).to eq 1 # the copy that's behind is the primary -- this would be unusual, but just to define the behavior
+      end
+    end
+  end
 end

--- a/spec/services/complete_moab_handler_check_exist_spec.rb
+++ b/spec/services/complete_moab_handler_check_exist_spec.rb
@@ -36,13 +36,15 @@ RSpec.describe CompleteMoabHandler do
       let(:druid) { 'bj102hs9687' }
 
       before do
-        v2 = create(:preserved_object, druid: druid, current_version: 2)
-        v2.complete_moabs.create!(
-          version: v2.current_version,
+        create(:preserved_object, druid: druid, current_version: 2)
+        po.complete_moabs.create!(
+          version: po.current_version,
           size: 1,
           moab_storage_root: ms_root,
           status: 'ok' # NOTE: we are pretending we checked for moab validation errs
-        )
+        ) do |primary_cm|
+          PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: primary_cm)
+        end
       end
 
       context 'incoming and db versions match' do
@@ -361,8 +363,6 @@ RSpec.describe CompleteMoabHandler do
       context 'db update error' do
         context 'ActiveRecordError' do
           let(:incoming_version) { 2 }
-          let(:cm) { create(:complete_moab, pres_object: po, moab_storage_root: ms_root) }
-          let(:po) { cm.preserved_object }
 
           before do
             allow(moab_validator.complete_moab).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
@@ -426,6 +426,46 @@ RSpec.describe CompleteMoabHandler do
           # but no associated CompleteMoab
 
           it_behaves_like 'CompleteMoab does not exist', :check_existence
+        end
+      end
+
+      context 'there are two moabs for the druid' do
+        let(:druid) { 'bz514sm9647' }
+        let(:msr_1) { MoabStorageRoot.find_by!(name: 'fixture_sr1') }
+        let(:msr_a) { MoabStorageRoot.find_by!(name: 'fixture_srA') }
+        let(:cm_1) { CompleteMoab.by_druid(druid).find_by!(moab_storage_root: msr_1) }
+        let(:cm_a) { CompleteMoab.by_druid(druid).find_by!(moab_storage_root: msr_a) }
+
+        context 'the one with the lower version is the primary' do
+          before do
+            described_class.new(druid, 3, 356, msr_1).check_existence # first added is primary by default
+            described_class.new(druid, 1, 232, msr_a).check_existence
+          end
+
+          it 'sets CompleteMoab#version to the version of the moab on that storage root' do
+            expect(cm_1.version).to eq 3
+            expect(cm_a.version).to eq 1
+          end
+
+          it 'sets PreservedObject#current_version to the highest version seen for the primary CompleteMoab' do
+            expect(po.current_version).to eq 3
+          end
+        end
+
+        context 'the one with the higher version is the primary' do
+          before do
+            described_class.new(druid, 1, 232, msr_a).check_existence # first added is primary by default
+            described_class.new(druid, 3, 356, msr_1).check_existence
+          end
+
+          it 'sets CompleteMoab#version to the version of the moab on that storage root' do
+            expect(cm_1.version).to eq 3
+            expect(cm_a.version).to eq 1
+          end
+
+          it 'sets PreservedObject#current_version to the highest version seen for the primary CompleteMoab' do
+            expect(po.current_version).to eq 1 # the copy that's behind is the primary -- this would be unusual, but just to define the behavior
+          end
         end
       end
 

--- a/spec/services/complete_moab_handler_confirm_version_spec.rb
+++ b/spec/services/complete_moab_handler_confirm_version_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe CompleteMoabHandler do
       let!(:cm) do
         # Adds new complete moab with the same druid to confirm that tests pass
         create(:complete_moab, preserved_object: po, moab_storage_root: create(:moab_storage_root))
-        create(:complete_moab, preserved_object: po, version: cm_version, moab_storage_root: ms_root)
+        create(:complete_moab, preserved_object: po, version: cm_version, moab_storage_root: ms_root) do |primary_cm|
+          PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: primary_cm)
+        end
       end
       let(:moab_validator) { complete_moab_handler.send(:moab_validator) }
 

--- a/spec/services/complete_moab_handler_update_version_spec.rb
+++ b/spec/services/complete_moab_handler_update_version_spec.rb
@@ -34,15 +34,17 @@ RSpec.describe CompleteMoabHandler do
 
     context 'in Catalog' do
       before do
-        v2 = create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_prez_policy)
-        v2.complete_moabs.create!(
-          version: v2.current_version,
+        create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_prez_policy)
+        po.complete_moabs.create!(
+          version: po.current_version,
           size: 1,
           moab_storage_root: ms_root,
           status: 'ok', # pretending we checked for moab validation errs at create time
           last_version_audit: Time.current,
           last_moab_validation: Time.current
-        )
+        ) do |primary_cm|
+          PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: primary_cm)
+        end
       end
 
       context 'incoming version newer than catalog versions (both) (happy path)' do
@@ -291,7 +293,9 @@ RSpec.describe CompleteMoabHandler do
             status: 'ok', # NOTE: pretending we checked for moab validation errs at create time
             last_version_audit: t,
             last_moab_validation: t
-          )
+          ) do |primary_cm|
+            PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: primary_cm)
+          end
         end
 
         let(:po) { PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_prez_policy) }
@@ -436,7 +440,9 @@ RSpec.describe CompleteMoabHandler do
             status: 'ok', # pretending we checked for moab validation errs at create time
             last_version_audit: t,
             last_moab_validation: t
-          )
+          ) do |primary_cm|
+            PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: primary_cm)
+          end
         end
 
         context 'checksums_validated = false' do


### PR DESCRIPTION
## Why was this change made?

I didn't get around to ticketing this, but I discussed this with @andrewjbtw at the beginning of last week.

Our expectation is that pres robots will keep the primary updated, and the non-primary copy will be synced out of band from pres cat and pres robots to keep it up to date, using the primary copy as the syncing source, e.g. in preparation for migrating moab content to new storage hardware (allowing content to be synced and validated gradually from within the catalog, without needing to shut down pres cat and migrate DB entries while it refrains from doing anything with storage, so as to only see one copy of a moab in one known location at a time).  Alternatively, a non-primary copy might be created when retrieving a cloud copy, e.g. for use in remediating a damaged local copy.

In both of those scenarios, it would be surprising for a non-primary copy to have a higher version than the primary, and in general the "primary" copy is expected to be on the correct version, so we'll only update `current_version` on the parent `PreservedObject` when we see an increase in the `version` for the primary `CompleteMoab` for a druid.  Previously, we generally described `current_version` as the highest version we'd seen so far for the moab.  Now we're just explicitly qualifying that to apply to the primary copy only.

## How was this change tested?

unit tests, but i tried to do much of it through integration-y tests that dealt with actual moab fixtures on disk, at least for the new tests that i added.

for some of the existing tests, i just explicitly marked the `CompleteMoab` on which expectations were set as the primary, since that is the role those test objects have been playing so far.

## Which documentation and/or configurations were updated?

documentation is covered under other tickets (#1600, #1588, #1595).  configuration n/a here.