### PR TITLE
add endpoint for new MoabValidation job

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -12,6 +12,13 @@ class ObjectsController < ApplicationController
     render json: PreservedObject.find_by!(druid: druid).to_json
   end
 
+  # queue a ValidateMoab job for a specific druid, typically called by a preservationIngestWF robot
+  # GET /v1/objects/:id/validate_moab
+  def validate_moab
+    ValidateMoabJob.perform_later(druid)
+    render(plain: 'ok', status: :ok)
+  end
+
   # return a specific file from the Moab
   # GET /v1/objects/:id/file?category=manifest&filepath=signatureCatalog.xml
   # useful params:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     resources :objects, only: %i[show] do
       member do
         get 'checksum'
+        get 'validate_moab'
         get 'file', format: false # no need to add extension to url
         get 'primary_moab_location'
         post 'content_diff'

--- a/openapi.yml
+++ b/openapi.yml
@@ -134,8 +134,6 @@ paths:
           description: Job queued
         '400':
           description: Bad request (e.g., malformed druid)
-        '404':
-          description: Object not found
       parameters:
         - name: id
           in: path

--- a/openapi.yml
+++ b/openapi.yml
@@ -124,6 +124,25 @@ paths:
           example: 'druid:bc123df4567.json'
           schema:
             $ref: '#/components/schemas/DruidWithOptionalFormat'
+  /v1/objects/{id}/validate_moab:
+    get:
+      tags:
+        - objects
+      summary: Starts a validate moab job, which does a validation of the on disk Moab, without reference to the preservation-catalog basis
+      responses:
+        '200':
+          description: Job queued
+        '400':
+          description: Bad request (e.g., malformed druid)
+        '404':
+          description: Object not found
+      parameters:
+        - name: id
+          in: path
+          required: true
+          example: 'druid:bc123df4567'
+          schema:
+            $ref: '#/components/schemas/Druid'
   /v1/objects/{id}/checksum.json:
     get:
       tags:

--- a/spec/requests/objects_controller_validate_moab_spec.rb
+++ b/spec/requests/objects_controller_validate_moab_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe ObjectsController, type: :request do
+  let(:prefixed_druid) { 'druid:bj102hs9687' }
+  let(:bare_druid) { 'bj102hs9687' }
+  let(:post_headers) { valid_auth_header.merge('Content-Type' => 'application/json') }
+
+  describe 'GET #validate_moab' do
+    context 'when valid druid passed in' do
+      before do
+        allow(ValidateMoabJob).to receive(:perform_later).and_return(true)
+      end
+
+      it 'queues the job and response ok' do
+        get validate_moab_object_url(prefixed_druid), headers: valid_auth_header
+        expect(response).to have_http_status(:ok)
+        expect(ValidateMoabJob).to have_received(:perform_later).with(bare_druid)
+      end
+
+      it 'queues the job and response ok when given a bare druid' do
+        get validate_moab_object_url(bare_druid), headers: valid_auth_header
+        expect(response).to have_http_status(:ok)
+        expect(ValidateMoabJob).to have_received(:perform_later).with(bare_druid)
+      end
+    end
+
+    context 'when bad parameter passed in' do
+      it 'returns a 400 response code' do
+        get validate_moab_object_url('not a druid'), headers: valid_auth_header
+        expect(response).to have_http_status(:bad_request)
+        expect(ValidateMoabJob).not_to receive(:perform_later)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Adds a new endpoint to start a MoabValidation job which can later be called from a new preservationWF robot

## How was this change tested?

Added new tests


## Which documentation and/or configurations were updated?



