### PR TITLE
use pry, not pry-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'pg' # postgres database
 gem 'postgresql_cursor' # for paging over large result sets efficiently
 # pry is useful for debugging, even in prod
 gem 'pry-byebug' # call 'binding.pry' anywhere in the code to stop execution and get a pry-byebug console
-gem 'pry-rails' # use pry as the rails console shell instead of IRB
+gem 'pry' # make it possible to use pry for IRB
 gem 'puma', '~> 5.5' # app server
 gem 'rails', '~> 6.1.0'
 gem 'resque', '~> 1.27'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,8 +258,6 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     public_suffix (5.0.0)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -431,8 +429,8 @@ DEPENDENCIES
   okcomputer
   pg
   postgresql_cursor
+  pry
   pry-byebug
-  pry-rails
   puma (~> 5.5)
   rails (~> 6.1.0)
   rails-controller-testing


### PR DESCRIPTION
## Why was this change made? 🤔

`pry-rails` is no longer maintained;  some of us still prefer `pry`, tho.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



