### PR TITLE
Wtf

### DIFF
--- a/spec/lib/audit/catalog_to_moab_spec.rb
+++ b/spec/lib/audit/catalog_to_moab_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Audit::CatalogToMoab do
                     results_as_string: nil)
   end
   let(:exp_details_prefix) { 'check_catalog_version (actual location: fixture_sr1; ' }
-  let(:events_client) { instance_double(Dor::Services::Client::Events) }
   let(:hb_exp_msg) do
     'check_catalog_version\\(bj102hs9687, fixture_sr1\\)' \
       ' db CompleteMoab \\(created .*Z; last updated .*Z\\) exists but Moab not found'
@@ -92,11 +91,7 @@ RSpec.describe Audit::CatalogToMoab do
     end
 
     it 'calls online_moab_found?' do
-      allow(Dor::Services::Client).to receive(:object).with("druid:#{druid}").and_return(
-        instance_double(Dor::Services::Client::Object, events: events_client)
-      )
       allow(Honeybadger).to receive(:notify).with(Regexp.new(hb_exp_msg))
-      allow(events_client).to receive(:create).with(type: 'preservation_audit_failure', data: instance_of(Hash))
       expect(c2m).to receive(:online_moab_found?)
       c2m.check_catalog_version
     end
@@ -104,11 +99,7 @@ RSpec.describe Audit::CatalogToMoab do
     context 'moab is nil (exists in catalog but not online)' do
       before do
         allow(Moab::StorageObject).to receive(:new).with(druid, String).and_return(nil)
-        allow(Dor::Services::Client).to receive(:object).with("druid:#{druid}").and_return(
-          instance_double(Dor::Services::Client::Object, events: events_client)
-        )
         allow(Honeybadger).to receive(:notify).with(Regexp.new(hb_exp_msg))
-        allow(events_client).to receive(:create).with(type: 'preservation_audit_failure', data: instance_of(Hash))
       end
 
       it 'adds a MOAB_NOT_FOUND result' do

--- a/spec/services/audit_results_spec.rb
+++ b/spec/services/audit_results_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe AuditResults do
   let(:actual_version) { 6 }
   let(:audit_results) { described_class.new(druid, actual_version, ms_root) }
   let(:druid) { 'ab123cd4567' }
-  let(:events_client) { instance_double(Dor::Services::Client::Events) }
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
 
   describe '#new' do

--- a/spec/services/reporters/event_service_reporter_spec.rb
+++ b/spec/services/reporters/event_service_reporter_spec.rb
@@ -5,17 +5,12 @@ require 'rails_helper'
 RSpec.describe Reporters::EventServiceReporter do
   let(:subject) { described_class.new }
 
-  let(:client) { instance_double(Dor::Services::Client::Events) }
   let(:druid) { 'ab123cd4567' }
   let(:actual_version) { 6 }
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
   let(:check_name) { 'FooCheck' }
 
   before do
-    allow(Dor::Services::Client).to receive(:object).with("druid:#{druid}").and_return(
-      instance_double(Dor::Services::Client::Object, events: client)
-    )
-    allow(client).to receive(:create)
     allow(Socket).to receive(:gethostname).and_return('fakehost')
   end
 

--- a/spec/services/reporters/event_service_reporter_spec.rb
+++ b/spec/services/reporters/event_service_reporter_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Reporters::EventServiceReporter do
 
     it 'creates events' do
       subject.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
-
+puts "in event service reporter. Client is #{client}"
       expect(client).to have_received(:create).with(
         type: 'preservation_audit_success',
         data: {


### PR DESCRIPTION
## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



