### PR TITLE
ValidateMoabJob only does data file checksums for latest version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,7 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Max: 4 # default: 3
   Exclude:
+    - 'spec/jobs/validate_moab_job_spec.rb'
     - 'spec/lib/audit/catalog_to_moab_spec.rb'
     - 'spec/lib/audit/moab_to_catalog_spec.rb'
     - 'spec/requests/objects_controller_content_diff_spec.rb'


### PR DESCRIPTION
## Why was this change made?

Fixes #1720

We only want to perform checksums for Moab content files for the latest version, not for all versions.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



