### PR TITLE
ValidateMoabJob added 

### DIFF
--- a/app/jobs/validate_moab_job.rb
+++ b/app/jobs/validate_moab_job.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+# Confirm checksums for one Moab object on disk (not in database)
+class ValidateMoabJob < ApplicationJob
+  queue_as :validate_moab
+
+  before_enqueue do |job|
+    err_msg = 'Druid param required, with druid prefix and without alpha chars aeilou'
+    raise ArgumentError, err_msg unless DruidTools::Druid.valid?(job.arguments.first, true)
+  end
+
+  attr :druid
+
+  # @param [String] druid of Moab on disk to be checksum validated
+  def perform(druid)
+    @druid = druid
+    start = Time.zone.now
+    log_started
+
+    # TODO: what if we lose connectivity while it's running in resque
+    errors = validate
+    if errors.empty?
+      log_success(Time.zone.now - start)
+    else
+      log_failure(errors)
+    end
+  rescue StandardError => e
+    log_failure(e.inspect)
+  end
+
+  private
+
+  # validate checksums of a Moab
+  # rubocop:disable Metrics/AbcSize
+  def validate
+    errors = []
+    structural_validator = Stanford::StorageObjectValidator.new(moab)
+    structural_errors = structural_validator.validation_errors # Returns an array of hashes with error codes => messages
+    errors << structural_errors unless structural_errors.empty?
+
+    moab.version_list.each do |version|
+      # ensure all files in signatureCatalog.xml exist
+      errors << verification_errors(version.verify_signature_catalog)
+
+      # verify_version_storage includes:
+      #   verify_manifest_inventory, (which computes and compares v000x/manifest file checksums)
+      #   verify_version_inventory,
+      #   verify_version_additions (which computes v000x/data file checksums and compares them with values in signatureCatalog.xml)
+      errors << verification_errors(version.verify_version_storage)
+    rescue Errno::ENOENT => e
+      errors << e.message # No such file or directory
+    rescue Nokogiri::XML::SyntaxError => e
+      errors << e
+    end
+
+    errors.flatten.compact
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  # turn the Moab::VerificationResult into something more easily consumed
+  def verification_errors(verification_result, entity = '', errors = [])
+    return if verification_result.verified
+
+    new_entity = entity.present? ? "#{entity}: #{verification_result.entity}" : verification_result.entity
+    errors << { new_entity => verification_result.details } if verification_result.details
+
+    verification_result.subentities.map do |child_verification_result|
+      verification_errors(child_verification_result, new_entity, errors)
+    end
+
+    errors
+  end
+
+  # @return [Moab::StorageObject] representation of a Moab's storage directory
+  def moab
+    @moab ||= begin
+      bare_druid = druid.split(':').last
+      Moab::StorageServices.find_storage_object(bare_druid)
+    end
+  end
+
+  def log_started
+    workflow_client.update_status(druid: druid,
+                                  workflow: 'preservationIngestWF',
+                                  process: 'validate-moab',
+                                  status: 'started',
+                                  note: "Started by preservation_catalog on #{Socket.gethostname}.")
+  end
+
+  def log_success(elapsed)
+    workflow_client.update_status(druid: druid,
+                                  workflow: 'preservationIngestWF',
+                                  process: 'validate-moab',
+                                  status: 'completed',
+                                  elapsed: elapsed,
+                                  note: "Completed by preservation_catalog on #{Socket.gethostname}.")
+  end
+
+  def log_failure(errors)
+    workflow_client.update_error_status(druid: druid,
+                                        workflow: 'preservationIngestWF',
+                                        process: 'validate-moab',
+                                        error_msg: "Problem with Moab validation run on #{Socket.gethostname}: #{errors}")
+  end
+
+  def workflow_client
+    @workflow_client ||=
+      begin
+        wf_log = Logger.new('log/workflow_service.log', 'weekly')
+        Dor::Workflow::Client.new(url: Settings.workflow_services_url, logger: wf_log)
+      end
+  end
+end

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -146,7 +146,7 @@ class AuditResults
     @reporters ||= [
       Reporters::LoggerReporter.new(logger),
       Reporters::HoneybadgerReporter.new,
-      Reporters::WorkflowReporter.new,
+      Reporters::AuditWorkflowReporter.new,
       Reporters::EventServiceReporter.new
     ].freeze
   end

--- a/app/services/reporters/audit_workflow_reporter.rb
+++ b/app/services/reporters/audit_workflow_reporter.rb
@@ -2,7 +2,7 @@
 
 module Reporters
   # Reports to DOR Workflow Service.
