### PR TITLE
Prevent deletion of transfers directory

### DIFF
--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -13,7 +13,8 @@ namespace :prescat do
   namespace :cache_cleaner do
     desc 'Clean zip storage cache of empty directories'
     task empty_directories: :environment do
-      `find #{Settings.zip_storage} -not -path "*/\.*" -type d -empty -delete`
+      # Setting mindepth to 1 prevents the command from wiping out the root dir if empty
+      `find #{Settings.zip_storage} -mindepth 1 -not -path "*/\.*" -type d -empty -delete`
     end
 
     desc 'Clean zip storage cache of stale checksum & zip files'


### PR DESCRIPTION
Fixes #1782

## Why was this change made?

To prevent deleting a directory that must be present. This was happening on QA.

## How was this change tested?

I ran the find command before and after with a test directory locally. Before this change, the test dir was deleted. After, it wasn't.

## Which documentation and/or configurations were updated?

None

