### PR TITLE
inline the logic provided by the resque-lock gem, drop the dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'pry-rails' # use pry as the rails console shell instead of IRB
 gem 'puma', '~> 5.3' # app server
 gem 'rails', '~> 6.1.0'
 gem 'resque', '~> 1.27'
-gem 'resque-lock' # deduplication of worker queue jobs
 gem 'resque-pool'
 gem 'whenever' # manage cron for audit checks
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,7 +344,6 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    resque-lock (1.1.0)
     resque-pool (0.7.1)
       rake (>= 10.0, < 14.0)
       resque (>= 1.22, < 3)
@@ -458,7 +457,6 @@ DEPENDENCIES
   rails (~> 6.1.0)
   rails-controller-testing
   resque (~> 1.27)
-  resque-lock
   resque-pool
   rspec-rails (~> 4.0)
   rubocop (~> 1.0)

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -51,7 +51,7 @@ class ApplicationJob < ActiveJob::Base
     # return true if we successfully acquired the lock
     # "Set key to hold string value if key does not exist" (otherwise no-op) -- https://redis.io/commands/setnx
     if Resque.redis.setnx(key, timeout)
-      Rails.logger.debug("acquired lock on #{key} (none existed)")
+      Rails.logger.info("acquired lock on #{key} (none existed)")
       return true
     end
 
@@ -59,7 +59,7 @@ class ApplicationJob < ActiveJob::Base
     # (we cannot acquire the lock during the timeout period)
     key_expires_at = Resque.redis.get(key).to_i
     if now <= key_expires_at
-      Rails.logger.debug("failed to acquire lock on #{key}, because it has not expired (#{now} <= #{key_expires_at})")
+      Rails.logger.info("failed to acquire lock on #{key}, because it has not expired (#{now} <= #{key_expires_at})")
       return false
     end
 
@@ -68,19 +68,19 @@ class ApplicationJob < ActiveJob::Base
     # "Atomically sets key to value and returns the old value stored at key." -- https://redis.io/commands/getset
     key_expires_at = Resque.redis.getset(key, timeout).to_i
     if now > key_expires_at
-      Rails.logger.debug("acquired lock on #{key} (old lock expired, #{now} > #{key_expires_at})")
+      Rails.logger.info("acquired lock on #{key} (old lock expired, #{now} > #{key_expires_at})")
       true
     else
-      Rails.logger.debug("failed to acquired lock on #{key} but updated expiry time to #{timeout} (#{now} <= #{key_expires_at})")
+      Rails.logger.info("failed to acquired lock on #{key} but updated expiry time to #{timeout} (#{now} <= #{key_expires_at})")
       false
     end
   end
 
   def self.clear_lock(*args)
     key = queue_lock_key(*args)
-    Rails.logger.debug("clearing lock for #{key}...")
+    Rails.logger.info("clearing lock for #{key}...")
     Resque.redis.del(key).tap do |del_result|
-      Rails.logger.debug("...cleared lock for #{key} (del_result=#{del_result})")
+      Rails.logger.info("...cleared lock for #{key} (del_result=#{del_result})")
     end
   end
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,18 +1,17 @@
 # frozen_string_literal: true
 
-require 'resque/plugins/lock'
-
 # Base job for this Application
-# @note We do queue locking via 2 methods from resque-lock in callbacks.
-# We abort on lock collision, preventing duplicate Jobs from enqueuing.
-# The key is specified by a 3rd `lock` method, by default based on job name and
-# serialized arguments (which works well for druid/version), but can be overridden
-# per job class, if needed.  Locks are stored in Redis w/ TTL date integers.
-# @see [resque-lock] https://github.com/defunkt/resque-lock/blob/master/lib/resque/plugins/lock.rb
-# @see [redis setnx] http://redis.io/commands/setnx
+#
+# @note We abort on lock collision, preventing duplicate Jobs from enqueuing.
+# The key is specified by the `queue_lock_key` class method, by default based on job name
+# and serialized arguments (which works well for druid/version), but can be overridden
+# per job class, if needed.  Locks are stored in Redis w/ expiry dates as integers.
+# @see [redis setnx] https://redis.io/commands/setnx (explains the reasoning behind the pattern)
+#
+# @note The queue locking mechanism was lifted from resque-lock. See end of file for
+# obligatory license info and rationale for inlining the gem's logic.
+# @see [resque-lock] https://github.com/defunkt/resque-lock/blob/e06fc2bd26f96f4f3fe893caa49c1cd42c0c9423/lib/resque/plugins/lock.rb
 class ApplicationJob < ActiveJob::Base
-  extend Resque::Plugins::Lock
-
   before_perform do |_job|
     ActiveRecord::Base.clear_active_connections!
   end
