### PR TITLE
Use cap-rvm in prescat

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -15,6 +15,7 @@ require "capistrano/honeybadger"
 require "dlss/capistrano"
 require "dlss/capistrano/resque_pool"
 require 'whenever/capistrano'
+require 'capistrano/rvm'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -51,4 +51,5 @@ group :deploy do
   gem 'capistrano-rails'
   gem 'capistrano-passenger'
   gem 'dlss-capistrano'
+  gem 'capistrano-rvm'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,9 @@ GEM
     capistrano-rails (1.6.1)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
+    capistrano-rvm (0.1.2)
+      capistrano (~> 3.0)
+      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
     cocina-models (0.64.0)
@@ -443,6 +446,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.17)
   capistrano-passenger
   capistrano-rails
+  capistrano-rvm
   committee
   config
   dlss-capistrano


### PR DESCRIPTION
## Why was this change made?

It let us get past a deployment error to the new web-stage machines:
```
bundle stderr: /usr/bin/env: 'bundle': No such file or directory
```

## How was this change tested?

Deployed to the stage load-balanced nodes

## Which documentation and/or configurations were updated?

DevOpsDoce PR forthcoming

