### PR TITLE
Switch dor-event-client for dor-services-client for creating events.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gem 'aws-sdk-s3', '~> 1.17'
 gem 'committee' # Validates HTTP requests/responses per OpenAPI specification
 gem 'config' # Settings to manage configs on different instances
-gem 'dor-services-client', '~> 12.0' # avoid inadvertent cocina-models updates
+gem 'dor-event-client', '~> 1.0'
 gem 'dor-workflow-client', '~> 4.0' # audit errors are reported to the workflow service
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'jbuilder', '~> 2.5' # Build JSON APIs with ease.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,8 +64,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
+    amq-protocol (2.3.2)
     ast (2.4.2)
-    attr_extras (6.2.5)
     aws-eventstream (1.2.0)
     aws-partitions (1.601.0)
     aws-sdk-core (3.131.2)
@@ -86,6 +86,9 @@ GEM
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    bunny (2.19.0)
+      amq-protocol (~> 2.3, >= 2.3.1)
+      sorted_set (~> 1, >= 1.0.2)
     byebug (11.1.3)
     capistrano (3.17.0)
       airbrussh (>= 1.0.0)
@@ -110,27 +113,11 @@ GEM
       sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.82.0)
-      activesupport
-      deprecation
-      dry-struct (~> 1.0)
-      dry-types (~> 1.1)
-      edtf
-      equivalent-xml
-      jsonpath
-      nokogiri
-      openapi3_parser
-      openapi_parser (>= 0.11.1, < 1.0)
-      rss
-      super_diff
-      thor
-      zeitwerk (~> 2.1)
     coderay (1.1.3)
     committee (4.4.0)
       json_schema (~> 0.14, >= 0.14.3)
       openapi_parser (>= 0.11.1, < 1.0)
       rack (>= 1.5)
-    commonmarker (0.23.5)
     concurrent-ruby (1.1.10)
     config (4.0.0)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -148,12 +135,9 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (12.4.0)
+    dor-event-client (1.0.0)
       activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.82.0)
-      deprecation
-      faraday (~> 2.0)
-      faraday-retry
+      bunny (~> 2.17)
       zeitwerk (~> 2.1)
     dor-workflow-client (4.0.0)
       activesupport (>= 3.2.1, < 8)
@@ -184,10 +168,6 @@ GEM
       dry-initializer (~> 3.0)
       dry-logic (~> 1.0)
       dry-types (~> 1.5)
-    dry-struct (1.4.0)
-      dry-core (~> 0.5, >= 0.5)
-      dry-types (~> 1.5)
-      ice_nine (~> 0.11)
     dry-types (1.5.1)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
