### PR TITLE
Handle validation of moab with empty directory.

### DIFF
--- a/app/services/checksum_validator.rb
+++ b/app/services/checksum_validator.rb
@@ -63,7 +63,7 @@ class ChecksumValidator
   # return true and exit if the moab exists.  otherwise update status to missing on complete_moab, report results, and return false.
   # @return [Boolean] true and exit if the moab exists, false otherwise
   def check_file_existence!
-    return true if File.exist?(object_dir)
+    return true if File.exist?(object_dir) && latest_moab_version.present?
 
     transaction_ok = ActiveRecordUtils.with_transaction_and_rescue(results) do
       mark_moab_not_found


### PR DESCRIPTION
closes #1903

## Why was this change made? 🤔
So that possible error case handled correctly.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

Unit

