### PR TITLE
Add CatalogRemediator class to prune replication failures from catalog 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -323,3 +323,18 @@ Rails/I18nLocaleAssignment: # (new in 2.11)
   Enabled: true
 Rails/UnusedIgnoredColumns: # (new in 2.11)
   Enabled: true
+
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: true
+Lint/AmbiguousOperatorPrecedence: # new in 1.21
+  Enabled: true
+Lint/AmbiguousRange: # new in 1.19
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: true
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: true
+Rails/EagerEvaluationLogMessage: # new in 2.11
+  Enabled: false
+Rails/RedundantTravelBack: # new in 2.12
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'druid-tools' # for druid validation and druid-tree parsing
 gem 'moab-versioning' # work with Moab Objects
 
 group :development, :test do
+  gem 'rspec-rails', '~> 4.0'
   # Ruby static code analyzer https://rubocop.readthedocs.io/en/latest/
   gem 'rubocop', '~> 1.0'
   gem 'rubocop-rails'
@@ -40,7 +41,6 @@ end
 group :test do
   gem 'factory_bot_rails', '~> 4.0'
   gem 'rails-controller-testing'
-  gem 'rspec-rails', '~> 4.0'
   gem 'shoulda-matchers'
   # Codeclimate is not compatible with 0.18+. See https://github.com/codeclimate/test-reporter/issues/413
   gem 'simplecov', '~> 0.17.1'

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,7 @@ Rails.application.load_tasks
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
+# clear the default task injected by rspec
+task(:default).clear
+
 task default: [:rubocop, :spec]

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -115,13 +115,19 @@ class AuditResults
 
   def report_results
     # Report completed
-    completed_results = result_array.select { |result| status_changed_to_ok?(result) }
     report_completed(completed_results)
 
     # Report errors
-    error_results = result_array - completed_results
     report_errors(error_results)
     result_array
+  end
+
+  def completed_results
+    result_array.select(&result_ok?)
+  end
+
+  def error_results
+    result_array.reject(&result_ok?)
   end
 
   def contains_result_code?(code)
@@ -141,6 +147,10 @@ class AuditResults
   end
 
   private
