### PR TITLE
Change zip version to instance variable.

### DIFF
--- a/app/models/druid_version_zip.rb
+++ b/app/models/druid_version_zip.rb
@@ -148,10 +148,8 @@ class DruidVersionZip
     "zip -r0X -s #{zip_split_size} #{file_path} #{druid.id}/#{v_version}"
   end
 
-  # We presume the system guts do not change underneath a given class instance.
-  # We want to avoid shelling out (forking) unnecessarily, just for the version.
   def zip_version
-    @@zip_version ||= fetch_zip_version # rubocop:disable Style/ClassVars
+    @zip_version ||= fetch_zip_version
   end
 
   # @return [Pathname]


### PR DESCRIPTION
refs #1881

## Why was this change made? 🤔
Thread safety. Maybe.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡


