### PR TITLE
make capistrano deployment roles consistent between prod, stage, and qa

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 server 'preservation-catalog-qa-01.stanford.edu', user: 'pres', roles: %w[app db web]
-server 'preservation-catalog-qa-02.stanford.edu', user: 'pres', roles: %w[resque app]
+server 'preservation-catalog-qa-02.stanford.edu', user: 'pres', roles: %w[app resque queue_populator cache_cleaner]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 set :bundle_without, 'deploy test'
 set :deploy_to, '/opt/app/pres/preservation_catalog'
+set :whenever_roles, [:queue_populator, :cache_cleaner]
 append :linked_files, 'config/newrelic.yml', 'config/resque.yml'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 server 'preservation-catalog-stage-01.stanford.edu', user: 'pres', roles: %w[app db web]
-server 'preservation-catalog-stage-02.stanford.edu', user: 'pres', roles: %w[resque app]
+server 'preservation-catalog-stage-02.stanford.edu', user: 'pres', roles: %w[app resque queue_populator cache_cleaner]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 set :bundle_without, 'deploy test'
 set :deploy_to, '/opt/app/pres/preservation_catalog'
+set :whenever_roles, [:queue_populator, :cache_cleaner]
 append :linked_files, 'config/newrelic.yml', 'config/resque.yml'


### PR DESCRIPTION
specifically:
* everything that has the `app` role puts it first, for a bit more readability
* the missing `queue_populator` and `cache_cleaner` roles are added to the worker boxes (-02) for stage and QA, as they apparently went entirely missing at some point (noticed because the zip temp space filled up on stage, and the cache cleaner rake task wasn't in the crontab for -stage-02, where i'd have expected it).

## Why was this change made?

noticed because stage workers couldn't create archive zips, because the zip temp space had filled up

## How was this change tested?

* this branch was deployed to stage at 4:37 pm
* the job was allowed to run at 5:00 pm (it's scheduled for the top of the hour)
* space started freeing up once the job started (at 635 GB of 1 TB available as of 5:34 pm)
* the failed `zipmaker` jobs were retried, and all of the 10 or so that i spot checked succeeded (including a 9.78 GB object, with a 41.1 GB object still chugging along)

## Which documentation and/or configurations were updated?

cap deploy configs for the QA and stage envs