+
+  def result_ok?
+    proc { |result| status_changed_to_ok?(result) }
+  end
 
   def reporters
     @reporters ||= [

--- a/app/services/audit_results.rb
+++ b/app/services/audit_results.rb
@@ -44,11 +44,11 @@ class AuditResults
 
   RESPONSE_CODE_TO_MESSAGES = {
     ACTUAL_VERS_GT_DB_OBJ => 'actual version (%{actual_version}) greater than ' \
-      '%{db_obj_name} db version (%{db_obj_version})',
+                             '%{db_obj_name} db version (%{db_obj_version})',
     ACTUAL_VERS_LT_DB_OBJ => 'actual version (%{actual_version}) less than ' \
-      '%{db_obj_name} db version (%{db_obj_version}); ERROR!',
+                             '%{db_obj_name} db version (%{db_obj_version}); ERROR!',
     CM_PO_VERSION_MISMATCH => 'CompleteMoab online Moab version %{cm_version} ' \
-      'does not match PreservedObject current_version %{po_version}',
+                              'does not match PreservedObject current_version %{po_version}',
     CM_STATUS_CHANGED => 'CompleteMoab status changed from %{old_status} to %{new_status}',
     CREATED_NEW_OBJECT => 'added object to db as it did not exist',
     DB_OBJ_ALREADY_EXISTS => '%{addl} db object already exists',
@@ -57,33 +57,33 @@ class AuditResults
     FILE_NOT_IN_MANIFEST => 'Moab file %{file_path} was not found in Moab manifest %{manifest_file_path}',
     FILE_NOT_IN_MOAB => '%{manifest_file_path} refers to file (%{file_path}) not found in Moab',
     FILE_NOT_IN_SIGNATURE_CATALOG => 'Moab file %{file_path} was not found in ' \
-      'Moab signature catalog %{signature_catalog_path}',
+                                     'Moab signature catalog %{signature_catalog_path}',
     INVALID_ARGUMENTS => 'encountered validation error(s): %{addl}',
     INVALID_MANIFEST => 'unable to parse %{manifest_file_path} in Moab',
     INVALID_MOAB => 'Invalid Moab, validation errors: %{addl}',
     MANIFEST_NOT_IN_MOAB => '%{manifest_file_path} not found in Moab',
     MOAB_CHECKSUM_VALID => 'checksum(s) match',
     MOAB_FILE_CHECKSUM_MISMATCH => 'checksums or size for %{file_path} version ' \
-      '%{version} do not match entry in latest signatureCatalog.xml.',
+                                   '%{version} do not match entry in latest signatureCatalog.xml.',
     MOAB_NOT_FOUND => 'db CompleteMoab (created %{db_created_at}; last updated ' \
-      '%{db_updated_at}) exists but Moab not found',
+                      '%{db_updated_at}) exists but Moab not found',
     SIGNATURE_CATALOG_NOT_IN_MOAB => '%{signature_catalog_path} not found in Moab',
     UNABLE_TO_CHECK_STATUS => 'unable to validate when CompleteMoab status is %{current_status}',
     UNEXPECTED_VERSION => 'actual version (%{actual_version}) has unexpected ' \
-      'relationship to %{db_obj_name} db version (%{db_obj_version}); ERROR!',
+                          'relationship to %{db_obj_name} db version (%{db_obj_version}); ERROR!',
     VERSION_MATCHES => 'actual version (%{actual_version}) matches %{addl} db version',
     ZIP_PART_CHECKSUM_MISMATCH => 'replicated md5 mismatch on %{endpoint_name}: ' \
-      "%{s3_key} catalog md5 (%{md5}) doesn't match the replicated md5 " \
-      '(%{replicated_checksum}) on %{bucket_name}',
+                                  "%{s3_key} catalog md5 (%{md5}) doesn't match the replicated md5 " \
+                                  '(%{replicated_checksum}) on %{bucket_name}',
     ZIP_PART_NOT_FOUND => 'replicated part not found on %{endpoint_name}: ' \
-      '%{s3_key} was not found on %{bucket_name}',
+                          '%{s3_key} was not found on %{bucket_name}',
     ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL => '%{version} on %{endpoint_name}: ' \
-      "ZippedMoabVersion stated parts count (%{db_count}) doesn't match actual " \
-      'number of zip parts rows (%{actual_count})',
+                                           "ZippedMoabVersion stated parts count (%{db_count}) doesn't match actual " \
+                                           'number of zip parts rows (%{actual_count})',
     ZIP_PARTS_COUNT_INCONSISTENCY => '%{version} on %{endpoint_name}: ' \
-      'ZippedMoabVersion has variation in child parts_counts: %{child_parts_counts}',
+                                     'ZippedMoabVersion has variation in child parts_counts: %{child_parts_counts}',
     ZIP_PARTS_NOT_ALL_REPLICATED => '%{version} on %{endpoint_name}: not all ' \
-      'ZippedMoabVersion parts are replicated yet: %{unreplicated_parts_list}',
+                                    'ZippedMoabVersion parts are replicated yet: %{unreplicated_parts_list}',
     ZIP_PARTS_NOT_CREATED => '%{version} on %{endpoint_name}: no zip_parts exist yet for this ZippedMoabVersion'
   }.freeze
 

--- a/app/services/catalog_remediator.rb
+++ b/app/services/catalog_remediator.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Remediates catalog entries, e.g., failed replication records
+class CatalogRemediator
+  def self.prune_replication_failures(druid:, version:)
+    new(druid: druid, version: version).prune_replication_failures
+  end
+
+  def initialize(druid:, version:)
+    @druid = druid
+    @version = version
+  end
+
+  def prune_replication_failures
+    zipped_moab_versions_with_errors.map do |zipped_moab_version, audit_results|
+      zip_parts = zipped_moab_version.zip_parts
+      Rails.logger.info(
+        "Replication failure error(s) found with #{druid} (v#{version}): #{audit_results.error_results}\n" \
+        "Destroying zip parts (#{zip_parts.pluck(:id)}) and zipped moab version (#{zipped_moab_version.id})"
+      )
+
+      ActiveRecordUtils.with_transaction_and_rescue(audit_results) do
+        # NOTE: The order here matters! ZipPart instances must be destroyed before the ZippedMoabVersion
+        zip_parts.destroy_all
+        zipped_moab_version.destroy
+      end
+
+      [zipped_moab_version.version, zipped_moab_version.zip_endpoint.endpoint_name]
+    end
+  end
+
+  private
+
+  attr_reader :druid, :version
+
+  delegate :check_child_zip_part_attributes, to: Audit::CatalogToArchive
+
+  def preserved_object
+    PreservedObject.find_by(druid: druid)
+  end
+
+  def zip_cache_expiry_timestamp
+    Settings.zip_cache_expiry_time.to_i.minutes.ago
+  end
+
+  def zipped_moab_versions_beyond_expiry
+    preserved_object.zipped_moab_versions.where(version: version, created_at: ..zip_cache_expiry_timestamp)
+  end
+
+  def zipped_moab_versions_with_errors
+    zipped_moab_versions_beyond_expiry.to_a.filter_map do |zipped_moab_version|
+      audit_results = audit_results_for(zipped_moab_version)
+      # If this check returns false, it indicates a lack of zip parts, in which
+      # case we still want to delete the ZMV, so short-circuit the rest of the
+      # block
+      next [zipped_moab_version, audit_results] unless check_child_zip_part_attributes(zipped_moab_version, audit_results)
+
+      endpoint_audit_class_for(zipped_moab_version).check_replicated_zipped_moab_version(zipped_moab_version, audit_results, true)
+      next if audit_results.error_results.empty?
+
+      [zipped_moab_version, audit_results]
+    end
+  end
+
+  def audit_results_for(zipped_moab_version)
+    AuditResults.new(druid, version, zipped_moab_version.zip_endpoint)
+  end
+
+  def endpoint_audit_class_for(zipped_moab_version)
+    zipped_moab_version.zip_endpoint.audit_class
+  end
+end

--- a/app/services/catalog_remediator.rb
+++ b/app/services/catalog_remediator.rb
@@ -19,7 +19,7 @@ class CatalogRemediator
         "Destroying zip parts (#{zip_parts.pluck(:id)}) and zipped moab version (#{zipped_moab_version.id})"
       )
 
