### PR TITLE
comment out prune_dead_workers cap hook

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -59,16 +59,20 @@ task :db_seed do
   end
 end
 
-desc 'Prune dead Resque workers'
-after 'resque:pool:hot_swap', :prune_dead_workers do
-  on roles(:resque) do
-    within release_path do
-      with rails_env: fetch(:rails_env) do
-        # If a Resque process doesn't stop gracefully, it may leave stale state information in Redis. This call
-        # does some garbage collection, checking the current Redis state info against the actual environment,
-        # and removing entries from Redis for any workers that aren't actually running. See Resque::Worker#prune_dead_workers
-        execute :rails, 'runner', '"Resque.workers.map(&:prune_dead_workers)"'
-      end
-    end
-  end
-end
+# TODO: this worked when tested against QA and stage, but for a couple of prod deployments,
+# it seemed like this caused Resque web console to erroneously report zero workers even though
+# listing resque related processes on the VM showed all the workers we'd expect to be running.
+# see https://github.com/sul-dlss/preservation_catalog/issues/1836
+# desc 'Prune dead Resque workers'
+# after 'resque:pool:hot_swap', :prune_dead_workers do
+#   on roles(:resque) do
+#     within release_path do
+#       with rails_env: fetch(:rails_env) do
+#         # If a Resque process doesn't stop gracefully, it may leave stale state information in Redis. This call
+#         # does some garbage collection, checking the current Redis state info against the actual environment,
+#         # and removing entries from Redis for any workers that aren't actually running. See Resque::Worker#prune_dead_workers
+#         execute :rails, 'runner', '"Resque.workers.map(&:prune_dead_workers)"'
+#       end
+#     end
+#   end
+# end


### PR DESCRIPTION
see https://github.com/sul-dlss/preservation_catalog/issues/1836

## Why was this change made? 🤔

remedy what seems like a small deployment and monitoring rough edge that may have been newly introduced, while we figure out what's going on.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