@@ -200,10 +180,6 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.8, >= 1.8.0)
-    edtf (3.0.8)
-      activesupport (>= 3.0, < 8.0)
-    equivalent-xml (0.6.0)
-      nokogiri (>= 1.4.3)
     erubi (1.10.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -223,15 +199,12 @@ GEM
     honeybadger (4.12.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    ice_nine (0.11.2)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.1)
     json (2.6.2)
     json_schema (0.21.0)
-    jsonpath (1.1.2)
-      multi_json
     jwt (2.4.1)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -274,15 +247,10 @@ GEM
     nokogiri-happymapper (0.9.0)
       nokogiri (~> 1.5)
     okcomputer (1.18.4)
-    openapi3_parser (0.9.2)
-      commonmarker (~> 0.17)
     openapi_parser (0.15.0)
-    optimist (3.0.1)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    patience_diff (1.2.0)
-      optimist (~> 3.0)
     pg (1.4.1)
     postgresql_cursor (0.6.4)
       activerecord (>= 3.1.0)
@@ -338,6 +306,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rbtree (0.4.5)
     redis (4.7.0)
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
@@ -373,8 +342,6 @@ GEM
     rspec-support (3.11.0)
     rspec_junit_formatter (0.5.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rss (0.2.9)
-      rexml
     rubocop (1.31.0)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -394,6 +361,7 @@ GEM
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    set (1.0.2)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
     simplecov (0.21.2)
@@ -407,6 +375,9 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.0)
       tilt (~> 2.0)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -417,10 +388,6 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    super_diff (0.9.0)
-      attr_extras (>= 6.2.4)
-      diff-lcs
-      patience_diff
     thor (1.2.1)
     tilt (2.0.10)
     tzinfo (2.0.4)
@@ -452,7 +419,7 @@ DEPENDENCIES
   committee
   config
   dlss-capistrano
-  dor-services-client (~> 12.0)
+  dor-event-client (~> 1.0)
   dor-workflow-client (~> 4.0)
   druid-tools
   factory_bot_rails (~> 4.0)

--- a/app/jobs/results_recorder_job.rb
+++ b/app/jobs/results_recorder_job.rb
@@ -69,8 +69,8 @@ class ResultsRecorderJob < ApplicationJob
       { s3_key: part.s3_key, size: part.size, md5: part.md5 }
     end
 
-    events_client = Dor::Services::Client.object("druid:#{druid}").events
-    events_client.create(
+    Dor::Event::Client.create(
+      druid: "druid:#{druid}",
       type: 'druid_version_replicated',
       data: {
         host: Socket.gethostname,

--- a/app/services/reporters/event_service_reporter.rb
+++ b/app/services/reporters/event_service_reporter.rb
@@ -52,12 +52,9 @@ module Reporters
 
     private
 
-    def events_client_for(druid)
-      Dor::Services::Client.object(druid).events
-    end
-
     def create_success_event(druid, version, process_name, storage_area)
-      events_client_for(druid).create(
+      Dor::Event::Client.create(
+        druid: druid,
         type: 'preservation_audit_success',
         data: {
           host: Socket.gethostname,
@@ -70,7 +67,8 @@ module Reporters
     end
 
     def create_error_event(druid, version, process_name, storage_area, error_message)
-      events_client_for(druid).create(
+      Dor::Event::Client.create(
+        druid: druid,
         type: 'preservation_audit_failure',
         data: {
           host: Socket.gethostname,

--- a/config/initializers/dor_event_client.rb
+++ b/config/initializers/dor_event_client.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Dor::Event::Client.configure(hostname: Settings.rabbitmq.hostname,
+                             vhost: Settings.rabbitmq.vhost,
+                             username: Settings.rabbitmq.username,
+                             password: Settings.rabbitmq.password)

--- a/config/initializers/dor_services_client.rb
+++ b/config/initializers/dor_services_client.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-# Configure dor-services-client to use the dor-services URL
-Dor::Services::Client.configure(url: Settings.dor_services.url,
-                                token: Settings.dor_services.token)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,3 @@
-dor_services:
-  url: 'https://dor-services-app.example.edu'
-  token: 'not-a-real-token'
-
 # named storage roots are in the storage_root_map (see config/settings/xxx.yml for examples).
 # the storage_root_map contains lookups of storage roots per host.
 # see sul-dlss/shared_configs for the storage_root_map of all hosts we deploy to.
@@ -52,3 +48,9 @@ api_jwt:
 # we expect/hope that this will not stay around forever.  see usage for further explanation.
 hacks:
   zipmaker_delay_seconds: 0.05 # the default value is artificially low to keep test suite fast -- should override to be many seconds in prod
+
+rabbitmq:
+  hostname: localhost
+  vhost: /
+  username: guest
+  password: guest

--- a/spec/jobs/integration_spec.rb
+++ b/spec/jobs/integration_spec.rb
@@ -23,8 +23,6 @@ describe 'the whole replication pipeline', type: :job do
   let(:ibm_provider) { instance_double(PreservationCatalog::IbmProvider, bucket: ibm_bucket) }
   let(:moab_storage_root) { MoabStorageRoot.find_by!(name: 'fixture_sr1') }
 
-  let(:events_client) { instance_double(Dor::Services::Client::Events, create: nil) }
-
   around do |example|
     old_adapter = ApplicationJob.queue_adapter
     ApplicationJob.queue_adapter = :inline
@@ -36,10 +34,7 @@ describe 'the whole replication pipeline', type: :job do
     allow(Settings).to receive(:zip_storage).and_return(Rails.root.join('spec', 'fixtures', 'zip_storage'))
     allow(PreservationCatalog::AwsProvider).to receive(:new).and_return(aws_provider)
     allow(PreservationCatalog::IbmProvider).to receive(:new).and_return(ibm_provider)
-    allow(Dor::Services::Client).to receive(:object).with("druid:#{druid}").and_return(
-      instance_double(Dor::Services::Client::Object, events: events_client)
-    )
-    allow(events_client).to receive(:create)
+    allow(Dor::Event::Client).to receive(:create)
     allow(Socket).to receive(:gethostname).and_return('fakehost')
   end
 
@@ -55,11 +50,15 @@ describe 'the whole replication pipeline', type: :job do
     # other endpoints as added...
     expect(ResultsRecorderJob).to receive(:perform_later).with(druid, version, s3_key, 'S3WestDeliveryJob').and_call_original
     expect(ResultsRecorderJob).to receive(:perform_later).with(druid, version, s3_key, 'IbmSouthDeliveryJob').and_call_original
-    expect(events_client).to receive(:create).with(
-      { type: 'druid_version_replicated', data: a_hash_including({ host: 'fakehost', version: 1, endpoint_name: 'aws_s3_west_2' }) }
+    expect(Dor::Event::Client).to receive(:create).with(
+      druid: "druid:#{druid}",
+      type: 'druid_version_replicated',
+      data: a_hash_including({ host: 'fakehost', version: 1, endpoint_name: 'aws_s3_west_2' })
     )
-    expect(events_client).to receive(:create).with(
-      { type: 'druid_version_replicated', data: a_hash_including({ host: 'fakehost', version: 1, endpoint_name: 'ibm_us_south' }) }
+    expect(Dor::Event::Client).to receive(:create).with(
+      druid: "druid:#{druid}",
+      type: 'druid_version_replicated',
+      data: a_hash_including({ host: 'fakehost', version: 1, endpoint_name: 'ibm_us_south' })
     )
     expect(Resque.redis.redis).to receive(:lpush).with('replication.results', hash.to_json)
 
@@ -85,11 +84,15 @@ describe 'the whole replication pipeline', type: :job do
       # other endpoints as added...
       expect(ResultsRecorderJob).to receive(:perform_later).with(druid, next_version, s3_key, 'S3WestDeliveryJob').and_call_original
       expect(ResultsRecorderJob).to receive(:perform_later).with(druid, next_version, s3_key, 'IbmSouthDeliveryJob').and_call_original
-      expect(events_client).to receive(:create).with(
-        { type: 'druid_version_replicated', data: a_hash_including({ host: 'fakehost', version: 3, endpoint_name: 'aws_s3_west_2' }) }
+      expect(Dor::Event::Client).to receive(:create).with(
+        druid: "druid:#{druid}",
+        type: 'druid_version_replicated',
+        data: a_hash_including({ host: 'fakehost', version: 3, endpoint_name: 'aws_s3_west_2' })
       )
-      expect(events_client).to receive(:create).with(
-        { type: 'druid_version_replicated', data: a_hash_including({ host: 'fakehost', version: 3, endpoint_name: 'ibm_us_south' }) }
+      expect(Dor::Event::Client).to receive(:create).with(
+        druid: "druid:#{druid}",
+        type: 'druid_version_replicated',
+        data: a_hash_including({ host: 'fakehost', version: 3, endpoint_name: 'ibm_us_south' })
       )
       expect(Resque.redis.redis).to receive(:lpush).with('replication.results', hash.merge(version: next_version).to_json)
 

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -45,15 +45,10 @@ RSpec.describe ChecksumValidator do
 
   describe '#validate_checksums' do
     context 'moab is missing from storage' do
-      let(:events_client) { instance_double(Dor::Services::Client::Events) }
-
       before do
         # fake a moab gone missing by updating the preserved object to use a non-existent druid
         comp_moab.preserved_object.update(druid: 'tr808sp1200')
-        allow(Dor::Services::Client).to receive(:object).with('druid:tr808sp1200').and_return(
-          instance_double(Dor::Services::Client::Object, events: events_client)
-        )
-        allow(events_client).to receive(:create).with(type: 'preservation_audit_failure', data: instance_of(Hash))
+        allow(Dor::Event::Client).to receive(:create).with(druid: 'druid:tr808sp1200', type: 'preservation_audit_failure', data: instance_of(Hash))
       end
 
       it 'sets status to online_moab_not_found and adds corresponding audit result' do


### PR DESCRIPTION
closes #1860

## Why was this change made? 🤔
To make the job more resilient.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

Unit

