### PR TITLE
Adding create_bag.rb from preservation_robots

### DIFF
--- a/bin/create_bag
+++ b/bin/create_bag
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This script can be used to pull objects from preservation, if we need to re-accession it into DOR.
+#
+# You must run it from ~/preservation_catalog/current/
+# using bin/create_bag /directory/with/druids/druid-list.txt /some/directory
+# where /directory/with/druids/druid-list.txt is wherever your druid file list is,
+# and where /some/directory is wherever you want the bags to land, usually in the tmp directory.
+# 
+# NOTE: druids should be each on their own line in the list, with or without the druid prefix, 
+# e.g. druid:pv564yb1711 or pv564yb1711
+
+require 'rubygems'
+require 'bundler/setup'
+require 'moab/stanford'
+require 'yaml'
+
+# rubocop:disable Style/MixinUsage
+include Stanford
+# rubocop:enable Style/MixinUsage
+
+settings = YAML.load_file(File.join(__dir__, '..', 'config', 'settings', 'production.yml'))
+
+Moab::Config.configure do
+  storage_roots settings['storage_root_map']['default'].values.sort
+  storage_trunk 'sdr2objects'
+  deposit_trunk 'deposit'
+  path_method 'druid_tree'
+end
+
+druids = []
+druidlist = File.open(ARGV[0])
+druidlist.each_line { |line| druids.push line.chomp }
+
+druids.each do |druid|
+  druid = druid.delete_prefix('druid:')
+  storage_object = StorageServices.find_storage_object(druid)
+  version_id = storage_object.current_version_id
+  bag_dir = "#{ARGV[1]}/bags/#{druid}"
+  storage_object.reconstruct_version(version_id, bag_dir)
+rescue ObjectNotFoundException => e
+  puts "#{druid}, #{e}"
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Port `bin/create_bag.rb` from preservation_robots so that it can run against a read-only filesystem in prescat environments.

Closes #1871 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