-      ActiveRecordUtils.with_transaction_and_rescue(audit_results) do
+      ApplicationRecord.transaction do
         # NOTE: The order here matters! ZipPart instances must be destroyed before the ZippedMoabVersion
         zip_parts.destroy_all
         zipped_moab_version.destroy

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -3,6 +3,13 @@
 require 'csv'
 
 namespace :prescat do
+  desc 'Prune failed remediation records from catalog'
+  task :prune_failed_remediation, [:druid, :version] => :environment do |_task, args|
+    CatalogRemediator.prune_replication_failures(druid: args[:druid], version: args[:version]).each do |zmv_version, endpoint_name|
+      puts "pruned zipped moab version #{zmv_version} on #{endpoint_name}"
+    end
+  end
+
   namespace :cache_cleaner do
     desc 'Clean zip storage cache of empty directories'
     task empty_directories: :environment do

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -3,8 +3,8 @@
 require 'csv'
 
 namespace :prescat do
-  desc 'Prune failed remediation records from catalog'
-  task :prune_failed_remediation, [:druid, :version] => :environment do |_task, args|
+  desc 'Prune failed replication records from catalog'
+  task :prune_failed_replication, [:druid, :version] => :environment do |_task, args|
     CatalogRemediator.prune_replication_failures(druid: args[:druid], version: args[:version]).each do |zmv_version, endpoint_name|
       puts "pruned zipped moab version #{zmv_version} on #{endpoint_name}"
     end

--- a/spec/lib/audit/catalog_to_archive_spec.rb
+++ b/spec/lib/audit/catalog_to_archive_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Audit::CatalogToArchive do
     it 'logs the discrepancy' do
       described_class.check_child_zip_part_attributes(zmv, results)
       msg = "#{result_prefix}: ZippedMoabVersion stated parts count"\
-        " (3) doesn't match actual number of zip parts rows (2)"
+            " (3) doesn't match actual number of zip parts rows (2)"
       expect(results.result_array).to include(
         a_hash_including(AuditResults::ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL => msg)
       )

--- a/spec/lib/audit/catalog_to_moab_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Audit::CatalogToMoab do
   let(:events_client) { instance_double(Dor::Services::Client::Events) }
   let(:hb_exp_msg) do
     'check_catalog_version\\(bj102hs9687, fixture_sr1\\)' \