-  class WorkflowReporter < BaseReporter
+  class AuditWorkflowReporter < BaseReporter
     protected
 
     def handled_single_codes

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 RSpec.describe CatalogController, type: :controller do
-  let(:workflow_reporter) { instance_double(Reporters::WorkflowReporter, report_errors: nil) }
+  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
   let(:size) { 2342 }
   let(:ver) { 3 }
   let(:bare_druid) { 'bj102hs9687' }
@@ -15,7 +15,7 @@ RSpec.describe CatalogController, type: :controller do
 
   before do
     allow(described_class.logger).to receive(:info) # silence STDOUT chatter
-    allow(Reporters::WorkflowReporter).to receive(:new).and_return(workflow_reporter)
+    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
     allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
     allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)

--- a/spec/jobs/validate_moab_job_spec.rb
+++ b/spec/jobs/validate_moab_job_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ValidateMoabJob, type: :job do
+  let(:job) { described_class.new }
+  let(:bare_druid) { 'bj102hs9687' }
+  let(:druid) { "druid:#{bare_druid}" }
+  let(:path) { 'spec/fixtures/storage_root01/sdr2objects/bj/102/hs/9687/bj102hs9687' }
+  let(:moab) { Moab::StorageObject.new(druid, path) }
+  let(:workflow_client) { instance_double(Dor::Workflow::Client) }
+
+  before do
+    allow(Moab::StorageServices).to receive(:find_storage_object).with(bare_druid).and_return(moab)
+    allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)
+    allow(Settings).to receive(:workflow_services_url).and_return('http://workflow')
+    allow(workflow_client).to receive(:update_status).with(a_hash_including(druid: druid,
+                                                                            workflow: 'preservationIngestWF',
+                                                                            process: 'validate-moab')).at_least(:twice)
+    allow(workflow_client).to receive(:update_error_status)
+  end
+
+  describe '#perform' do
+    it 'tells workflow server check has started' do
+      job.perform(druid)
+      exp_str = 'Started by preservation_catalog on '
+      expect(workflow_client).to have_received(:update_status).with(druid: druid,
+                                                                    workflow: 'preservationIngestWF',
+                                                                    process: 'validate-moab',
+                                                                    status: 'started',
+                                                                    note: a_string_starting_with(exp_str))
+    end
+
+    it 'reports success to workflow server when no validation errors are found' do
+      allow(job).to receive(:validate).and_return([]) # test object bj102hs9687 has errors
+      job.perform(druid)
+      expect(workflow_client).to have_received(:update_status).twice
+      exp_str = 'Completed by preservation_catalog on '
+      expect(workflow_client).to have_received(:update_status).with(druid: druid,
+                                                                    workflow: 'preservationIngestWF',
+                                                                    process: 'validate-moab',
+                                                                    elapsed: a_value > 0,
+                                                                    status: 'completed',
+                                                                    note: a_string_starting_with(exp_str))
+    end
+
+    it 'reports failure to workflow server when there are validation errors' do
+      job.perform(druid) # test object bj102hs9687 has errors
+      validation_err_substring = 'druid:bj102hs9687-v0001: version_additions: file_differences'
+      expected_str_regex = /^Problem with Moab validation run on .*#{validation_err_substring}.*/
+      expect(workflow_client).to have_received(:update_error_status).with(druid: druid,
+                                                                          workflow: 'preservationIngestWF',
+                                                                          process: 'validate-moab',
+                                                                          error_msg: a_string_matching(expected_str_regex))
+    end
+
+    context 'when validation runs' do
+      let(:expected_validation_err_regex) { /^Problem with Moab validation run on .*#{error_regex_str}.*/ }
+
+      before do
+        job.perform(druid)
+      end
+
+      context 'when structural validation errors' do
+        let(:bare_druid) { 'zz111rr1111' }
+        let(:error_regex_str) { 'expected.*druid:zz111rr1111-v0001.*found.*druid:bj102hs9687-v0001' }
+
+        it 'sends error to workflow client' do
+          expect(workflow_client).to have_received(:update_error_status).with(druid: druid,
+                                                                              workflow: 'preservationIngestWF',
+                                                                              process: 'validate-moab',
+                                                                              error_msg: a_string_matching(expected_validation_err_regex))
+        end
+      end
+
+      context 'when it fails an existence check for a manifest file' do
+        let(:bare_druid) { 'zz102hs9687' }
+        let(:error_regex_str) { 'expected.*druid:zz102hs9687.*version_inventory.*' }
+
+        it 'sends error to workflow client' do
+          expect(workflow_client).to have_received(:update_error_status).with(druid: druid,
+                                                                              workflow: 'preservationIngestWF',
+                                                                              process: 'validate-moab',
+                                                                              error_msg: a_string_matching(expected_validation_err_regex))
+        end
+      end
+
+      context 'when it fails an existence check for a data file' do
+        let(:bare_druid) { 'dc048cw1328' }
+        let(:error_regex_str) { 'expected.*druid:dc048cw1328.*versionMetadata.xml.*' }
+
+        it 'sends error to workflow client' do
+          expect(workflow_client).to have_received(:update_error_status).with(druid: druid,
+                                                                              workflow: 'preservationIngestWF',
+                                                                              process: 'validate-moab',
+                                                                              error_msg: a_string_matching(expected_validation_err_regex))
+        end
+      end
+
+      context 'when it fails a checksum verification for a manifest file' do
+        let(:bare_druid) { 'zz925bx9565' }
+        let(:error_regex_str) { 'zz925bx9565-v0001: version_additions: file_differences.*signatures.*"md5"' }
+
+        it 'sends error to workflow client' do
+          expect(workflow_client).to have_received(:update_error_status).with(druid: druid,
+                                                                              workflow: 'preservationIngestWF',
+                                                                              process: 'validate-moab',
+                                                                              error_msg: a_string_matching(expected_validation_err_regex))
+        end
+      end
+
+      context 'when it fails a checksum verification for a data file' do
+        let(:bare_druid) { 'zz925bx9565' }
+        let(:error_regex_str) { 'zz925bx9565.*versionMetadata\.xml.*signatures.*md5' }
+
+        it 'sends error to workflow client' do
+          expect(workflow_client).to have_received(:update_error_status).with(druid: druid,
+                                                                              workflow: 'preservationIngestWF',
+                                                                              process: 'validate-moab',
+                                                                              error_msg: a_string_matching(expected_validation_err_regex))
+        end
+      end
+
+      context 'when error is raised' do
+        let(:expected_validation_err_regex) { /^Problem with Moab validation run on .*#{error_regex_str}.*/ }
+        let(:storage_object_validator) { Stanford::StorageObjectValidator.new(moab) }
+        let(:storage_object_version1) { Moab::StorageObjectVersion.new(moab, 1) }
+        let(:verification_result) { Moab::VerificationResult.new('ignore_here') }
+
+        before do
+          allow(Stanford::StorageObjectValidator).to receive(:new).and_return(storage_object_validator)
+          allow(storage_object_validator).to receive(:validation_errors).and_call_original
+          allow(verification_result).to receive(:verified).and_return(true)
+          allow(Moab::VerificationResult).to receive(:new).and_return(verification_result)
+          allow(moab).to receive(:version_list).and_return([storage_object_version1])
+        end
+
+        it 'no such file error is rescued and appears in err messages' do
+          allow(storage_object_version1).to receive(:verify_signature_catalog).and_raise(Errno::ENOENT, 'No such file or directory')
+          job.perform(druid)
+          expected_str_regex = /^Problem with Moab validation run on .*No such file or directory.*/
+          expect(workflow_client).to have_received(:update_error_status).with(druid: druid,
+                                                                              workflow: 'preservationIngestWF',
+                                                                              process: 'validate-moab',
+                                                                              error_msg: a_string_matching(expected_str_regex))
+        end
+
+        it 'Nokogiri::XML::SyntaxError is rescued and appears in err messages' do
+          allow(storage_object_version1).to receive(:verify_signature_catalog).and_raise(Nokogiri::XML::SyntaxError, 'gonzo')
+          job.perform(druid)
+          expected_str_regex = /^Problem with Moab validation run on .*Nokogiri::XML::SyntaxError: gonzo.*/
+          expect(workflow_client).to have_received(:update_error_status).with(druid: druid,
+                                                                              workflow: 'preservationIngestWF',
+                                                                              process: 'validate-moab',
+                                                                              error_msg: a_string_matching(expected_str_regex))
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/audit/catalog_to_moab_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe Audit::CatalogToMoab do
     'check_catalog_version\\(bj102hs9687, fixture_sr1\\)' \
     ' db CompleteMoab \\(created .*Z; last updated .*Z\\) exists but Moab not found'
   end
-  let(:workflow_reporter) { instance_double(Reporters::WorkflowReporter, report_errors: nil) }
+  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
   let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil) }
   let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil) }
 
   before do
