### PR TITLE
add more rigorous okcomputer checks for pres disks

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -68,10 +68,8 @@ end
 # rubocop:enable Metrics/AbcSize
 
 Settings.storage_root_map.default.each do |name, location|
-  deposit_location = "#{location}/deposit"
-  sdrobjects_locations = "#{location}/sdr2objects"
-  OkComputer::Registry.register "feature-#{name}-deposit", DirectoryExistsCheck.new(deposit_location)
-  OkComputer::Registry.register "feature-#{name}-sdr2objects", DirectoryExistsCheck.new(sdrobjects_locations, Settings.minimum_subfolder_count)
+  sdrobjects_location = "#{location}/#{Settings.moab.storage_trunk}"
+  OkComputer::Registry.register "feature-#{name}-sdr2objects", DirectoryExistsCheck.new(sdrobjects_location, Settings.minimum_subfolder_count)
 end
 
 OkComputer::Registry.register 'ruby_version', OkComputer::RubyVersionCheck.new

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -35,31 +35,43 @@ class TablesHaveDataCheck < OkComputer::Check
 end
 OkComputer::Registry.register 'feature-tables-have-data', TablesHaveDataCheck.new
 
+# rubocop:disable Metrics/AbcSize
 # check that directory is accessible without consideration for writability
 class DirectoryExistsCheck < OkComputer::Check
-  attr_accessor :directory
+  attr_accessor :directory, :min_subfolder_count
 
-  def initialize(directory)
+  def initialize(directory, min_subfolder_count = nil)
     self.directory = directory
+    self.min_subfolder_count = min_subfolder_count
   end
 
   def check
-    stat = File.stat(directory) if File.exist?(directory)
-    if stat
-      if stat.directory?
-        mark_message "'#{directory}' is a reachable directory"
-      else
-        mark_message "'#{directory}' is not a directory."
-        mark_failure
-      end
-    else
+    unless File.exist? directory
       mark_message "Directory '#{directory}' does not exist."
+      mark_failure
+    end
+
+    unless File.directory? directory
+      mark_message "'#{directory}' is not a directory."
+      mark_failure
+    end
+
+    mark_message "'#{directory}' is a reachable directory"
+    if min_subfolder_count && Dir.entries(directory).size > min_subfolder_count
+      mark_message "'#{directory}' has the required minimum number of subfolders (#{min_subfolder_count})"
+    elsif min_subfolder_count
+      mark_message "'#{directory}' does not have the required minimum number of subfolders (#{min_subfolder_count})"
       mark_failure
     end
   end
 end
+# rubocop:enable Metrics/AbcSize
+
 Settings.storage_root_map.default.each do |name, location|
-  OkComputer::Registry.register "feature-#{name}", DirectoryExistsCheck.new(location)
+  deposit_location = "#{location}/deposit"
+  sdrobjects_locations = "#{location}/sdr2objects"
+  OkComputer::Registry.register "feature-#{name}-deposit", DirectoryExistsCheck.new(deposit_location)
+  OkComputer::Registry.register "feature-#{name}-sdr2objects", DirectoryExistsCheck.new(sdrobjects_locations, Settings.minimum_subfolder_count)
 end
 
 OkComputer::Registry.register 'ruby_version', OkComputer::RubyVersionCheck.new

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,6 +43,8 @@ replication:
   audit_should_backfill: false
 
 total_worker_count: 117 # for okcomputer endpoint
+minimum_subfolder_count: null # for okcomputer pres-cat mount check, verifies the storage_trunk has at least this many subfolders
+                             # NOTE: when null, no minimum check is performed, and this can be overriden per environment as needed
 
 api_jwt:
   hmac_secret: 'my$ecretK3y'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,8 +43,8 @@ replication:
   audit_should_backfill: false
 
 total_worker_count: 117 # for okcomputer endpoint
-minimum_subfolder_count: null # for okcomputer pres-cat mount check, verifies the storage_trunk has at least this many subfolders
-                             # NOTE: when null, no minimum check is performed, and this can be overriden per environment as needed
+minimum_subfolder_count: 1 # for okcomputer pres-cat mount check, verifies the storage_trunk has at least this many subfolders
+                           # NOTE: when null, no minimum check is performed, and this can be overriden per environment as needed
 
 api_jwt:
   hmac_secret: 'my$ecretK3y'

--- a/spec/lib/okcomputer_spec.rb
+++ b/spec/lib/okcomputer_spec.rb
@@ -30,6 +30,14 @@ describe 'OkComputer custom checks' do # rubocop:disable RSpec/DescribeClass
       expect(described_class.new(Settings.zip_storage)).to be_successful
     end
 
+    it 'successful for existing directory with minumum number of subfolders' do
+      expect(described_class.new(Rails.root, 5)).to be_successful
+    end
+
+    it 'fails for existing directory with fewer than the minumum number of subfolders' do
+      expect(described_class.new(Rails.root, 500)).not_to be_successful
+    end
+
     it 'fails for a file' do
       zip_path = 'spec/fixtures/zip_storage/bj/102/hs/9687/bj102hs9687.v0001.zip'
       expect(described_class.new(zip_path)).not_to be_successful


### PR DESCRIPTION
## Why was this change made?

Fixes #1712 -- add more thorough okcomputer checks for pres-cat disks

This now verifies:
1. That both the `sdr2objects` and `deposits` directories exist for each pres-cat disk and that they are directories
2. That the `sdr2objects` directory has a minimum number of subfolders contained in it (configurable in settings, but should be set at a threshold below the current numbers for all disks, which is currently 402 in production).  This could be a problem when a new disk is added since the count would then be lower for just the last disk.  At this point we may want to configure it per disk instead by adding some new settings.

## How was this change tested?

Updated the existing unit test.
Deployed to stage to validate

## Which documentation and/or configurations were updated?



