### PR TITLE
Fix PlexerJob infinite retries

### DIFF
--- a/app/jobs/plexer_job.rb
+++ b/app/jobs/plexer_job.rb
@@ -45,17 +45,15 @@ class PlexerJob < ZipPartJobBase
   end
 
   def find_or_create_unreplicated_part(zmv, part_s3_key, metadata)
-    zmv.zip_parts.find_or_create_by(
+    zmv.zip_parts.create_with(
       create_info: metadata.slice(:zip_cmd, :zip_version).to_s,
       md5: metadata[:checksum_md5],
       parts_count: metadata[:parts_count],
       size: metadata[:size],
       suffix: File.extname(part_s3_key)
+    ).create_or_find_by(
+      suffix: File.extname(part_s3_key)
     ) { |part| part.unreplicated! }
-  rescue ActiveRecord::RecordNotUnique
-    # This catches an exception triggered by a race condition because find_or_create_by is not atomic.
-
-    retry
   end
 
   # @return [Array<Class>] target delivery worker classes


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1830. 

## How was this change tested? 🤨
Unit tests pass and specs added. Ran `create_preassembly_image_spec.rb` from integration tests successfully on stage. 

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



