### PR TITLE
Zipmaker raise on undersized extant zip

### DIFF
--- a/app/jobs/zipmaker_job.rb
+++ b/app/jobs/zipmaker_job.rb
@@ -6,7 +6,7 @@
 # Invoke PlexerJob for each zip part.
 class ZipmakerJob < ApplicationJob
   queue_as :zipmaker
-  delegate :create_zip!, :file_path, :part_keys, to: :zip
+  delegate :ensure_zip!, :file_path, :part_keys, to: :zip
 
   attr_accessor :zip
 
@@ -26,11 +26,7 @@ class ZipmakerJob < ApplicationJob
   def perform(druid, version, moab_replication_path) # rubocop:disable Lint/UnusedMethodArgument
     wait_as_needed
 
-    if File.exist?(file_path)
-      FileUtils.touch(file_path)
-    else
-      create_zip!
-    end
+    ensure_zip!
     part_keys.each do |part_key|
       PlexerJob.perform_later(druid, version, part_key, DruidVersionZipPart.new(zip, part_key).metadata)
     end

--- a/app/jobs/zipmaker_job.rb
+++ b/app/jobs/zipmaker_job.rb
@@ -6,7 +6,7 @@
 # Invoke PlexerJob for each zip part.
 class ZipmakerJob < ApplicationJob
   queue_as :zipmaker
-  delegate :ensure_zip!, :file_path, :part_keys, to: :zip
+  delegate :find_or_create_zip!, :file_path, :part_keys, to: :zip
 
   attr_accessor :zip
 
@@ -26,7 +26,7 @@ class ZipmakerJob < ApplicationJob
   def perform(druid, version, moab_replication_path) # rubocop:disable Lint/UnusedMethodArgument
     wait_as_needed
 
-    ensure_zip!
+    find_or_create_zip!
     part_keys.each do |part_key|
       PlexerJob.perform_later(druid, version, part_key, DruidVersionZipPart.new(zip, part_key).metadata)
     end

--- a/app/models/druid_version_zip.rb
+++ b/app/models/druid_version_zip.rb
@@ -31,7 +31,7 @@ class DruidVersionZip
   # file to refresh atime and mtime, so the zip cache cleaning cron job doesn't see it as stale.  If it doesn't,
   # create it.
   # @raise [StandardError] if there's a zip file for this druid-version, but it looks too small to be complete.
-  def ensure_zip!
+  def find_or_create_zip!
     if File.exist?(file_path)
       raise "zip already exists, but size (#{total_part_size}) is smaller than the moab version size (#{moab_version_size})!" unless zip_size_ok?
       FileUtils.touch(file_path)

--- a/app/models/druid_version_zip.rb
+++ b/app/models/druid_version_zip.rb
@@ -27,6 +27,19 @@ class DruidVersionZip
     @base_key ||= s3_key.sub(/.zip\z/, '')
   end
 
+  # Checks to see whether a zip file already exists for this druid-version.  If it does, just touch the
+  # file to refresh atime and mtime, so the zip cache cleaning cron job doesn't see it as stale.  If it doesn't,
+  # create it.
+  # @raise [StandardError] if there's a zip file for this druid-version, but it looks too small to be complete.
+  def ensure_zip!
+    if File.exist?(file_path)
+      raise "zip already exists, but size (#{total_part_size}) is smaller than the moab version size (#{moab_version_size})!" unless zip_size_ok?
+      FileUtils.touch(file_path)
+    else
+      create_zip!
+    end
+  end
+
   # Creates a zip of Druid-Version content.
   # Changes directory so that the storage root (and druid tree) are not part of
   # the archival directory structure, just the object, e.g. starting at 'ab123cd4567/...' directory,
@@ -146,6 +159,15 @@ class DruidVersionZip
     @zip_storage ||= Pathname.new(Settings.zip_storage)
   end
 
+  def zip_size_ok?
+    total_part_size > moab_version_size
+  end
+
+  # @return [String] the option included with "zip -s"
+  def zip_split_size
+    '10g'
+  end
+
   private
 
   # Throws an error if any of the files in the moab are not yet readable.  For example due to
@@ -156,10 +178,6 @@ class DruidVersionZip
   # @raise [Errno::EACCES, Errno::EIO, Errno::ENOENT, Errno::ESTALE, ?] if it is not possible to stat one or more files in the Moab
   def check_moab_version_readability!
     moab_version_files.map { |f| File.stat(f) }
-  end
-
-  def zip_size_ok?
-    total_part_size > moab_version_size
   end
 
   def cleanup_zip_parts!
@@ -181,6 +199,7 @@ class DruidVersionZip
   end
 
   def moab_version_files
