### PR TITLE
fix prod deploy targets

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'preservation-catalog-prod-01.stanford.edu', user: 'pres', roles: %w[app db web]
+server 'preservation-catalog-web-prod-01.stanford.edu', user: 'pres', roles: %w[app db web]
 server 'preservation-catalog-prod-02.stanford.edu', user: 'pres', roles: %w[app resque queue_populator]
 server 'preservation-catalog-prod-03.stanford.edu', user: 'pres', roles: %w[app resque]
 server 'preservation-catalog-prod-04.stanford.edu', user: 'pres', roles: %w[app resque cache_cleaner]


### PR DESCRIPTION
## Why was this change made?

Ops seems to have changed the VM name:

![image](https://user-images.githubusercontent.com/96775/142924056-494dd2c1-ee5a-459c-bae6-82cbce1eb393.png)


## How was this change tested?



## Which documentation and/or configurations were updated?



