### PR TITLE
Remove the vestiges of Dor::Services::Client from the tests

### DIFF
--- a/spec/lib/audit/catalog_to_moab_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Audit::CatalogToMoab do
                     results_as_string: nil)
   end
   let(:exp_details_prefix) { 'check_catalog_version (actual location: fixture_sr1; ' }
-  let(:events_client) { instance_double(Dor::Services::Client::Events) }
   let(:hb_exp_msg) do
     'check_catalog_version\\(bj102hs9687, fixture_sr1\\)' \
       ' db CompleteMoab \\(created .*Z; last updated .*Z\\) exists but Moab not found'
@@ -92,11 +91,7 @@ RSpec.describe Audit::CatalogToMoab do
     end
 
     it 'calls online_moab_found?' do
-      allow(Dor::Services::Client).to receive(:object).with("druid:#{druid}").and_return(
-        instance_double(Dor::Services::Client::Object, events: events_client)
-      )
       allow(Honeybadger).to receive(:notify).with(Regexp.new(hb_exp_msg))
-      allow(events_client).to receive(:create).with(type: 'preservation_audit_failure', data: instance_of(Hash))
       expect(c2m).to receive(:online_moab_found?)
       c2m.check_catalog_version
     end
@@ -104,11 +99,7 @@ RSpec.describe Audit::CatalogToMoab do
     context 'moab is nil (exists in catalog but not online)' do
       before do
         allow(Moab::StorageObject).to receive(:new).with(druid, String).and_return(nil)
-        allow(Dor::Services::Client).to receive(:object).with("druid:#{druid}").and_return(
-          instance_double(Dor::Services::Client::Object, events: events_client)
-        )
         allow(Honeybadger).to receive(:notify).with(Regexp.new(hb_exp_msg))
-        allow(events_client).to receive(:create).with(type: 'preservation_audit_failure', data: instance_of(Hash))
       end
 
       it 'adds a MOAB_NOT_FOUND result' do

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe AuditResults do
   let(:actual_version) { 6 }
   let(:audit_results) { described_class.new(druid, actual_version, ms_root) }
   let(:druid) { 'ab123cd4567' }
-  let(:events_client) { instance_double(Dor::Services::Client::Events) }
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
 
   describe '#new' do


### PR DESCRIPTION
## Why was this change made? 🤔

This gets the build working again. There was a problem because we don't have Dor::Services::Client in the gemfile anymore.

This prevents errors like:
```
      Failure/Error:
        allow(Dor::Services::Client).to receive(:object).with("druid:#{druid}").and_return(
          instance_double(Dor::Services::Client::Object, events: events_client)
        )

      NameError:
        uninitialized constant Dor::Services
 ```
 
 when running the tests.

## How was this change tested? 🤨
CI

