### PR TITLE
manual bundle update to force getting new deps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.55.0)
+    cocina-models (0.56.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -138,9 +138,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.5)
-    dor-services-client (6.27.0)
+    dor-services-client (6.30.1)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.55.0)
+      cocina-models (~> 0.56.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)


### PR DESCRIPTION
## Why was this change made?

force updating to latest cocina-models and dor-services-client (didn't happen with weekly updates, for whatever reason)

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



