### PR TITLE
Remove capistrano-rvm dependency

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -15,7 +15,6 @@ require "capistrano/honeybadger"
 require "dlss/capistrano"
 require "dlss/capistrano/resque_pool"
 require 'whenever/capistrano'
-require 'capistrano/rvm'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -52,5 +52,4 @@ group :deploy do
   gem 'capistrano-rails'
   gem 'capistrano-passenger'
   gem 'dlss-capistrano'
-  gem 'capistrano-rvm'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,9 +108,6 @@ GEM
     capistrano-rails (1.6.2)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
     coderay (1.1.3)
@@ -412,7 +409,6 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.17)
   capistrano-passenger
   capistrano-rails
-  capistrano-rvm
   committee
   config
   dlss-capistrano

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,10 +27,6 @@ append :linked_dirs, 'log', 'config/settings', 'tmp/pids'
 
 set :honeybadger_env, fetch(:stage)
 
-# the honeybadger gem should integrate automatically with capistrano-rvm but it
-# doesn't appear to do so on our new Ubuntu boxes :shrug:
-set :rvm_map_bins, fetch(:rvm_map_bins, []).push('honeybadger')
-
 set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
 
 set :resque_server_roles, :resque


### PR DESCRIPTION
## Why was this change made? 🤔

This commit removes capistrano-rvm, a dependency we no longer need. Done because it is on the FR board.



## How was this change tested? 🤨

Tested by deploying to stage
