### PR TITLE
raise if trying to delete a ZippedMoabVersion for which ZipParts still exist

### DIFF
--- a/app/models/zipped_moab_version.rb
+++ b/app/models/zipped_moab_version.rb
@@ -10,7 +10,7 @@
 class ZippedMoabVersion < ApplicationRecord
   belongs_to :preserved_object, inverse_of: :zipped_moab_versions
   belongs_to :zip_endpoint, inverse_of: :zipped_moab_versions
-  has_many :zip_parts, dependent: :destroy, inverse_of: :zipped_moab_version
+  has_many :zip_parts, dependent: :restrict_with_exception, inverse_of: :zipped_moab_version
 
   validates :preserved_object, :version, :zip_endpoint, presence: true
 


### PR DESCRIPTION
## Why was this change made?

This will make it easier to safely remediate Moab replications that got wedged part way through the pipeline, by allowing more confidence that data about replicated parts won't be accidentally deleted when trying to clean up hanging `ZippedMoabVersion` records.

(discussed briefly on slack last week)


## How was this change tested?

unit tests.  in the normal course of app operation, `ZippedMoabVersion`s aren't deleted.  that's only done manually, to remediate replication problems.

## Which documentation and/or configurations were updated?

n/a