-    ' db CompleteMoab \\(created .*Z; last updated .*Z\\) exists but Moab not found'
+      ' db CompleteMoab \\(created .*Z; last updated .*Z\\) exists but Moab not found'
   end
   let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
@@ -382,7 +382,7 @@ RSpec.describe Audit::CatalogToMoab do
 
               it 'status_details updated' do
                 exp = exp_details_prefix + 'actual version: 4) Invalid Moab, validation errors: ["err msg"] && ' \
-                      "CompleteMoab status changed from #{orig_status} to invalid_moab"
+                                           "CompleteMoab status changed from #{orig_status} to invalid_moab"
                 expect(comp_moab.reload.status_details).to eq exp
               end
             end

--- a/spec/lib/preservation_catalog/shared_examples_s3_audit.rb
+++ b/spec/lib/preservation_catalog/shared_examples_s3_audit.rb
@@ -207,7 +207,7 @@ RSpec.shared_examples 's3 audit' do |provider_class, bucket_name, check_name, en
         described_class.check_replicated_zipped_moab_version(zmv, results)
         zmv.zip_parts.where(suffix: ['.zip', '.z01']).each do |part|
           msg = "replicated md5 mismatch on #{endpoint_name}: #{part.s3_key} catalog md5 (#{part.md5})"\
-            " doesn't match the replicated md5 (#{non_matching_md5}) on #{bucket_name}"
+                " doesn't match the replicated md5 (#{non_matching_md5}) on #{bucket_name}"
           expect(results.result_array).to include(a_hash_including(AuditResults::ZIP_PART_CHECKSUM_MISMATCH => msg))
         end
       end
@@ -306,7 +306,7 @@ RSpec.shared_examples 's3 audit' do |provider_class, bucket_name, check_name, en
       it 'logs the checksum mismatches' do
         part = zmv.zip_parts.second
         msg = "replicated md5 mismatch on #{endpoint_name}: #{part.s3_key} catalog md5 (#{part.md5}) "\
-          "doesn't match the replicated md5 (#{non_matching_md5}) on #{bucket_name}"
+              "doesn't match the replicated md5 (#{non_matching_md5}) on #{bucket_name}"
         described_class.check_replicated_zipped_moab_version(zmv, results)
         expect(results.result_array).to include(a_hash_including(AuditResults::ZIP_PART_CHECKSUM_MISMATCH => msg))
       end

--- a/spec/requests/objects_controller_primary_moab_spec.rb
+++ b/spec/requests/objects_controller_primary_moab_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ObjectsController, type: :request do
           get primary_moab_location_object_url(pres_obj.druid), headers: valid_auth_header
           expect(response).to have_http_status(:locked)
           expect(response.body).to include 'Cannot retrieve primary moab location because versioning ' \
-            "is locked for the preserved object with id #{pres_obj.druid}"
+                                           "is locked for the preserved object with id #{pres_obj.druid}"
         end
       end
     end

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -142,6 +142,35 @@ RSpec.describe AuditResults do
     end
   end
 
