### PR TITLE
put M2C and C2M audits on monthly schedule

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -147,7 +147,11 @@ class VersionAuditWindowCheck < OkComputer::Check
   end
 
   private def clause
-    14.days.ago
+    # currently: M2C and C2M are queued on the 1st and 15th of the month, respectively, and
+    # expiry time on CV is 3 months (those are the three audits that touch this timestamp).
+    # M2C should run at most 16 days after C2M (following a 31 day month), but give a little buffer
+    # since the queues might take a while to work down, and ordering for enqueue is uncertain.
+    21.days.ago
   end
 end
 OkComputer::Registry.register 'feature-version-audit-window-check', VersionAuditWindowCheck.new

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -3,20 +3,24 @@
 # Use this file to easily define all of your cron jobs.
 # Learn more: http://github.com/javan/whenever
 
-# these append to existing logs
-every :tuesday, roles: [:queue_populator] do
+# these cron jobs all append to existing log files
+
+# 11 am on the 1st of every month
+every :month, at: '11:00', roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/m2c-err.log'
   runner 'MoabStorageRoot.find_each(&:m2c_check!)'
+end
+
+# 11 am on the 15th of every month - the 'whenever' syntax for this is awkward and needs an ignored month
+# for the day to get parsed, so just use raw cron syntax
+every '0 11 15 * *', roles: [:queue_populator] do
+  set :output, standard: nil, error: 'log/c2m-err.log'
+  runner 'MoabStorageRoot.find_each(&:c2m_check!)'
 end
 
 every :wednesday, roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/c2a-err.log'
   runner 'PreservedObject.archive_check_expired.find_each(&:audit_moab_version_replication!)'
-end
-
-every :friday, roles: [:queue_populator] do
-  set :output, standard: nil, error: 'log/c2m-err.log'
-  runner 'MoabStorageRoot.find_each(&:c2m_check!)'
 end
 
 every :sunday, at: '1am', roles: [:queue_populator] do


### PR DESCRIPTION
and adjust audit threshold to prevent false alerts.

for your consideration: the alternative (more idiomatic?) native whenever syntax for the job where raw cron syntax was used would be:

`every :month, at: 'Jan 15th at 11:00'`

the month part of the `at:` param would be disregarded (but without that placeholder month in the `at:` param, '15', '15th', etc, is interpreted as an hour on the first day of the month, not a day of the month).  this appears to be an artifact of whenever's use of chronic (the gem whenever relies on for date parsing).

## Why was this change made? 🤔

Per recurring discussion/suggestion in slack (see e.g. [here](https://stanfordlib.slack.com/archives/G6K8R3VBK/p1655835935574139)) we think that the current level of parallelization of the m2c and c2m work (done by `MoabToCatalogJob` and `CatalogToMoabJob` respectively) is unnecessary and causing performance problems.

Unnecessary, because in the 4ish years that pres cat has been running in production, we don't recall either of these audits detecting a problem, and so while we'd like to keep them in place, we also think it's safe to turn down the frequency (other audits such as replication audit and checksum validation do occasionally detect problems, and these audits would detect things like stray files in the pres file system or accidental human deletion of pres content, so they do seem valuable).

We think the performance problems are due to more concurrent file access from multiple machines than Ceph is comfortable with.  In addition to this reduction in frequency for running these two audits, we're also decreasing the number of workers allocated to the relevant queues, to one per worker VM (from 6 per worker VM), dropping concurrency from 18 processes to 3.  Our back of the envelope calculation is that this will still get the m2c and c2m queues drained before they are next populated.  We can continue tuning if that turns out to be wrong.

## How was this change tested? 🤨

I checked the cron definitions that'd be generated by deploying to stage as I iterated, and then by running `bundle exec whenever` locally, after I discovered that'd show the crontab whenever would generate from the current `schedule.rb`.  Here is the crontab that this branch will generate; the first two entries are the re-scheduled m2c and c2m queue population jobs:

```
0 11 1 * * /bin/bash -l -c 'cd /Users/suntzu/software_dev_projects/preservation_catalog && bundle exec bin/rails runner -e production '\''MoabStorageRoot.find_each(&:m2c_check!)'\'' >> /dev/null 2>> log/m2c-err.log'

0 11 15 * * /bin/bash -l -c 'cd /Users/suntzu/software_dev_projects/preservation_catalog && bundle exec bin/rails runner -e production '\''MoabStorageRoot.find_each(&:c2m_check!)'\'' >> /dev/null 2>> log/c2m-err.log'

0 0 * * 3 /bin/bash -l -c 'cd /Users/suntzu/software_dev_projects/preservation_catalog && bundle exec bin/rails runner -e production '\''PreservedObject.archive_check_expired.find_each(&:audit_moab_version_replication!)'\'' >> /dev/null 2>> log/c2a-err.log'

0 1 * * 0 /bin/bash -l -c 'cd /Users/suntzu/software_dev_projects/preservation_catalog && bundle exec bin/rails runner -e production '\''MoabStorageRoot.find_each(&:validate_expired_checksums!)'\'' >> /dev/null 2>> log/cv-err.log'

0 * * * * /bin/bash -l -c 'cd /Users/suntzu/software_dev_projects/preservation_catalog && RAILS_ENV=production bundle exec rake prescat:cache_cleaner:stale_files --silent >> /var/log/preservation_catalog/zip_cache_cleanup.log'

15 1 * * * /bin/bash -l -c 'cd /Users/suntzu/software_dev_projects/preservation_catalog && RAILS_ENV=production bundle exec rake prescat:cache_cleaner:empty_directories --silent >> /var/log/preservation_catalog/zip_cache_cleanup.log'
```

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



