### PR TITLE
Let capistrano report to honeybadger

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -26,6 +26,11 @@ append :linked_files, 'config/database.yml', 'config/resque.yml', 'config/resque
 append :linked_dirs, 'log', 'config/settings', 'tmp/pids'
 
 set :honeybadger_env, fetch(:stage)
+
+# the honeybadger gem should integrate automatically with capistrano-rvm but it
+# doesn't appear to do so on our new Ubuntu boxes :shrug:
+set :rvm_map_bins, fetch(:rvm_map_bins, []).push('honeybadger')
+
 set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
 
 set :resque_server_roles, :resque


### PR DESCRIPTION
## Why was this change made?

Because honeybadger doesn't integrate with capistrano-rvm

## How was this change tested?

This worked for technical-metadata-service

## Which documentation and/or configurations were updated?

N/A