+  describe 'result array subsets' do
+    let(:result_code) { AuditResults::CM_STATUS_CHANGED }
+    let(:error_status_hash) { { old_status: 'invalid_checksum', new_status: 'invalid_moab' } }
+    let(:completed_status_hash) { { old_status: 'invalid_checksum', new_status: 'ok' } }
+
+    before do
+      audit_results.add_result(result_code, completed_status_hash)
+      audit_results.add_result(result_code, error_status_hash)
+    end
+
+    describe '#error_results' do
+      it 'returns only error results' do
+        expect(audit_results.error_results.count).to eq(1)
+        expect(audit_results.error_results).to include(
+          result_code => format(AuditResults::RESPONSE_CODE_TO_MESSAGES[result_code], error_status_hash)
+        )
+      end
+    end
+
+    describe '#completed_results' do
+      it 'returns only non-error results' do
+        expect(audit_results.completed_results.count).to eq(1)
+        expect(audit_results.completed_results).to include(
+          result_code => format(AuditResults::RESPONSE_CODE_TO_MESSAGES[result_code], completed_status_hash)
+        )
+      end
+    end
+  end
+
   describe '#status_changed_to_ok?' do
     it 'returns true if the new status is ok' do
       added_code = AuditResults::CM_STATUS_CHANGED

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -47,19 +47,19 @@ RSpec.describe AuditResults do
       expect(audit_workflow_reporter).to have_received(:report_errors)
         .with(druid: druid, version: actual_version, storage_area: ms_root, check_name: nil,
               results: [{ invalid_moab: "Invalid Moab, validation errors: [\"Version directory name not in 'v00xx' " \
-          'format: original-v1", "Version v0005: No files present in manifest dir"]' }])
+                                        'format: original-v1", "Version v0005: No files present in manifest dir"]' }])
       expect(event_service_reporter).to have_received(:report_errors)
         .with(druid: druid, version: actual_version, storage_area: ms_root, check_name: nil,
               results: [{ invalid_moab: "Invalid Moab, validation errors: [\"Version directory name not in 'v00xx' " \
-          'format: original-v1", "Version v0005: No files present in manifest dir"]' }])
+                                        'format: original-v1", "Version v0005: No files present in manifest dir"]' }])
       expect(honeybadger_reporter).to have_received(:report_errors)
         .with(druid: druid, version: actual_version, storage_area: ms_root, check_name: nil,
               results: [{ invalid_moab: "Invalid Moab, validation errors: [\"Version directory name not in 'v00xx' " \
-          'format: original-v1", "Version v0005: No files present in manifest dir"]' }])
+                                        'format: original-v1", "Version v0005: No files present in manifest dir"]' }])
       expect(logger_reporter).to have_received(:report_errors)
         .with(druid: druid, version: actual_version, storage_area: ms_root, check_name: nil,
               results: [{ invalid_moab: "Invalid Moab, validation errors: [\"Version directory name not in 'v00xx' " \
-          'format: original-v1", "Version v0005: No files present in manifest dir"]' }])
+                                        'format: original-v1", "Version v0005: No files present in manifest dir"]' }])
 
       expect(audit_workflow_reporter).to have_received(:report_completed)
         .with(druid: druid, version: actual_version, storage_area: ms_root, check_name: nil,

--- a/spec/services/catalog_remediator_spec.rb
+++ b/spec/services/catalog_remediator_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CatalogRemediator do
+  let(:fake_audit_results_no_errors) { instance_double(AuditResults, error_results: [], add_result: nil) }
+  let(:fake_audit_results_with_errors) { instance_double(AuditResults, error_results: [{ this_is: 'an error' }], add_result: nil) }
+  let(:instance) { described_class.new(druid: preserved_object.druid, version: preserved_object.current_version) }
+  let!(:preserved_object) { create(:preserved_object) }
+  let!(:zip_endpoint) { ZipEndpoint.find_by(endpoint_name: 'aws_s3_west_2') }
+  let!(:zipped_moab_version_new) do
+    create(:zipped_moab_version, preserved_object: preserved_object, zip_endpoint: zip_endpoint)
+  end
+  let!(:zipped_moab_version_no_errors) do
+    create(:zipped_moab_version, preserved_object: preserved_object, zip_endpoint: zip_endpoint, created_at: 3.months.ago).tap do |zmv|
+      create(:zip_part, zipped_moab_version: zmv)
+    end
+  end
+  let!(:zipped_moab_version_no_parts) do
+    create(:zipped_moab_version, preserved_object: preserved_object, zip_endpoint: zip_endpoint, created_at: 3.months.ago)
+  end
+  let!(:zipped_moab_version_with_errors) do
+    create(:zipped_moab_version, preserved_object: preserved_object, zip_endpoint: zip_endpoint, created_at: 3.months.ago).tap do |zmv|
+      create(:zip_part, zipped_moab_version: zmv)
+    end
+  end
+
+  describe '.prune_replication_failures' do
+    let(:instance) { instance_double(described_class, prune_replication_failures: nil) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+    end
+
+    it 'calls #prune_replication_failures on a new instance' do
+      described_class.prune_replication_failures(druid: preserved_object.druid, version: preserved_object.current_version)
+      expect(instance).to have_received(:prune_replication_failures).once
+    end
+  end
+
+  # NOTE: Yes, we are testing a private method here. There's some logic in the
+  #       method that is important enough, given the scope and scale of what
+  #       prescat does, to take extra care to test that it works as expected.
+  #       Why not make it a public method? There aren't any use cases for making
+  #       the method public; there would currently be zero collaborators using
+  #       it. Thus, we'll test the private method here.
+  describe '#zipped_moab_versions_with_errors' do
+    subject(:zipped_moab_versions) { instance.send(:zipped_moab_versions_with_errors).map(&:first) }
+
+    let(:fake_audit_class) { class_double(PreservationCatalog::S3Audit, check_replicated_zipped_moab_version: nil) }
+
+    before do
+      # NOTE: We are mocking out the audit-related collaborations of
+      #       CatalogRemediator to avoid making e.g. AWS API calls.
+      allow(instance).to receive(:endpoint_audit_class_for).and_return(fake_audit_class)
+      allow(instance).to receive(:audit_results_for).with(zipped_moab_version_new).and_return(fake_audit_results_no_errors)
+      allow(instance).to receive(:audit_results_for).with(zipped_moab_version_no_errors).and_return(fake_audit_results_no_errors)
+      allow(instance).to receive(:audit_results_for).with(zipped_moab_version_no_parts).and_return(fake_audit_results_no_errors)
+      allow(instance).to receive(:audit_results_for).with(zipped_moab_version_with_errors).and_return(fake_audit_results_with_errors)
+    end
+
+    it 'ignores zipped moab versions newer then expiry timestamp' do
+      expect(zipped_moab_versions).not_to include(zipped_moab_version_new)
+    end
+
+    it 'ignores zipped moab versions lacking errors in audit results' do
+      expect(zipped_moab_versions).not_to include(zipped_moab_version_no_errors)
+    end
+
+    it 'includes zipped moab versions lacking zip parts' do
+      expect(zipped_moab_versions).to include(zipped_moab_version_no_parts)
+    end
+
+    it 'includes zipped moab versions with errors in audit results' do
+      expect(zipped_moab_versions).to include(zipped_moab_version_with_errors)
+    end
+  end
+
+  describe '#prune_replication_failures' do
+    let(:failures) { instance.prune_replication_failures }
+
+    before do
+      allow(Rails.logger).to receive(:info)
+      allow(instance).to receive(:zipped_moab_versions_with_errors)
+        .and_return(
+          [
+            [zipped_moab_version_no_parts, fake_audit_results_no_errors],
+            [zipped_moab_version_with_errors, fake_audit_results_with_errors]
+          ]
+        )
+      allow(ActiveRecordUtils).to receive(:with_transaction_and_rescue).and_call_original
+
+      failures
+    end
+
+    it 'logs an informational message' do
+      expect(Rails.logger).to have_received(:info).twice
+    end
+
+    it 'creates a transaction' do
+      expect(ActiveRecordUtils).to have_received(:with_transaction_and_rescue).twice
+    end
+
+    it 'destroys the affected zipped moab versions and related zip parts' do
+      expect(zipped_moab_version_no_parts.zip_parts).to be_empty
+      expect(zipped_moab_version_no_parts).to be_destroyed
+      expect(zipped_moab_version_with_errors.zip_parts).to be_empty
+      expect(zipped_moab_version_with_errors).to be_destroyed
+    end
+
+    it 'returns an array of zipped moab version versions and endpoint names' do
+      expect(failures).to eq([
+                               [zipped_moab_version_no_parts.version, zipped_moab_version_no_parts.zip_endpoint.endpoint_name],
+                               [zipped_moab_version_with_errors.version, zipped_moab_version_with_errors.zip_endpoint.endpoint_name]
+                             ])
+    end
+  end
+end

--- a/spec/services/catalog_remediator_spec.rb
+++ b/spec/services/catalog_remediator_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe CatalogRemediator do
             [zipped_moab_version_with_errors, fake_audit_results_with_errors]
           ]
         )
