### PR TITLE
Update to latest workflow client.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'aws-sdk-s3', '~> 1.17'
 gem 'committee' # Validates HTTP requests/responses per OpenAPI specification
 gem 'config' # Settings to manage configs on different instances
 gem 'dor-event-client', '~> 1.0'
-gem 'dor-workflow-client', '~> 4.0' # audit errors are reported to the workflow service
+gem 'dor-workflow-client', '~> 5.0' # audit errors are reported to the workflow service
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'jbuilder', '~> 2.5' # Build JSON APIs with ease.
 gem 'jwt' # for gating programmatic access to the application

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,11 +139,11 @@ GEM
       activesupport (>= 4.2, < 8)
       bunny (~> 2.17)
       zeitwerk (~> 2.1)
-    dor-workflow-client (4.0.0)
+    dor-workflow-client (5.0.0)
       activesupport (>= 3.2.1, < 8)
       deprecation (>= 0.99.0)
       faraday (~> 2.0)
-      faraday-retry
+      faraday-retry (~> 1.0)
       nokogiri (~> 1.6)
       zeitwerk (~> 2.1)
     druid-tools (2.2.1)
@@ -189,8 +189,7 @@ GEM
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.1.0)
-    faraday-retry (2.0.0)
-      faraday (~> 2.0)
+    faraday-retry (1.0.3)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -420,7 +419,7 @@ DEPENDENCIES
   config
   dlss-capistrano
   dor-event-client (~> 1.0)
-  dor-workflow-client (~> 4.0)
+  dor-workflow-client (~> 5.0)
   druid-tools
   factory_bot_rails (~> 4.0)
   honeybadger


### PR DESCRIPTION
closes #1926

## Why was this change made? 🤔
To pin the correct version of faraday-retries.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



