### PR TITLE
add the app role back for the stage worker VM

### DIFF
--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,7 +2,7 @@
 
 server 'preservation-catalog-web-stage-01.stanford.edu', user: 'pres', roles: %w[app web]
 server 'preservation-catalog-web-stage-02.stanford.edu', user: 'pres', roles: %w[app web]
-server 'preservation-catalog-stage-02.stanford.edu', user: 'pres', roles: %w[db resque queue_populator cache_cleaner]
+server 'preservation-catalog-stage-02.stanford.edu', user: 'pres', roles: %w[app db resque queue_populator cache_cleaner]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'


### PR DESCRIPTION
## Why was this change made? 🤔

seems capistrano-shared_configs will only update configs on hosts with the app role:  https://github.com/sul-dlss/capistrano-shared_configs/blob/8d518df87a38691f921afa7aec300634b0a9cf2a/lib/capistrano/tasks/shared_configs.rake

when i first tried to redeploy pres cat to stage this morning with shared_configs changes (to adjust worker counts), shared_configs was updated on the two web VMs, but not on the worker VM.  after looking for possibly relevant differences between the configurations for those hosts, i noticed the lack of `app` role for the pres cat stage worker VM, and its presence on the web VMs, and on worker VMs for other environments/apps.  adding back the `app` role to the worker VM allowed shared_configs updates to work as expected.

## How was this change tested? 🤨

applied locally, redeployed pres cat to stage, saw shared_configs get updated on all 3 VMs (instead of just the two web VMs).

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