-      allow(ActiveRecordUtils).to receive(:with_transaction_and_rescue).and_call_original
+      allow(ApplicationRecord).to receive(:transaction).and_call_original
 
       failures
     end
@@ -98,7 +98,7 @@ RSpec.describe CatalogRemediator do
     end
 
     it 'creates a transaction' do
-      expect(ActiveRecordUtils).to have_received(:with_transaction_and_rescue).twice
+      expect(ApplicationRecord).to have_received(:transaction).at_least(:twice)
     end
 
     it 'destroys the affected zipped moab versions and related zip parts' do

--- a/spec/services/reporters/audit_workflow_reporter_spec.rb
+++ b/spec/services/reporters/audit_workflow_reporter_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe Reporters::AuditWorkflowReporter do
       it 'updates workflow for each error' do
         subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1, result2])
         error_msg1 = 'FooCheck (actual location: fixture_sr1; actual version: 6) || Invalid Moab, validation errors: ' \
-          "[Version directory name not in 'v00xx' format: original-v1]"
+                     "[Version directory name not in 'v00xx' format: original-v1]"
         expect(client).to have_received(:update_error_status).with(druid: "druid:#{druid}",
                                                                    workflow: 'preservationAuditWF',
                                                                    process: 'moab-valid',
                                                                    error_msg: error_msg1)
         error_msg2 = 'FooCheck (actual location: fixture_sr1; actual version: 6) || Invalid Moab, validation errors: ' \