@@ -21,16 +20,69 @@ class ApplicationJob < ActiveJob::Base
     throw(:abort) unless job.class.before_enqueue_lock(*job.arguments)
   end
 
-  # Overriding so that changes in ActiveModel object don't result in new lock (which they do when just calling to_s).
-  def self.lock(*args)
-    new_args = args.map { |arg| arg.class.method_defined?(:to_global_id) ? arg.to_global_id.to_s : arg }
-    "lock:#{self.class.name}-#{new_args}"
+  around_perform do |job, block|
+    block.call
+  ensure
+    # Always clear the lock when we're done, even if there was an error.
+    job.class.clear_lock(*job.arguments)
   end
 
   # Override in subclass to tune per queue.
-  # def lock_timeout
-  #   3600
-  # end
+  # @return [Integer] lock_timeout in seconds, after which lock is no longer valid,
+  # regardless of whether the job that created the lock is still in queue or working.
+  def self.lock_timeout
+    # 1 hour is a reasonable default, because most jobs in this app will
+    # cause only minor trouble if re-executed too aggressively.
+    3600
+  end
+
+  # @return [String] the key for locking this job/payload combination, e.g. 'lock:MySpecificJob-bt821jk7040;1'
+  def self.queue_lock_key(*args)
+    # Changes in ActiveModel object don't result in new lock (which they do when just calling to_s).
+    queue_lock_args = args.map { |arg| arg.class.method_defined?(:to_global_id) ? arg.to_global_id.to_s : arg }
+    "lock:#{name}-#{queue_lock_args.join(';')}"
+  end
+
+  def self.before_enqueue_lock(*args) # rubocop:disable Metrics/AbcSize
+    key = queue_lock_key(*args)
+    now = Time.now.to_i
+    timeout = now + lock_timeout + 1
+
+    # return true if we successfully acquired the lock
+    # "Set key to hold string value if key does not exist" (otherwise no-op) -- https://redis.io/commands/setnx
+    if Resque.redis.setnx(key, timeout)
+      Rails.logger.debug("acquired lock on #{key} (none existed)")
+      return true
+    end
+
+    # see if the existing timeout is still valid and return false if it is
+    # (we cannot acquire the lock during the timeout period)
+    key_expires_at = Resque.redis.get(key).to_i
+    if now <= key_expires_at
+      Rails.logger.debug("failed to acquire lock on #{key}, because it has not expired (#{now} <= #{key_expires_at})")
+      return false
+    end
+
+    # otherwise set the timeout and ensure that no other worker has
+    # acquired the lock, possibly pushing out the expiry time further
+    # "Atomically sets key to value and returns the old value stored at key." -- https://redis.io/commands/getset
+    key_expires_at = Resque.redis.getset(key, timeout).to_i
+    if now > key_expires_at
+      Rails.logger.debug("acquired lock on #{key} (old lock expired, #{now} > #{key_expires_at})")
+      true
+    else
+      Rails.logger.debug("failed to acquired lock on #{key} but updated expiry time to #{timeout} (#{now} <= #{key_expires_at})")
+      false
+    end
+  end
+
+  def self.clear_lock(*args)
+    key = queue_lock_key(*args)
+    Rails.logger.debug("clearing lock for #{key}...")
+    Resque.redis.del(key).tap do |del_result|
+      Rails.logger.debug("...cleared lock for #{key} (del_result=#{del_result})")
+    end
+  end
 
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked
@@ -53,3 +105,35 @@ class ApplicationJob < ActiveJob::Base
     end
   end
 end
+
+# Q: Why copy the logic out of resque-lock instead of using the gem?
+# A: It's a small amount of (MIT licensed) code, the gem is and unmaintained (last updated in 2012),
+# and the lock cleanup hook wasn't getting invoked automatically in our jobs.  Inlining the code
+# reduces indirection and dependency (on both resque-lock and on Resque itself, since we use ActiveJob
+# hooks here instead of Resque hooks).
+#
+# logic for `before_enqueue` `around_perform`/`clear_lock`, `queue_lock_key`, `before_enqueue_lock`, and
+# `lock_timeout` from resque-lock.
+# Copyright (c) Chris Wanstrath, Ray Krueger
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# Software), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# https://github.com/defunkt/resque-lock/blob/e06fc2bd26f96f4f3fe893caa49c1cd42c0c9423/LICENSE
+#
+# This additional copyright statement applies solely to the code that was taken from resque-lock.

--- a/app/jobs/zip_part_job_base.rb
+++ b/app/jobs/zip_part_job_base.rb
@@ -11,8 +11,8 @@ class ZipPartJobBase < ApplicationJob
   end
 
   # Does queue locking on ONLY druid, version and part (as first 3 parameters)
