### PR TITLE
log to event service when all zip parts for a moab version have been replicated to one cloud endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,7 +59,7 @@ RSpec/MessageSpies:
   Enabled: false
 
 RSpec/MultipleExpectations:
-  Max: 8
+  Max: 12
 
 RSpec/NamedSubject:
   Enabled: false

--- a/app/jobs/results_recorder_job.rb
+++ b/app/jobs/results_recorder_job.rb
@@ -27,6 +27,10 @@ class ResultsRecorderJob < ApplicationJob
   def perform(druid, version, s3_part_key, delivery_class) # rubocop:disable Lint/UnusedMethodArgument used as job.arguments.fourth in before_perform
     part = zip_part!(s3_part_key)
     part.ok!
+
+    # log to event service if this part upload is the last one for the endpoint
+    create_zmv_replicated_event(druid) if zmv.reload.all_parts_replicated?
+
     # only publish result if all of the parts replicated for all zip_endpoints
     return unless zmvs.reload.all?(&:all_parts_replicated?)
 
@@ -58,5 +62,23 @@ class ResultsRecorderJob < ApplicationJob
     # Example: RabbitMQ using `connection` from the gem "Bunny":
     # connection.create_channel.fanout('replication.results').publish(message)
     Resque.redis.redis.lpush('replication.results', message)
+  end
+
+  def create_zmv_replicated_event(druid)
+    parts_info = zmv.zip_parts.order(:suffix).map do |part|
+      { s3_key: part.s3_key, size: part.size, md5: part.md5 }
+    end
+
+    events_client = Dor::Services::Client.object("druid:#{druid}").events
+    events_client.create(
+      type: 'druid_version_replicated',
+      data: {
+        host: Socket.gethostname,
+        invoked_by: 'preservation-catalog',
+        version: zmv.version,
+        endpoint_name: zmv.zip_endpoint.endpoint_name,
+        parts_info: parts_info
+      }
+    )
   end
 end

--- a/app/jobs/results_recorder_job.rb
+++ b/app/jobs/results_recorder_job.rb
@@ -24,7 +24,7 @@ class ResultsRecorderJob < ApplicationJob
   # @param [Integer] version
   # @param [String] s3_part_key
   # @param [String] delivery_class Name of the worker class that performed delivery
-  def perform(druid, version, s3_part_key, _delivery_class)
+  def perform(druid, version, s3_part_key, delivery_class) # rubocop:disable Lint/UnusedMethodArgument used as job.arguments.fourth in before_perform
     part = zip_part!(s3_part_key)
     part.ok!
     # only publish result if all of the parts replicated for all zip_endpoints

--- a/app/models/zipped_moab_version.rb
+++ b/app/models/zipped_moab_version.rb
@@ -32,6 +32,9 @@ class ZippedMoabVersion < ApplicationRecord
   end
 
   def all_parts_replicated?
+    # the assumption is that all of the database part records are created at once,
+    # initialized to 'unreplicated', as soon as the (possibly multi-part) zip file
+    # has been created and completely written to disk.  see DruidVersionZip.
     zip_parts.count.positive? && zip_parts.all?(&:ok?)
   end
 end

--- a/db/README.md
+++ b/db/README.md
@@ -7,7 +7,7 @@ _Please keep this up to date as the schema changes!_
 
 To generate the updated ER diagram
 * Make sure the `db` container is running, and that the `development` database has all migrations applied (`bin/rails db:create db:migrate`).
-* Run `docker-compose run gen_er_diagram` from the project root.
+* Run `docker-compose run --rm gen_er_diagram` from the project root.
 * Commit the updated copy of `db/schema_er_diagram.svg`.
 
 ###### Key:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -77,8 +77,8 @@ ActiveRecord::Schema.define(version: 2020_06_29_232757) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "preservation_policy_id", null: false
-    t.boolean "robot_versioning_allowed", default: true, null: false
     t.datetime "last_archive_audit"
+    t.boolean "robot_versioning_allowed", default: true, null: false
     t.index ["created_at"], name: "index_preserved_objects_on_created_at"
     t.index ["druid"], name: "index_preserved_objects_on_druid", unique: true
     t.index ["last_archive_audit"], name: "index_preserved_objects_on_last_archive_audit"

--- a/spec/factories/zip_parts.rb
+++ b/spec/factories/zip_parts.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :zip_part do
     md5 { '00236a2ae558018ed13b5222ef1bd977' }
-    create_info { 'ok' }
+    create_info { { zip_cmd: 'zip some args', zip_version: '3.14' } }
     parts_count { 1 }
     size { 1234 }
     status { 'unreplicated' }

--- a/spec/jobs/results_recorder_job_spec.rb
+++ b/spec/jobs/results_recorder_job_spec.rb
@@ -11,25 +11,75 @@ describe ResultsRecorderJob, type: :job do
   let(:zip_endpoint2) { zmv2.zip_endpoint }
   let(:zip_part_attributes) { [attributes_for(:zip_part)] }
   let(:druid_version_zip) { DruidVersionZip.new(druid, zmv.version) }