-          "[Version directory name not in 'v00xx' format: original-v2]"
+                     "[Version directory name not in 'v00xx' format: original-v2]"
         expect(client).to have_received(:update_error_status).with(druid: "druid:#{druid}",
                                                                    workflow: 'preservationAuditWF',
                                                                    process: 'moab-valid',
@@ -57,7 +57,7 @@ RSpec.describe Reporters::AuditWorkflowReporter do
       it 'merges errors and updates workflow' do
         subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1, result2])
         error_msg = 'FooCheck (actual location: fixture_sr1; actual version: 6) does not match PreservedObject current_version ' \
-          '&& actual version (6) has unexpected relationship to db version'
+                    '&& actual version (6) has unexpected relationship to db version'
         expect(client).to have_received(:update_error_status).with(druid: "druid:#{druid}",
                                                                    workflow: 'preservationAuditWF',
                                                                    process: 'preservation-audit',

--- a/spec/services/reporters/event_service_reporter_spec.rb
+++ b/spec/services/reporters/event_service_reporter_spec.rb
@@ -23,17 +23,17 @@ RSpec.describe Reporters::EventServiceReporter do
     context 'when INVALID_MOAB' do
       let(:result1) do
         { AuditResults::INVALID_MOAB => 'Invalid Moab, validation errors: [Version directory name not in ' \
-        "'v00xx' format: original-v1]" }
+                                        "'v00xx' format: original-v1]" }
       end
       let(:result2) do
         { AuditResults::INVALID_MOAB => 'Invalid Moab, validation errors: [Version directory name not in ' \
-        "'v00xx' format: original-v2]" }
+                                        "'v00xx' format: original-v2]" }
       end
 
       it 'creates events' do
         subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1, result2])
         error1 = 'FooCheck (actual location: fixture_sr1; actual version: 6) || Invalid Moab, validation errors: ' \
-          "[Version directory name not in 'v00xx' format: original-v1]"
+                 "[Version directory name not in 'v00xx' format: original-v1]"
         expect(client).to have_received(:create).with(
           type: 'preservation_audit_failure',
           data: {
@@ -46,7 +46,7 @@ RSpec.describe Reporters::EventServiceReporter do
           }
         )
         error2 = 'FooCheck (actual location: fixture_sr1; actual version: 6) || Invalid Moab, validation errors: ' \
-          "[Version directory name not in 'v00xx' format: original-v2]"
+                 "[Version directory name not in 'v00xx' format: original-v2]"
         expect(client).to have_received(:create).with(
           type: 'preservation_audit_failure',
           data: {
@@ -76,7 +76,7 @@ RSpec.describe Reporters::EventServiceReporter do
             actual_version: 6,
             check_name: 'preservation-audit',
             error: 'FooCheck (actual location: fixture_sr1; actual version: 6) does not match PreservedObject ' \
-              'current_version && actual version (6) has unexpected relationship to db version'
+                   'current_version && actual version (6) has unexpected relationship to db version'
           }
         )
       end


### PR DESCRIPTION
Fixes #1748

And call the class from a new rake task, printing out results.

Also includes:
* Add new Rubocop rules
  * Because rubocop barked at me. And, as part of spinning up the app after a long time, do a little work to make sure `rake` does what we expect usually. That involved moving rspec-rails to the dev/test bundler group and some Rakefile touches.

## Why was this change made?

Fixes #1748 

## How was this change tested?

TBD

## Which documentation and/or configurations were updated?

None