-    allow(Reporters::WorkflowReporter).to receive(:new).and_return(workflow_reporter)
+    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
     allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
     allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)

--- a/spec/lib/audit/checksum_spec.rb
+++ b/spec/lib/audit/checksum_spec.rb
@@ -5,14 +5,14 @@ require 'rails_helper'
 RSpec.describe Audit::Checksum do
   let(:root_name) { 'fixture_sr1' }
   let(:logger_double) { instance_double(ActiveSupport::Logger, info: nil, add: nil, debug: nil, warn: nil) }
-  let(:workflow_reporter) { instance_double(Reporters::WorkflowReporter, report_errors: nil, report_completed: nil) }
+  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
   let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
   let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
 
   before do
     allow(described_class.logger).to receive(:info) # silence STDOUT chatter
-    allow(Reporters::WorkflowReporter).to receive(:new).and_return(workflow_reporter)
+    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
     allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
     allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Audit::MoabToCatalog do
     allow(Moab::StorageObject).to receive(:new).and_return(m)
     m
   end
-  let(:workflow_reporter) { instance_double(Reporters::WorkflowReporter, report_errors: nil, report_completed: nil) }
+  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
   let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
   let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
 
   before do
     allow(described_class.logger).to receive(:info) # silence STDOUT chatter
-    allow(Reporters::WorkflowReporter).to receive(:new).and_return(workflow_reporter)
+    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
     allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
     allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe AuditResults do
   end
 
   describe '#report_results' do