-  def self.lock(*args)
-    "lock:#{name}-#{args.slice(0..2)}"
+  def self.queue_lock_key(*args)
+    "lock:#{name}-#{args.slice(0..2).join(';')}"
   end
 
   # A Job subclass must implement this method:

--- a/app/jobs/zipmaker_job.rb
+++ b/app/jobs/zipmaker_job.rb
@@ -15,8 +15,8 @@ class ZipmakerJob < ApplicationJob
   end
 
   # Does queue locking on ONLY druid and version (as first and second parameters)
-  def self.lock(*args)
-    "lock:#{name}-#{args.slice(0..1)}"
+  def self.queue_lock_key(*args)
+    "lock:#{name}-#{args.slice(0..1).join(';')}"
   end
 
   # @param [String] druid

--- a/openapi.yml
+++ b/openapi.yml
@@ -134,6 +134,8 @@ paths:
           description: Job queued
         '400':
           description: Bad request (e.g., malformed druid)
+        '423':
+          description: Failed to enqueue the job, likely because it is a duplicate of a job already waiting in the queue. Caller may retry later if appropriate.
       parameters:
         - name: id
           in: path

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -2,34 +2,79 @@
 
 require 'rails_helper'
 
+# A very simple job class that extends ApplicationJob to allow testing of basic queue locking behavior
+class RegularParameterJob < ApplicationJob
+  def self.lock_timeout
+    1
+  end
+
+  def perform(param_a, param_b, should_raise)
+    Rails.logger.info("simulate a running job to better test queue locking: (#{param_a}, #{param_b}, #{should_raise})")
+
+    raise 'oops' if should_raise
+  end
+end
+
 describe ApplicationJob, type: :job do
+  include ActiveJob::TestHelper
+
   around do |example|
-    old_adapter = described_class.queue_adapter
-    described_class.queue_adapter = :resque
+    old_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :resque
     example.run
-    described_class.queue_adapter = old_adapter
+    ActiveJob::Base.queue_adapter = old_adapter
   end
 
   it 'queues start empty' do
-    expect(Resque.info).to include(pending: 0)
+    expect(enqueued_jobs.size).to eq 0
   end
 
   context 'a subclass with message(s) queued' do
-    before do
-      allow(ZipmakerJob).to receive(:perform_later).and_call_original # undo rails_helper block
-      ZipmakerJob.perform_later('1234abc', 1)
-    end
-
     it 'does not add duplicate messages' do
-      expect { ZipmakerJob.perform_later('1234abc', 1) }
-        .not_to change { Resque.info[:pending] }.from(1)
+      RegularParameterJob.perform_later('1234abc', 1, false)
+      expect { RegularParameterJob.perform_later('1234abc', 1, false) }
+        .not_to change(enqueued_jobs, :size).from(1)
     end
 
     it 'but adds novel messages' do
-      expect { ZipmakerJob.perform_later('7890xyz', 1) } # different druid
-        .to change { Resque.info[:pending] }.from(1).to(2)
-      expect { ZipmakerJob.perform_later('1234abc', 2) } # same druid, different version
-        .to change { Resque.info[:pending] }.from(2).to(3)
+      RegularParameterJob.perform_later('1234abc', 1, false)
+      expect { RegularParameterJob.perform_later('7890xyz', 1, false) } # different druid
+        .to change(enqueued_jobs, :size).from(1).to(2)
+      expect { RegularParameterJob.perform_later('1234abc', 2, false) } # same druid, different version
+        .to change(enqueued_jobs, :size).from(2).to(3)
+    end
+
+    it 'cleans up its lock after succeeding so that the same job with the same params can be queued again immediately' do
+      RegularParameterJob.perform_later('4321cba', 1, false)
+
+      perform_enqueued_jobs
+
+      expect { RegularParameterJob.perform_later('4321cba', 1, false) }
+        .to change(enqueued_jobs, :size).from(0).to(1)
+    end
+
+    it 'cleans up its lock after failing so that the same job with the same params can be queued again immediately' do
+      RegularParameterJob.perform_later('0987zyx', 1, true)
+
+      begin
+        perform_enqueued_jobs
+      rescue StandardError
+        # In the app code we wouldn't deal with errors directly when a job raises, because the
+        # workers are picking them up and running them async (and then the adapter, Resque,
+        # does the appropriate error handling, e.g. moves the job to the appropriate failure queue, etc)
+      end
+
+      expect { RegularParameterJob.perform_later('0987zyx', 1, true) }
+        .to change(enqueued_jobs, :size).from(0).to(1)
+    end
+
+    it 'enqueues the job if it detects an existing lock that has expired' do
+      RegularParameterJob.perform_later('4321cba', 1, false)
+
+      sleep(RegularParameterJob.lock_timeout + 3) # lock timeout is very short, this should go well past it
+
+      expect { RegularParameterJob.perform_later('4321cba', 1, false) }
+        .to change(enqueued_jobs, :size).from(1).to(2)
     end
   end
 
