### PR TITLE
replace expectations on removed dor-services-client event client with expectations on its replacement, Dor::Event::Client

### DIFF
--- a/spec/services/reporters/event_service_reporter_spec.rb
+++ b/spec/services/reporters/event_service_reporter_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Reporters::EventServiceReporter do
 
   before do
     allow(Socket).to receive(:gethostname).and_return('fakehost')
+    allow(Dor::Event::Client).to receive(:create)
   end
 
   describe '#report_errors' do
@@ -29,7 +30,8 @@ RSpec.describe Reporters::EventServiceReporter do
         subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1, result2])
         error1 = 'FooCheck (actual location: fixture_sr1; actual version: 6) || Invalid Moab, validation errors: ' \
                  "[Version directory name not in 'v00xx' format: original-v1]"
-        expect(client).to have_received(:create).with(
+        expect(Dor::Event::Client).to have_received(:create).with(
+          druid: "druid:#{druid}",
           type: 'preservation_audit_failure',
           data: {
             host: 'fakehost',
@@ -42,7 +44,8 @@ RSpec.describe Reporters::EventServiceReporter do
         )
         error2 = 'FooCheck (actual location: fixture_sr1; actual version: 6) || Invalid Moab, validation errors: ' \
                  "[Version directory name not in 'v00xx' format: original-v2]"
-        expect(client).to have_received(:create).with(
+        expect(Dor::Event::Client).to have_received(:create).with(
+          druid: "druid:#{druid}",
           type: 'preservation_audit_failure',
           data: {
             host: 'fakehost',
@@ -62,7 +65,8 @@ RSpec.describe Reporters::EventServiceReporter do
 
       it 'merges errors and creates single event' do
         subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1, result2])
-        expect(client).to have_received(:create).with(
+        expect(Dor::Event::Client).to have_received(:create).with(
+          druid: "druid:#{druid}",
           type: 'preservation_audit_failure',
           data: {
             host: 'fakehost',
@@ -84,7 +88,8 @@ RSpec.describe Reporters::EventServiceReporter do
     it 'creates events' do
       subject.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
 
-      expect(client).to have_received(:create).with(
+      expect(Dor::Event::Client).to have_received(:create).with(
+        druid: "druid:#{druid}",
         type: 'preservation_audit_success',
         data: {
           host: 'fakehost',
@@ -95,7 +100,8 @@ RSpec.describe Reporters::EventServiceReporter do
         }
       )
 
-      expect(client).to have_received(:create).with(
+      expect(Dor::Event::Client).to have_received(:create).with(
+        druid: "druid:#{druid}",
         type: 'preservation_audit_success',
         data: {
           host: 'fakehost',


### PR DESCRIPTION
## Why was this change made? 🤔

* it seemed like `client` was still referenced even after its definition was removed [here](https://github.com/sul-dlss/preservation_catalog/pull/1909/files#diff-092e0f690b001a6977f6f5b15d9412246f6ce67764588074112ec71dc818d436), so it wasn't clear to me how that spec was passing in Circle.
* and then when i tried to see what would happen for me locally with that branch, i got an error when those tests actually tried to connect to rabbitmq on `localhost` (where i had no rabbitmq instance running).
* it's nice to keep some explicit expectations about what the event service will receive, esp in that event reporter spec.

## How was this change tested? 🤨

unit tests (local/CI)

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