+  let(:events_client) { instance_double(Dor::Services::Client::Events, create: nil) }
 
   before do
     # creating the CompleteMoab triggers associated ZippedMoabVersion creation via AR hooks
     create(:complete_moab, preserved_object: preserved_object, version: preserved_object.current_version)
     zmv.zip_parts.create(zip_part_attributes)
     zmv2.zip_parts.create(zip_part_attributes)
+    allow(Dor::Services::Client).to receive(:object).with("druid:#{druid}").and_return(
+      instance_double(Dor::Services::Client::Object, events: events_client)
+    )
+    allow(events_client).to receive(:create)
+    allow(Socket).to receive(:gethostname).and_return('fakehost')
   end
 
   it 'descends from ApplicationJob' do
     expect(described_class.new).to be_an(ApplicationJob)
   end
 
-  context 'when all parts for zip_endpoint are replicated' do
-    it 'sets part status to ok' do
-      expect {
-        described_class.perform_now(druid, zmv.version, druid_version_zip.s3_key, zip_endpoint.delivery_class.to_s)
-      }.to change {
-        zmv.zip_parts.first.status
-      }.from('unreplicated').to('ok')
+  it 'sets part status to ok' do
+    expect {
+      described_class.perform_now(druid, zmv.version, druid_version_zip.s3_key, zip_endpoint.delivery_class.to_s)
+    }.to change {
+      zmv.zip_parts.first.status
+    }.from('unreplicated').to('ok')
+  end
+
+  context 'when there are multiple parts' do
+    let(:zip_part_attributes) {
+      base_attrs = attributes_for(:zip_part, parts_count: 3)
+      [base_attrs.merge({ suffix: '.z01' }),
+       base_attrs.merge({ suffix: '.z02' }),
+       base_attrs.merge({ suffix: '.zip' })]
+    }
+
+    context 'when there are parts that are not yet replicated' do
+      before do
+        described_class.perform_now(druid, zmv.version, druid_version_zip.s3_key('.z01'), zip_endpoint.delivery_class.to_s)
+        described_class.perform_now(druid, zmv.version, druid_version_zip.s3_key('.zip'), zip_endpoint.delivery_class.to_s)
+      end
+
+      it 'does not emit an event to the event service' do
+        expect(events_client).not_to have_received(:create)
+      end
+    end
+
+    context 'when all parts for zip_endpoint are replicated' do
+      before do
+        described_class.perform_now(druid, zmv.version, druid_version_zip.s3_key('.z01'), zip_endpoint.delivery_class.to_s)
+        described_class.perform_now(druid, zmv.version, druid_version_zip.s3_key('.z02'), zip_endpoint.delivery_class.to_s)
+        described_class.perform_now(druid, zmv.version, druid_version_zip.s3_key('.zip'), zip_endpoint.delivery_class.to_s)
+      end
+
+      it 'emits an event to the event service with info about the replicated parts' do
+        event_info = {
+          type: 'druid_version_replicated',
+          data: {
+            host: 'fakehost',
+            invoked_by: 'preservation-catalog',
+            version: zmv.version,
+            endpoint_name: zmv.zip_endpoint.endpoint_name,
+            parts_info: [
+              { s3_key: druid_version_zip.s3_key('.z01'), size: 1234, md5: '00236a2ae558018ed13b5222ef1bd977' },
+              { s3_key: druid_version_zip.s3_key('.z02'), size: 1234, md5: '00236a2ae558018ed13b5222ef1bd977' },
+              { s3_key: druid_version_zip.s3_key('.zip'), size: 1234, md5: '00236a2ae558018ed13b5222ef1bd977' }
+            ]
+          }
+        }
+        expect(events_client).to have_received(:create).with(event_info)
+      end
     end
   end
 

--- a/spec/models/zip_endpoint_spec.rb
+++ b/spec/models/zip_endpoint_spec.rb
@@ -158,7 +158,6 @@ RSpec.describe ZipEndpoint, type: :model do
     describe '.which_need_archive_copy' do
       let(:names) { [other_ep1.endpoint_name, other_ep2.endpoint_name, zip_endpoint.endpoint_name] }
 
-      # rubocop:disable RSpec/MultipleExpectations
       it "returns the zip endpoints which should have a complete moab for the druid/version, but which don't yet" do
         expect(described_class.which_need_archive_copy(druid, version).pluck(:endpoint_name).sort).to eq names
         expect(described_class.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name).sort).to eq names
@@ -177,7 +176,6 @@ RSpec.describe ZipEndpoint, type: :model do
         expect(described_class.which_need_archive_copy(other_druid, version).pluck(:endpoint_name).sort).to eq names
         expect(described_class.which_need_archive_copy(other_druid, version - 1).pluck(:endpoint_name).sort).to eq %w[ibm_us_south zip-endpoint]
       end
-      # rubocop:enable RSpec/MultipleExpectations
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

closes #1685 
ref https://github.com/sul-dlss/infrastructure-integration-test/issues/249

## How was this change tested?

* unit tests
* deploy to stage: run `create_preassembly_image_spec.rb` from infra integration test suite, look for replication event on argo detail page for item that was created (item should have two versions, stage has 3 cloud endpoints, so there should be 6 events)

random housekeeping and preparatory refactoring in the first commit.

in case it's helpful, here's the diagram of the replication pipeline:  https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md

## Which documentation and/or configurations were updated?

a couple comments, a bit of inline rubocop config

