### PR TITLE
configurable artificial delay before making zip for replication

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,3 +46,9 @@ total_worker_count: 117 # for okcomputer endpoint
 
 api_jwt:
   hmac_secret: 'my$ecretK3y'
+
+# we expect/hope that this will not stay around forever.  see usage for further explanation.
+hacks:
+  update_catalog_sleep:
+    base_time: 0.05    # the default values are artificially low to keep test suite fast -- should override to be many seconds in prod
+    max_stagger: 0.01


### PR DESCRIPTION
## Why was this change made?

in hopes of ameliorating problems due to lag between when pres robots worker finishes writing a file, and when pres cat is able to read it


## How was this change tested?

* unit tests cover the code change for basic functionality
* as a basic smoke test will deploy to stage and run infra integration tests and confirm preservation works, before deploying to prod.
  * will babysit in prod for a while after deployment

## Which documentation and/or configurations were updated?

added a couple settings, left explanation in code comments, since that seems like the most visible/useful place for the necessary info.
