### PR TITLE
Don't specify image because we're building the image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     depends_on:
       - db
       - redis
-    image: 'suldlss/preservation_catalog:latest'
   db:
     image: postgres
     ports:


### PR DESCRIPTION


## Why was this change made? 🤔

Otherwise docker-compose will pull an old copy and build a new copy

## How was this change tested? 🤨

`docker compose up`


