### PR TITLE
comment on cap call to Resque::Worker#prune_dead_workers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -64,6 +64,9 @@ after 'resque:pool:hot_swap', :prune_dead_workers do
   on roles(:resque) do
     within release_path do
       with rails_env: fetch(:rails_env) do
+        # If a Resque process doesn't stop gracefully, it may leave stale state information in Redis. This call
+        # does some garbage collection, checking the current Redis state info against the actual environment,
+        # and removing entries from Redis for any workers that aren't actually running. See Resque::Worker#prune_dead_workers
         execute :rails, 'runner', '"Resque.workers.map(&:prune_dead_workers)"'
       end
     end


### PR DESCRIPTION
see also https://github.com/sul-dlss/preservation_catalog/wiki/More-than-the-expected-number-of-Resque-workers-are-running---too-many-resque-workers---worker-count-high#the-above-determines-that-the-right-number-of-workers-are-actually-running

## Why was this change made? 🤔

small follow on to #1834 

## How was this change tested? 🤨

n/a, comment only change

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



