### PR TITLE
add 2 workers for validate-moab step by default

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -3,6 +3,7 @@
 #
 # These are queue names (like would be passed as QUEUES=... rake resque:work)
 # and the count of workers that should be spun up to service them.
+validate_moab: 2
 checksum_validation: 3
 zip_endpoint_events: 4
 "s3_us_east_1_delivery,s3_us_west_2_delivery": 6


### PR DESCRIPTION
## Why was this change made?

So there are workers to execute steps in the validate_moab queue.

May address #1719

## How was this change tested?


## Which documentation and/or configurations were updated?