+    raise unless File.exist?(moab_version_path)
     Dir
       .glob("#{moab_version_path}/**/*")
       .select { |path| File.file?(path) }
@@ -195,11 +214,6 @@ class DruidVersionZip
     end
     return match[1] if match && match[1].present?
     raise 'No version info matched from `zip -v` ouptut'
-  end
-
-  # @return [String] the option included with "zip -s"
-  def zip_split_size
-    '10g'
   end
 
   def zip_version_regexp

--- a/spec/jobs/zipmaker_job_spec.rb
+++ b/spec/jobs/zipmaker_job_spec.rb
@@ -63,6 +63,19 @@ describe ZipmakerJob, type: :job do
     end
   end
 
+  context 'a supsiciously small zip already exists in storage' do
+    let(:version) { 1 }
+
+    it 'raises an informative error' do
+      expect(File).to exist(zip_path)
+      expect(druid_version_zip).not_to receive(:create_zip!)
+
+      expect do
+        described_class.perform_now(druid, version, moab_replication_storage_location)
+      end.to raise_error(RuntimeError, 'zip already exists, but size (3) is smaller than the moab version size (1928387)!')
+    end
+  end
+
   context 'zip is not yet in zip storage' do
     let(:version) { 3 }
 

--- a/spec/jobs/zipmaker_job_spec.rb
+++ b/spec/jobs/zipmaker_job_spec.rb
@@ -5,43 +5,61 @@ require 'rails_helper'
 describe ZipmakerJob, type: :job do
   let(:druid) { 'bj102hs9687' }
   let(:dvz_part) { instance_double(DruidVersionZipPart, metadata: { fake: 1 }) }
-  let(:version) { 1 }
+  let(:version) { 3 }
   let(:zip_path) { "spec/fixtures/zip_storage/bj/102/hs/9687/#{druid}#{format('.v%04d.zip', version)}" }
   let(:druid_version_zip) { DruidVersionZip.new(druid, version, moab_replication_storage_location) }
-  let(:moab_replication_storage_location) { '/path/to/moab' }
+  let(:moab_replication_storage_location) { 'spec/fixtures/storage_root01/sdr2objects' }
 
   before do
     allow(PlexerJob).to receive(:perform_later).with(any_args)
-    allow(Settings).to receive(:zip_storage).and_return('spec/fixtures/zip_storage')
+    allow(Settings).to receive(:zip_storage).and_return(Rails.root.join('spec', 'fixtures', 'zip_storage'))
     allow(DruidVersionZip).to receive(:new).with(druid, version, moab_replication_storage_location).and_return(druid_version_zip)
   end
 
+  after do
+    FileUtils.rm_rf(File.join(Settings.zip_storage, 'bj/102/hs/9687/bj102hs9687.v0003.zip'))
+    FileUtils.rm_rf(File.join(Settings.zip_storage, 'bj/102/hs/9687/bj102hs9687.v0003.zip.md5'))
+  end
+
   it 'invokes PlexerJob (single part zip)' do
-    expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bj/102/hs/9687/bj102hs9687.v0001.zip', Hash)
+    expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bj/102/hs/9687/bj102hs9687.v0003.zip', Hash)
     described_class.perform_now(druid, version, moab_replication_storage_location)
   end
 
-  it 'handles segmented zips, invokes PlexerJob per part' do
-    allow(DruidVersionZipPart).to receive(:new).and_return(dvz_part)
-    allow(druid_version_zip).to receive(:part_keys).and_return(
-      [
-        'bj/102/hs/9687/bj102hs9687.v0001.zip',
-        'bj/102/hs/9687/bj102hs9687.v0001.z01',
-        'bj/102/hs/9687/bj102hs9687.v0001.z02'
-      ]
-    )
-    expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bj/102/hs/9687/bj102hs9687.v0001.zip', Hash)
-    expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bj/102/hs/9687/bj102hs9687.v0001.z01', Hash)
-    expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bj/102/hs/9687/bj102hs9687.v0001.z02', Hash)
-    described_class.perform_now(druid, version, moab_replication_storage_location)
+  context 'the moab version to be archived is bigger than the zip split size' do
+    let(:druid) { 'bz514sm9647' }
+    let(:version) { 1 }
+
+    before { allow(druid_version_zip).to receive(:zip_split_size).and_return('64k') }
+
+    after { FileUtils.rm_rf(File.join(Settings.zip_storage, 'bz/514/sm/9647')) }
+
+    it 'handles segmented zips, invokes PlexerJob per part' do
+      # v1 of bz514sm9647 is 232kB, so we'd expect 4 segments if we split at 64k
+      expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.zip', Hash)
+      expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.z01', Hash)
+      expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.z02', Hash)
+      expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.z03', Hash)
+      described_class.perform_now(druid, version, moab_replication_storage_location)
+    end
   end
 
