### PR TITLE
Use dlss-capistrano to manage resque-pool tasks 

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -13,8 +13,8 @@ require "capistrano/rails/migrations"
 require "capistrano/passenger"
 require "capistrano/honeybadger"
 require "dlss/capistrano"
+require "dlss/capistrano/resque_pool"
 require 'whenever/capistrano'
-require 'capistrano-resque-pool'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -51,5 +51,4 @@ group :deploy do
   gem 'capistrano-rails'
   gem 'capistrano-passenger'
   gem 'dlss-capistrano'
-  gem 'capistrano-resque-pool'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,9 +100,6 @@ GEM
     capistrano-rails (1.6.1)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-resque-pool (0.2.0)
-      capistrano
-      resque-pool
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
     cocina-models (0.42.1)
@@ -130,7 +127,7 @@ GEM
     deprecation (1.0.0)
       activesupport
     diff-lcs (1.4.4)
-    dlss-capistrano (3.9.0)
+    dlss-capistrano (3.10.0)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key
@@ -416,7 +413,6 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.17)
   capistrano-passenger
   capistrano-rails
-  capistrano-resque-pool
   committee
   config
   dlss-capistrano

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -20,7 +20,7 @@ set :deploy_to, "/opt/app/pres/#{fetch(:application)}"
 # set :pty, true
 
 # Default value for :linked_files is []
-append :linked_files, 'config/database.yml', 'config/resque.yml', 'config/resque-pool.yml'
+append :linked_files, 'config/database.yml', 'config/resque.yml', 'config/resque-pool.yml', 'tmp/resque-pool.lock'
 
 # Default value for linked_dirs is []
 append :linked_dirs, 'log', 'config/settings', 'tmp/pids'
@@ -41,10 +41,7 @@ set :resque_server_roles, :resque
 
 # update shared_configs before db seed
 before 'deploy:migrate', 'shared_configs:update'
-
 after 'deploy:migrate', 'db_seed'
-
-after 'deploy:restart', 'resque:pool:hot_swap'
 
 desc 'Run rake db:seed'
 task :db_seed do


### PR DESCRIPTION
## Why was this change made?

This replaces `capistrano-resque-pool` and works as expected with a hot-swappable pool.

Also includes:

* Store resque-pool lockfile in shared dir
  * this allows the `resque:pool:hot_swap` capistrano task to do what we expect it to do.

## How was this change tested?

in prescat-qa

## Which documentation and/or configurations were updated?

None

