### PR TITLE
Upgrade ruby-rails-orb to 3.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@3.1.0
+  ruby-rails: sul-dlss/ruby-rails@3.1.1
 workflows:
   build:
     jobs:


### PR DESCRIPTION
## Why was this change made? 🤔

Previously the build was failing trying to validate the openapi.yml


## How was this change tested? 🤨