-  context 'zip already exists in zip storage' do
+  context 'a reasonably sized zip already exists in zip storage' do
+    before { druid_version_zip.create_zip! }
+
     it 'does not create a zip, but touches the existing one' do
       expect(File).to exist(zip_path)
-      expect(FileUtils).to receive(:touch).with(druid_version_zip.file_path)
       expect(druid_version_zip).not_to receive(:create_zip!)
-      described_class.perform_now(druid, version, moab_replication_storage_location)
+
+      expect do
+        described_class.perform_now(druid, version, moab_replication_storage_location)
+      end.to(
+        (change {
+          File.stat(druid_version_zip.file_path).atime
+        }).and(change {
+          File.stat(druid_version_zip.file_path).mtime
+        })
+      )
     end
   end
 

--- a/spec/models/druid_version_zip_spec.rb
+++ b/spec/models/druid_version_zip_spec.rb
@@ -76,6 +76,7 @@ describe DruidVersionZip do
       after { FileUtils.rm_rf('/tmp/bj') } # cleanup
 
       it 'updates atime and mtime on the zip file that is already there' do
+        sleep(0.1) # sorta hate this, but sleep for a 1/10 s, to give a moment before checking atime/mtime (to prevent flappy test in CI).
         expect { dvz.find_or_create_zip! }.to(
           (change {
             File.stat(dvz.file_path).atime

--- a/spec/models/druid_version_zip_spec.rb
+++ b/spec/models/druid_version_zip_spec.rb
@@ -52,7 +52,7 @@ describe DruidVersionZip do
     end
   end
 
-  describe '#ensure_zip!' do
+  describe '#find_or_create_zip!' do
     let(:dvz) { described_class.new(druid, version, 'spec/fixtures/storage_root01/sdr2objects') }
 
     context 'there is a zip file already made, but it looks too small' do
@@ -62,7 +62,9 @@ describe DruidVersionZip do
       end
 
       it 'raises an error indicating that the file in the zip temp space looks too small' do
-        expect { dvz.ensure_zip! }.to raise_error(RuntimeError, 'zip already exists, but size (80) is smaller than the moab version size (1928387)!')
+        expect {
+          dvz.find_or_create_zip!
+        }.to raise_error(RuntimeError, 'zip already exists, but size (80) is smaller than the moab version size (1928387)!')
       end
     end
 
@@ -74,7 +76,7 @@ describe DruidVersionZip do
       after { FileUtils.rm_rf('/tmp/bj') } # cleanup
 
       it 'updates atime and mtime on the zip file that is already there' do
-        expect { dvz.ensure_zip! }.to(
+        expect { dvz.find_or_create_zip! }.to(
           (change {
             File.stat(dvz.file_path).atime
           }).and(change {
@@ -85,7 +87,7 @@ describe DruidVersionZip do
 
       it 'does not attempt to re-create the zip file' do
         expect(dvz).not_to receive(:create_zip!)
-        dvz.ensure_zip!
+        dvz.find_or_create_zip!
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

closes #1642

builds on #1644 (hence the non-master base branch, since that's already been approved)

First commit does some test improvement without touching the app code, hopefully making the modified tests more illustrative, more realistic, and less likely to break in the face of an implementation change that doesn't introduce regressions. (https://github.com/sul-dlss/preservation_catalog/commit/c7f064780040eaf41587a7993107388d60b9fac4 -- to make this easier to review, i pushed this commit as a separate branch to show that it passed CI on its own)

Second commit is the change that the first commit paves the way for, and is the functionality asked for by #1642 (I went with the "just raise" approach).  Third commit has two new tests to show that the new check does what it's supposed to, and hopefully the lack of change to existing tests (compared to the first commit) gives some confidence that no regressions were introduced.

Once this is merged, we can delete [zipmaker-test-improvements](https://github.com/sul-dlss/preservation_catalog/compare/cleanup-bad-archive-zips...zipmaker-test-improvements?expand=1), since this PR includes that branch's commit.

## How was this change tested?

- [x] unit test changes as described above 
- [ ] will deploy to stage and run infra integration tests


## Which documentation and/or configurations were updated?

if this gets merged, we can simplify https://github.com/sul-dlss/preservation_catalog/wiki/Investigating-a-failed-zipmaker-job/6f2d65706ec1c963ecd62ee8e82ec25f54c65999 to indicate that any failed `zipmaker` job is retriable without worry, and if it fails again with a size check error up front, use the advice that's already there for cleanup.