@@ -38,24 +83,23 @@ describe ApplicationJob, type: :job do
     let(:cm2) { create :complete_moab }
 
     before do
-      allow(CatalogToMoabJob).to receive(:perform_later).and_call_original # undo rails_helper block
       CatalogToMoabJob.perform_later(cm)
     end
 
     it 'does not add duplicate messages' do
       expect { CatalogToMoabJob.perform_later(cm) }
-        .not_to change { Resque.info[:pending] }.from(1)
+        .not_to change(enqueued_jobs, :size).from(1)
 
       # Change complete_moab
       cm.size = 1000
 
       expect { CatalogToMoabJob.perform_later(cm) }
-        .not_to change { Resque.info[:pending] }.from(1)
+        .not_to change(enqueued_jobs, :size).from(1)
     end
 
     it 'but adds novel messages' do
       expect { CatalogToMoabJob.perform_later(cm2) }
-        .to change { Resque.info[:pending] }.from(1).to(2)
+        .to change(enqueued_jobs, :size).from(1).to(2)
     end
   end
 end

--- a/spec/requests/objects_controller_validate_moab_spec.rb
+++ b/spec/requests/objects_controller_validate_moab_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ObjectsController, type: :request do
   describe 'GET #validate_moab' do
     context 'when valid druid passed in' do
       before do
-        allow(ValidateMoabJob).to receive(:perform_later).and_return(true)
+        allow(ValidateMoabJob).to receive(:perform_later).and_return(ValidateMoabJob.new)
       end
 
       it 'queues the job and response ok' do
@@ -30,6 +30,29 @@ RSpec.describe ObjectsController, type: :request do
         get validate_moab_object_url('not a druid'), headers: valid_auth_header
         expect(response).to have_http_status(:bad_request)
         expect(ValidateMoabJob).not_to receive(:perform_later)
+      end
+    end
+
+    context 'when the caller tries to enqueue the job for a valid druid that is already in the queue' do
+      before do
+        # the first attempt to enqueue is successful and returns an instance of the job class,
+        # the second attempt fails and returns false (simulating an attempt to queue when the
+        # same job is already waiting to be worked)
+        allow(ValidateMoabJob).to receive(:perform_later).and_return(ValidateMoabJob.new, false)
+      end
+
+      it 'returns a 423 response code' do
+        get validate_moab_object_url(bare_druid), headers: valid_auth_header
+        # expect(ValidateMoabJob).to have_received(:perform_later).with(bare_druid)
+        expect(response).to have_http_status(:ok)
+
+        get validate_moab_object_url(prefixed_druid), headers: valid_auth_header
+        # expect(ValidateMoabJob).to have_received(:perform_later).with(bare_druid)
+        expect(response).to have_http_status(:locked)
+        expect(response.body).to include("Failed to enqueue ValidateMoabJob for #{bare_druid}")
+        expect(response.body).to include('The most likely cause is that the job was already enqueued')
+
+        expect(ValidateMoabJob).to have_received(:perform_later).with(bare_druid).exactly(2).times
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

* wire up lock cleanup so it's actually invoked (fixes https://github.com/sul-dlss/preservation_catalog/issues/1726)
* comments explaining locking behavior and providing necessary license info

closes #1726

## How was this change tested?

- [x] existing unit tests to help detect regressions
- [x] manual testing on stage (by enqueuing multiple copies of the same checksum validation job, some overlapping, some not)
- [x] the infra integration test suite, particularly `create_preassembly_image_spec.rb` (since its failure is what caused me to open #1726)
- [x] i'd like to add a unit test to `application_job_spec.rb` showing that the lock gets cleaned up by the newly inlined code when the job runs successfully
- [x] i'd like to add a unit test to `application_job_spec.rb` showing that the lock gets cleaned up by the newly inlined code even when the job errors out (had a little trouble with this because the error gets raised in the test code when the job is run, which is not what i'd expect for an async job, and not what happens when the job errors IRL)
- [x] a lock timeout related test would be nice
- [ ] a test to address the uncovered conditional that's resulting in the code coverage drop would be nice (to be fair, this is likely a very unusual race condition)

WIP until testing's all sorted out

bonus: have `ObjectsController#validate_moab` return an informative error to the caller in the unlikely event that it can't queue the job.

## Which documentation and/or configurations were updated?

comments in relevant code
