### PR TITLE
Adds delay to ValidateMoabJob.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,12 @@ Naming/FileName:
     - 'Capfile'
     - 'Gemfile'
 
+RSpec/AnyInstance:
+  Enabled: true
+  Exclude:
+    - 'spec/jobs/validate_moab_job_spec.rb'
+    - 'spec/jobs/zipmaker_job_spec.rb'
+
 RSpec/ContextWording:
   Enabled: false # too dogmatic
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -21,4 +21,13 @@ class ApplicationJob < ActiveJob::Base
       raise ArgumentError, "Required metadata[:#{key}] not found" if metadata[key].blank?
     end
   end
+
+  # sleep for a configured amount of time.
+  #
+  # BUT WHY? to prevent duplication and possible explanation drift, see Robots::SdrRepo::PreservationIngest::UpdateCatalog#wait_as_needed
+  # for more detailed explanation.  the short version is, this helps alleviate Ceph MDS write/read sync and/or contention issues that
+  # we don't yet fully understand.
+  def wait_as_needed
+    sleep(Settings.filesystem_delay_seconds)
+  end
 end

--- a/app/jobs/validate_moab_job.rb
+++ b/app/jobs/validate_moab_job.rb
@@ -9,6 +9,7 @@ class ValidateMoabJob < ApplicationJob
   attr_accessor :druid
 
   # @param [String] druid of Moab on disk to be checksum validated
+  # rubocop:disable Metrics/AbcSize
   def perform(druid)
     log_failure('Valid druid param required') and return unless DruidTools::Druid.valid?(druid, true)
 
@@ -16,6 +17,8 @@ class ValidateMoabJob < ApplicationJob
 
     start = Time.zone.now
     log_started
+
+    wait_as_needed
 
     # TODO: what if we lose connectivity while it's running in resque
     errors = validate
@@ -27,6 +30,7 @@ class ValidateMoabJob < ApplicationJob
   rescue StandardError => e
     log_failure(e.inspect)
   end
+  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/app/jobs/zipmaker_job.rb
+++ b/app/jobs/zipmaker_job.rb
@@ -33,13 +33,4 @@ class ZipmakerJob < ApplicationJob
       PlexerJob.perform_later(druid, version, part_key, DruidVersionZipPart.new(zip, part_key).metadata)
     end
   end
-
-  # sleep for a configured amount of time.
-  #
-  # BUT WHY? to prevent duplication and possible explanation drift, see Robots::SdrRepo::PreservationIngest::UpdateCatalog#wait_as_needed
-  # for more detailed explanation.  the short version is, this helps alleviate Ceph MDS write/read sync and/or contention issues that
-  # we don't yet fully understand.
-  def wait_as_needed
-    sleep(Settings.hacks.zipmaker_delay_seconds)
-  end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,8 +16,8 @@ set :deploy_to, "/opt/app/pres/#{fetch(:application)}"
 # These are the defaults.
 # set :format_options, command_output: true, log_file: "log/capistrano.log", color: :auto, truncate: :auto
 
-# Default value for :pty is false
-# set :pty, true
+# for ubuntu to perform resque:pool:hot_swap
+set :pty, true
 
 # Default value for :linked_files is []
 append :linked_files, 'config/database.yml', 'config/resque.yml', 'config/resque-pool.yml', 'tmp/resque-pool.lock'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,8 +46,7 @@ api_jwt:
   hmac_secret: 'my$ecretK3y'
 
 # we expect/hope that this will not stay around forever.  see usage for further explanation.
-hacks:
-  zipmaker_delay_seconds: 0.05 # the default value is artificially low to keep test suite fast -- should override to be many seconds in prod
+filesystem_delay_seconds: 0.05 # the default value is artificially low to keep test suite fast -- should override to be many seconds in prod
 
 rabbitmq:
   hostname: localhost

--- a/spec/jobs/validate_moab_job_spec.rb
+++ b/spec/jobs/validate_moab_job_spec.rb
@@ -66,6 +66,11 @@ describe ValidateMoabJob, type: :job do
                                                                           error_msg: a_string_matching(expected_str_regex))
     end
 
+    it 'sleeps' do
+      expect_any_instance_of(described_class).to receive(:sleep).with(Settings.filesystem_delay_seconds)
+      job.perform(druid)
+    end
+
     context 'when validation runs' do
       let(:expected_validation_err_regex) { /^Problem with Moab validation run on .*#{error_regex_str}.*/ }
 

--- a/spec/jobs/zipmaker_job_spec.rb
+++ b/spec/jobs/zipmaker_job_spec.rb
@@ -26,6 +26,11 @@ describe ZipmakerJob, type: :job do
     described_class.perform_now(druid, version, moab_replication_storage_location)
   end
 
+  it 'sleeps' do
+    expect_any_instance_of(described_class).to receive(:sleep).with(Settings.filesystem_delay_seconds)
+    described_class.perform_now(druid, version, moab_replication_storage_location)
+  end
+
   context 'the moab version to be archived is bigger than the zip split size' do
     let(:druid) { 'bz514sm9647' }
     let(:version) { 1 }


### PR DESCRIPTION
closes #1918

## Why was this change made? 🤔
Be nice to ceph.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

* Unit
* `create_preassembly_image_spec.rb` in QA.

