### PR TITLE
Prune dead resque-pool workers after hot-swapping during deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,3 +58,14 @@ task :db_seed do
     end
   end
 end
+
+desc 'Prune dead Resque workers'
+after 'resque:pool:hot_swap', :prune_dead_workers do
+  on roles(:resque) do
+    within release_path do
+      with rails_env: fetch(:rails_env) do
+        execute :rails, 'runner', '"Resque.workers.map(&:prune_dead_workers)"'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Still occasionally seeing dead workers lingering after deployment. So prune dead workers as part of deployment process.


## How was this change tested? 🤨

CI, + a test deploy to stage. Resulted in expected number of workers! (Was previously +1.)