-    let(:workflow_reporter) { instance_double(Reporters::WorkflowReporter, report_errors: nil, report_completed: nil) }
+    let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
     let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
     let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
     let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
 
     before do
-      allow(Reporters::WorkflowReporter).to receive(:new).and_return(workflow_reporter)
+      allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
       allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
       allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
       allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
@@ -44,7 +44,7 @@ RSpec.describe AuditResults do
 
     it 'invokes the reporters' do
       audit_results.report_results
-      expect(workflow_reporter).to have_received(:report_errors)
+      expect(audit_workflow_reporter).to have_received(:report_errors)
         .with(druid: druid, version: actual_version, storage_area: ms_root, check_name: nil,
               results: [{ invalid_moab: "Invalid Moab, validation errors: [\"Version directory name not in 'v00xx' " \
           'format: original-v1", "Version v0005: No files present in manifest dir"]' }])
@@ -61,7 +61,7 @@ RSpec.describe AuditResults do
               results: [{ invalid_moab: "Invalid Moab, validation errors: [\"Version directory name not in 'v00xx' " \
           'format: original-v1", "Version v0005: No files present in manifest dir"]' }])
 
-      expect(workflow_reporter).to have_received(:report_completed)
+      expect(audit_workflow_reporter).to have_received(:report_completed)
         .with(druid: druid, version: actual_version, storage_area: ms_root, check_name: nil,
               result: { cm_status_changed: 'CompleteMoab status changed from invalid_checksum to ok' })
       expect(event_service_reporter).to have_received(:report_completed)

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ChecksumValidator do
   let(:moab_validator) { cv.send(:moab_validator) }
   let(:results) { instance_double(AuditResults, report_results: nil, check_name: nil, :actual_version= => nil) }
   let(:logger_double) { instance_double(ActiveSupport::Logger, info: nil, error: nil, add: nil) }
-  let(:workflow_reporter) { instance_double(Reporters::WorkflowReporter, report_errors: nil, report_completed: nil) }
+  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
   let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
   let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
@@ -22,7 +22,7 @@ RSpec.describe ChecksumValidator do
   before do
     allow(Audit::Checksum).to receive(:logger).and_return(logger_double) # silence log output
     allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
-    allow(Reporters::WorkflowReporter).to receive(:new).and_return(workflow_reporter)
+    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
     allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
   end
@@ -627,7 +627,7 @@ RSpec.describe ChecksumValidator do
 
     it 'has status changed to OK_STATUS and completes workflow' do
       comp_moab.invalid_moab!
