### PR TITLE
Downgrade ruby-rails orb to 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@3.1.0
+  ruby-rails: sul-dlss/ruby-rails@2.0.0
 workflows:
   build:
     jobs:


### PR DESCRIPTION


## Why was this change made? 🤔
So that the validate-api step will pass


## How was this change tested? 🤨
ci