### PR TITLE
Make job locking explicit

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -6,8 +6,6 @@ class ApplicationJob < ActiveJob::Base
     ActiveRecord::Base.clear_active_connections!
   end
 
-  include UniqueJob
-
   # Raises if the metadata is incomplete
   # @param [Hash<Symbol => String>] metadata
   # @option metadata [String] :checksum_md5

--- a/app/jobs/catalog_to_moab_job.rb
+++ b/app/jobs/catalog_to_moab_job.rb
@@ -9,6 +9,8 @@ class CatalogToMoabJob < ApplicationJob
     raise ArgumentError, 'CompleteMoab param required' unless job.arguments.first.is_a?(CompleteMoab)
   end
 
+  include UniqueJob
+
   # @param [CompleteMoab] complete_moab object to C2M check
   # @see Audit::CatalogToMoab#initialize
   def perform(complete_moab)

--- a/app/jobs/checksum_validation_job.rb
+++ b/app/jobs/checksum_validation_job.rb
@@ -9,6 +9,8 @@ class ChecksumValidationJob < ApplicationJob
     raise ArgumentError, 'CompleteMoab param required' unless job.arguments.first.is_a?(CompleteMoab)
   end
 
+  include UniqueJob
+
   # @param [CompleteMoab] complete_moab object to checksum
   def perform(complete_moab)
     ChecksumValidator.new(complete_moab).validate_checksums

--- a/app/jobs/moab_replication_audit_job.rb
+++ b/app/jobs/moab_replication_audit_job.rb
@@ -7,6 +7,8 @@
 class MoabReplicationAuditJob < ApplicationJob
   queue_as :moab_replication_audit
 
+  include UniqueJob
+
   # @param [PreservedObject] for which to verify presence of the archive zips we think we've replicated (and possibly backfill those we haven't)
   def perform(preserved_object)
     backfill_missing_zmvs if Settings.replication.audit_should_backfill

--- a/app/jobs/moab_to_catalog_job.rb
+++ b/app/jobs/moab_to_catalog_job.rb
@@ -9,6 +9,8 @@ class MoabToCatalogJob < ApplicationJob
     raise ArgumentError, 'MoabStorageRoot param required' unless job.arguments.first.is_a?(MoabStorageRoot)
   end
 
+  include UniqueJob
+
   # @param [MoabStorageRoot] root mount containing the Moab
   # @param [String] druid
   def perform(root, druid)

--- a/app/jobs/part_replication_audit_job.rb
+++ b/app/jobs/part_replication_audit_job.rb
@@ -9,6 +9,8 @@ class PartReplicationAuditJob < ApplicationJob
   queue_as { "part_audit_#{arguments.second.endpoint_name}" }
   delegate :check_child_zip_part_attributes, :logger, to: Audit::CatalogToArchive
 
+  include UniqueJob
+
   # @param [PreservedObject] preserved_object
   # @param [ZipEndpoint] zip_endpoint endpoint being checked
   def perform(preserved_object, zip_endpoint)

--- a/app/jobs/results_recorder_job.rb
+++ b/app/jobs/results_recorder_job.rb
@@ -20,6 +20,8 @@ class ResultsRecorderJob < ApplicationJob
     job.zmv ||= zmvs.find_by!(zip_endpoints: { delivery_class: job.arguments.fourth })
   end
 
+  include UniqueJob
+
   # @param [String] druid
   # @param [Integer] version
   # @param [String] s3_part_key

--- a/app/jobs/validate_moab_job.rb
+++ b/app/jobs/validate_moab_job.rb
@@ -4,6 +4,8 @@
 class ValidateMoabJob < ApplicationJob
   queue_as :validate_moab
 
+  include UniqueJob
+
   attr_accessor :druid
 
   # @param [String] druid of Moab on disk to be checksum validated

--- a/app/jobs/zip_part_job_base.rb
+++ b/app/jobs/zip_part_job_base.rb
@@ -10,6 +10,8 @@ class ZipPartJobBase < ApplicationJob
     job.dvz_part = DruidVersionZipPart.new(zip, job.arguments.third)
   end
 
+  include UniqueJob
+
   # Does queue locking on ONLY druid, version and part (as first 3 parameters)
   def self.queue_lock_key(*args)
     "lock:#{name}-#{args.slice(0..2).join(';')}"

--- a/app/jobs/zipmaker_job.rb
+++ b/app/jobs/zipmaker_job.rb
@@ -14,6 +14,8 @@ class ZipmakerJob < ApplicationJob
     job.zip = DruidVersionZip.new(job.arguments.first, job.arguments.second, job.arguments.third)
   end
 
+  include UniqueJob
+
   # Does queue locking on ONLY druid and version (as first and second parameters)
   def self.queue_lock_key(*args)
     "lock:#{name}-#{args.slice(0..1).join(';')}"

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 # A very simple job class that extends ApplicationJob to allow testing of basic queue locking behavior
 class RegularParameterJob < ApplicationJob
+  include UniqueJob
   def self.lock_timeout
     1
   end
@@ -15,7 +16,7 @@ class RegularParameterJob < ApplicationJob
   end
 end
 
-describe ApplicationJob, type: :job do
+RSpec.describe ApplicationJob, type: :job do
   include ActiveJob::TestHelper
 
   around do |example|


### PR DESCRIPTION


## Why was this change made? 🤔

Now every job that is using the locking strategy declares "include UniqueJob".  This means we only have jobs that have opted into this strategy on purpose rather than accidentally inheriting this behavior.

Fixes #1899

## How was this change tested? 🤨
Test suite