-      expect(workflow_reporter).to receive(:report_completed)
+      expect(audit_workflow_reporter).to receive(:report_completed)
         .with(druid: druid,
               version: 3,
               check_name: 'validate_checksums',
@@ -638,7 +638,7 @@ RSpec.describe ChecksumValidator do
 
     it 'has status that does not change and does not complete workflow' do
       comp_moab.ok!
-      expect(workflow_reporter).not_to receive(:report_completed)
+      expect(audit_workflow_reporter).not_to receive(:report_completed)
       cv.validate_checksums
     end
 
@@ -650,7 +650,7 @@ RSpec.describe ChecksumValidator do
 
       it 'does not complete workflow' do
         comp_moab.ok!
-        expect(workflow_reporter).not_to receive(:report_completed)
+        expect(audit_workflow_reporter).not_to receive(:report_completed)
         cv.validate_checksums
       end
     end
@@ -665,7 +665,7 @@ RSpec.describe ChecksumValidator do
       end
 
       it 'does not complete workflow' do
-        expect(workflow_reporter).not_to receive(:report_completed)
+        expect(audit_workflow_reporter).not_to receive(:report_completed)
         cv.validate_checksums
       end
     end

--- a/spec/services/complete_moab_handler_check_exist_spec.rb
+++ b/spec/services/complete_moab_handler_check_exist_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'services/shared_examples_complete_moab_handler'
 
 RSpec.describe CompleteMoabHandler do
-  let(:workflow_reporter) { instance_double(Reporters::WorkflowReporter, report_errors: nil) }
+  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }
@@ -23,7 +23,7 @@ RSpec.describe CompleteMoabHandler do
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
 
   before do
-    allow(Reporters::WorkflowReporter).to receive(:new).and_return(workflow_reporter)
+    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
     allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
     allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)

--- a/spec/services/complete_moab_handler_confirm_version_spec.rb
+++ b/spec/services/complete_moab_handler_confirm_version_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'services/shared_examples_complete_moab_handler'
 
 RSpec.describe CompleteMoabHandler do
-  let(:workflow_reporter) { instance_double(Reporters::WorkflowReporter, report_errors: nil) }
+  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }
   let(:ms_root) { create(:moab_storage_root) }
@@ -14,7 +14,7 @@ RSpec.describe CompleteMoabHandler do
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
 
   before do
-    allow(Reporters::WorkflowReporter).to receive(:new).and_return(workflow_reporter)
+    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
     allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
     allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)

--- a/spec/services/complete_moab_handler_create_spec.rb
+++ b/spec/services/complete_moab_handler_create_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe CompleteMoabHandler do
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: storage_dir) }
   let(:complete_moab_handler) { described_class.new(druid, incoming_version, incoming_size, ms_root) }
   let(:exp_msg) { 'added object to db as it did not exist' }
-  let(:workflow_reporter) { instance_double(Reporters::WorkflowReporter, report_errors: nil) }
+  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
   let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil) }
   let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil) }
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
 
   before do
-    allow(Reporters::WorkflowReporter).to receive(:new).and_return(workflow_reporter)
+    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
     allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
     allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)

--- a/spec/services/complete_moab_handler_spec.rb
+++ b/spec/services/complete_moab_handler_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'services/shared_examples_complete_moab_handler'
 
 RSpec.describe CompleteMoabHandler do
-  let(:workflow_reporter) { instance_double(Reporters::WorkflowReporter, report_errors: nil) }
+  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }
@@ -22,7 +22,7 @@ RSpec.describe CompleteMoabHandler do
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
 
   before do
-    allow(Reporters::WorkflowReporter).to receive(:new).and_return(workflow_reporter)
+    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
     allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
     allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)

--- a/spec/services/complete_moab_handler_update_version_spec.rb
+++ b/spec/services/complete_moab_handler_update_version_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'services/shared_examples_complete_moab_handler'
 
 RSpec.describe CompleteMoabHandler do
-  let(:workflow_reporter) { instance_double(Reporters::WorkflowReporter, report_errors: nil, report_completed: nil) }
+  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
   let(:db_update_failed_prefix) { 'db update failed' }
   let(:default_prez_policy) { PreservationPolicy.default_policy }
   let(:druid) { 'ab123cd4567' }
@@ -23,7 +23,7 @@ RSpec.describe CompleteMoabHandler do
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
 
   before do
-    allow(Reporters::WorkflowReporter).to receive(:new).and_return(workflow_reporter)
+    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
     allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
     allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)

--- a/spec/services/reporters/audit_workflow_reporter_spec.rb
+++ b/spec/services/reporters/audit_workflow_reporter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Reporters::WorkflowReporter do
+RSpec.describe Reporters::AuditWorkflowReporter do
   let(:subject) { described_class.new }
 
   let(:client) { instance_double(Dor::Workflow::Client) }


### PR DESCRIPTION
## Why was this change made?

In order to avoid continuing with preservationIngestWF when a Moab hasn't been correctly written to Ceph, or isn't yet ready to be accessed by the replication steps, we want to add a validation of the on disk Moab, without reference to the preservation-catalog basis.

Closes #1697, #1698

Review the 2 commits separately;  the first is a rename for clarity;  the second accomplishes the goals of the tickets.

## How was this change tested?

- unit tests
- script that is similar 

## Which documentation and/or configurations were updated?



