### PR TITLE
[HOLD] db migration: rename index to use 'complete_moab' rather than 'preserved copy'

### DIFF
--- a/app/lib/audit/moab_to_catalog.rb
+++ b/app/lib/audit/moab_to_catalog.rb
@@ -14,16 +14,15 @@ module Audit
     # this method intended to be called from rake task or via ReST call
     def self.check_existence_for_druid(druid)
       logger.info "#{Time.now.utc.iso8601} M2C check_existence_for_druid starting for #{druid}"
-      Stanford::StorageServices.search_storage_objects(druid).map do |moab|
-        storage_trunk = Settings.moab.storage_trunk
-        storage_dir = "#{moab.object_pathname.to_s.split(storage_trunk).first}#{storage_trunk}"
-        ms_root = MoabStorageRoot.find_by!(storage_location: storage_dir)
-        comp_moab_handler = CompleteMoabHandler.new(druid, moab.current_version_id, moab.size, ms_root)
-        comp_moab_handler.logger = Audit::MoabToCatalog.logger
-        results = comp_moab_handler.check_existence
-        logger.info "#{results} for #{druid}"
-        results
-      end
+      moab = Stanford::StorageServices.find_storage_object(druid)
+      storage_trunk = Settings.moab.storage_trunk
+      storage_dir = "#{moab.object_pathname.to_s.split(storage_trunk).first}#{storage_trunk}"
+      ms_root = MoabStorageRoot.find_by!(storage_location: storage_dir)
+      comp_moab_handler = CompleteMoabHandler.new(druid, moab.current_version_id, moab.size, ms_root)
+      comp_moab_handler.logger = Audit::MoabToCatalog.logger
+      results = comp_moab_handler.check_existence
+      logger.info "#{results} for #{druid}"
+      results
     rescue TypeError
       logger.info "#{Time.now.utc.iso8601} Moab object path does not exist."
     ensure

--- a/db/migrate/20221004215925_add_unique_constraint_preserved_object_id_to_complete_moab.rb
+++ b/db/migrate/20221004215925_add_unique_constraint_preserved_object_id_to_complete_moab.rb
@@ -1,0 +1,11 @@
+class AddUniqueConstraintPreservedObjectIdToCompleteMoab < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :complete_moabs, :name=> "index_complete_moabs_on_preserved_object_id"
+    add_index :complete_moabs, [:preserved_object_id], :unique => true, :name=> "index_complete_moabs_on_preserved_object_id"
+  end
+
+  def down
+    remove_index :complete_moabs, :name=> "index_complete_moabs_on_preserved_object_id"
+    add_index :complete_moabs, [:preserved_object_id], :name=> "index_complete_moabs_on_preserved_object_id"
+  end
+end

--- a/db/migrate/20221007185705_rename_index_complete_moab_on_po_and_storage_root.rb
+++ b/db/migrate/20221007185705_rename_index_complete_moab_on_po_and_storage_root.rb
@@ -1,0 +1,9 @@
+class RenameIndexCompleteMoabOnPoAndStorageRoot < ActiveRecord::Migration[6.1]
+  def up
+    rename_index :complete_moabs, 'index_preserved_copies_on_po_and_storage_root_and_version', 'index_complete_moabs_on_po_and_storage_root_and_version'
+  end
+
+  def down
+    rename_index :complete_moabs, 'index_complete_moabs_on_po_and_storage_root_and_version', 'index_preserved_copies_on_po_and_storage_root_and_version'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_29_232757) do
+ActiveRecord::Schema.define(version: 2022_10_04_215925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 2020_06_29_232757) do
     t.index ["moab_storage_root_id"], name: "index_complete_moabs_on_moab_storage_root_id"
     t.index ["preserved_object_id", "moab_storage_root_id", "version"], name: "index_preserved_copies_on_po_and_storage_root_and_version", unique: true
     t.index ["preserved_object_id", "moab_storage_root_id"], name: "index_complete_moab_on_po_and_storage_root_id", unique: true
-    t.index ["preserved_object_id"], name: "index_complete_moabs_on_preserved_object_id"
+    t.index ["preserved_object_id"], name: "index_complete_moabs_on_preserved_object_id", unique: true
     t.index ["status"], name: "index_complete_moabs_on_status"
     t.index ["updated_at"], name: "index_complete_moabs_on_updated_at"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_04_215925) do
+ActiveRecord::Schema.define(version: 2022_10_07_185705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2022_10_04_215925) do
     t.index ["last_moab_validation"], name: "index_complete_moabs_on_last_moab_validation"
     t.index ["last_version_audit"], name: "index_complete_moabs_on_last_version_audit"
     t.index ["moab_storage_root_id"], name: "index_complete_moabs_on_moab_storage_root_id"
-    t.index ["preserved_object_id", "moab_storage_root_id", "version"], name: "index_preserved_copies_on_po_and_storage_root_and_version", unique: true
+    t.index ["preserved_object_id", "moab_storage_root_id", "version"], name: "index_complete_moabs_on_po_and_storage_root_and_version", unique: true
     t.index ["preserved_object_id", "moab_storage_root_id"], name: "index_complete_moab_on_po_and_storage_root_id", unique: true
     t.index ["preserved_object_id"], name: "index_complete_moabs_on_preserved_object_id", unique: true
     t.index ["status"], name: "index_complete_moabs_on_status"

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -145,10 +145,6 @@ RSpec.describe CatalogController, type: :controller do
     let(:comp_moab) do
       pres_obj.complete_moabs.find_by!(moab_storage_root: MoabStorageRoot.find_by!(name: 'fixture_sr1'))
     end
-    let!(:comp_moab_sr_a) do
-      # create a CompleteMoab record for the other moab we have for this druid, to confirm support for multiple copies of a moab
-      create(:complete_moab, preserved_object: pres_obj, version: 1, moab_storage_root: MoabStorageRoot.find_by!(name: 'fixture_srA'))
-    end
     let(:primary_moab) { comp_moab }
 
     before do
@@ -172,21 +168,6 @@ RSpec.describe CatalogController, type: :controller do
 
       it 'returns an ok response code' do
         expect(response).to have_http_status(:ok)
-      end
-
-      context 'updating a non-primary' do
-        let!(:pres_obj) { create(:preserved_object, druid: bare_druid, current_version: 1) } # as if the one on srA was always primary
-        let!(:comp_moab) { create(:complete_moab, preserved_object: pres_obj, version: 3) } # create fixture_sr1 record, not created w/ PO this case
-        let(:primary_moab) { comp_moab_sr_a } # but we're still doing PATCH on the fixture_sr1 moab
-
-        it 'updates CompleteMoab#version' do
-          pending('this is known to fail, because CMH does not update CompleteMoab if its version does not match parent PO#current_version')
-          expect(comp_moab.reload.version).to eq upd_version
-        end
-
-        it 'updates PreservedObject#current_version' do
-          expect(pres_obj.reload.current_version).to eq primary_moab.version
-        end
       end
     end
 

--- a/spec/jobs/catalog_to_moab_job_spec.rb
+++ b/spec/jobs/catalog_to_moab_job_spec.rb
@@ -14,48 +14,5 @@ describe CatalogToMoabJob, type: :job do
       expect(Audit::CatalogToMoab).to receive(:new).with(cm).and_return(validator)
       job.perform(cm)
     end
-
-    context 'there are two moabs for the druid' do
-      let(:druid) { 'bz514sm9647' }
-      let(:msr_1) { MoabStorageRoot.find_by!(name: 'fixture_sr1') }
-      let(:msr_a) { MoabStorageRoot.find_by!(name: 'fixture_srA') }
-      let(:po) { create(:preserved_object, druid: druid, current_version: 1) }
-      let(:cm_1) { create(:complete_moab, preserved_object: po, version: 1, moab_storage_root: msr_1) } # this catalog entry lags disk to start test
-      let(:cm_a) { create(:complete_moab, preserved_object: po, version: 1, moab_storage_root: msr_a) }
-
-      context 'the one with the lower version is the primary' do
-        before do
-          PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: cm_1) # version that's ahead, on 01, is primary
-          job.perform(cm_1)
-          job.perform(cm_a)
-        end
-
-        it 'sets CompleteMoab#version to the version of the moab on that storage root' do
-          expect(cm_1.reload.version).to eq 3
-          expect(cm_a.reload.version).to eq 1
-        end
-
-        it 'sets PreservedObject#current_version to the highest version seen for the primary CompleteMoab' do
-          expect(po.reload.current_version).to eq 3
-        end
-      end
-
-      context 'the one with the higher version is the primary' do
-        before do
-          PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: cm_a) # version that's behind, on A, is primary
-          job.perform(cm_a)
-          job.perform(cm_1)
-        end
-
-        it 'sets CompleteMoab#version to the version of the moab on that storage root' do
-          expect(cm_1.reload.version).to eq 3
-          expect(cm_a.reload.version).to eq 1
-        end
-
-        it 'sets PreservedObject#current_version to the highest version seen for the primary CompleteMoab' do
-          expect(po.reload.current_version).to eq 1 # the copy that's behind is the primary -- this would be unusual, but just to define the behavior
-        end
-      end
-    end
   end
 end

--- a/spec/jobs/moab_to_catalog_job_spec.rb
+++ b/spec/jobs/moab_to_catalog_job_spec.rb
@@ -20,45 +20,4 @@ describe MoabToCatalogJob, type: :job do
       job.perform(msr, druid)
     end
   end
-
-  context 'there are two moabs for the druid' do
-    let(:druid) { 'bz514sm9647' }
-    let(:msr_1) { MoabStorageRoot.find_by!(name: 'fixture_sr1') }
-    let(:msr_a) { MoabStorageRoot.find_by!(name: 'fixture_srA') }
-    let(:cm_1) { CompleteMoab.by_druid(druid).find_by!(moab_storage_root: msr_1) }
-    let(:cm_a) { CompleteMoab.by_druid(druid).find_by!(moab_storage_root: msr_a) }
-    let(:po) { PreservedObject.find_by!(druid: druid) }
-
-    context 'the one with the lower version is the primary' do
-      before do
-        job.perform(msr_1, druid) # first added is primary by default
-        job.perform(msr_a, druid)
-      end
-
-      it 'sets CompleteMoab#version to the version of the moab on that storage root' do
-        expect(cm_1.version).to eq 3
-        expect(cm_a.version).to eq 1
-      end
-
-      it 'sets PreservedObject#current_version to the highest version seen for the primary CompleteMoab' do
-        expect(po.current_version).to eq 3
-      end
-    end
-
-    context 'the one with the higher version is the primary' do
-      before do
-        job.perform(msr_a, druid) # first added is primary by default
-        job.perform(msr_1, druid)
-      end
-
-      it 'sets CompleteMoab#version to the version of the moab on that storage root' do
-        expect(cm_1.version).to eq 3
-        expect(cm_a.version).to eq 1
-      end
-
-      it 'sets PreservedObject#current_version to the highest version seen for the primary CompleteMoab' do
-        expect(po.current_version).to eq 1 # the copy that's behind is the primary -- this would be unusual, but just to define the behavior
-      end
-    end
-  end
 end

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Audit::MoabToCatalog do
   let(:storage_dir) { 'spec/fixtures/storage_root01/sdr2objects' }
   let(:ms_root) { MoabStorageRoot.find_by!(storage_location: storage_dir) }
   let(:moab) do
-    m = instance_double(Moab::StorageObject, object_pathname: storage_dir, :storage_root= => nil)
-    allow(Moab::StorageObject).to receive(:new).and_return(m)
-    m
+    moab = instance_double(Moab::StorageObject, object_pathname: storage_dir, :storage_root= => nil)
+    allow(Moab::StorageObject).to receive(:new).and_return(moab)
+    moab
   end
   let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
@@ -35,12 +35,19 @@ RSpec.describe Audit::MoabToCatalog do
   end
 
   describe '.seed_catalog_for_all_storage_roots' do
-    it 'calls seed_catalog_for_dir with the right argument once per root' do
-      expect(described_class).to receive(:seed_catalog_for_dir).exactly(MoabStorageRoot.count).times
+    before do
+      allow(described_class).to receive(:seed_catalog_for_dir).exactly(MoabStorageRoot.count).times
       MoabStorageRoot.pluck(:storage_location) do |path|
-        expect(described_class).to receive(:seed_catalog_for_dir).with("#{path}/#{Settings.moab.storage_trunk}")
+        allow(described_class).to receive(:seed_catalog_for_dir).with("#{path}/#{Settings.moab.storage_trunk}")
       end
+    end
+
+    it 'calls seed_catalog_for_dir with the right argument once per root' do
       described_class.seed_catalog_for_all_storage_roots
+      expect(described_class).to have_received(:seed_catalog_for_dir).exactly(MoabStorageRoot.count).times
+      MoabStorageRoot.pluck(:storage_location) do |path|
+        expect(described_class).to have_received(:seed_catalog_for_dir).with("#{path}/#{Settings.moab.storage_trunk}")
+      end
     end
   end
 
@@ -48,49 +55,39 @@ RSpec.describe Audit::MoabToCatalog do
     let(:druid) { 'bz514sm9647' }
     let(:storage_dir_a) { 'spec/fixtures/storage_rootA/sdr2objects' }
     let(:results) do
-      [[{ db_obj_does_not_exist: 'CompleteMoab db object does not exist' },
-        { created_new_object: 'added object to db as it did not exist' }],
-       [{ db_obj_does_not_exist: 'CompleteMoab db object does not exist' },
-        { created_new_object: 'added object to db as it did not exist' }]]
+      [{ db_obj_does_not_exist: 'CompleteMoab db object does not exist' },
+       { created_new_object: 'added object to db as it did not exist' }]
     end
     let(:po) { PreservedObject.find_by!(druid: druid) }
     let(:msr) { MoabStorageRoot.find_by!(storage_location: storage_dir) }
-    let(:msr_a) { MoabStorageRoot.find_by!(storage_location: storage_dir_a) }
 
-    it 'finds and catalogs the relevant moabs' do
+    it 'finds and catalogs the relevant moab' do
       expect(CompleteMoab.by_druid(druid).by_storage_root(msr)).not_to exist
-      expect(CompleteMoab.by_druid(druid).by_storage_root(msr_a)).not_to exist
       described_class.check_existence_for_druid(druid)
       expect(CompleteMoab.by_druid(druid).by_storage_root(msr)).to exist
-      expect(CompleteMoab.by_druid(druid).by_storage_root(msr_a)).to exist
     end
 
     it 'creates the CompleteMoab records, each with its respective version' do
       described_class.check_existence_for_druid(druid)
       expect(CompleteMoab.find_by!(preserved_object: po, moab_storage_root: msr).version).to eq 3
-      expect(CompleteMoab.find_by!(preserved_object: po, moab_storage_root: msr_a).version).to eq 1
     end
 
     it 'calls CompleteMoabHandler.check_existence' do
       complete_moab_handler = instance_double(CompleteMoabHandler)
-      complete_moab_handler_a = instance_double(CompleteMoabHandler)
-      expect(CompleteMoabHandler).to receive(:new).with(
-        druid,
-        3, # current_version
-        instance_of(Integer), # size
-        ms_root
-      ).and_return(complete_moab_handler)
-      expect(CompleteMoabHandler).to receive(:new).with(
-        druid,
-        1, # version of the second copy
-        instance_of(Integer), # size
-        MoabStorageRoot.find_by(storage_location: storage_dir_a)
-      ).and_return(complete_moab_handler_a)
-      expect(complete_moab_handler).to receive(:logger=)
-      expect(complete_moab_handler).to receive(:check_existence)
-      expect(complete_moab_handler_a).to receive(:logger=)
-      expect(complete_moab_handler_a).to receive(:check_existence)
+      allow(CompleteMoabHandler).to receive(:new).with(druid,
+                                                       3, # current_version
+                                                       instance_of(Integer), # size
+                                                       ms_root)
+                                                 .and_return(complete_moab_handler)
+      allow(complete_moab_handler).to receive(:logger=)
+      allow(complete_moab_handler).to receive(:check_existence)
       described_class.check_existence_for_druid(druid)
+      expect(CompleteMoabHandler).to have_received(:new).with(druid,
+                                                              3, # current_version
+                                                              instance_of(Integer), # size
+                                                              ms_root)
+      expect(complete_moab_handler).to have_received(:logger=)
+      expect(complete_moab_handler).to have_received(:check_existence)
     end
 
     it 'returns results' do
@@ -101,19 +98,27 @@ RSpec.describe Audit::MoabToCatalog do
       let(:druid) { 'db102hs2345' }
 
       it 'does not call CompleteMoabHandler.check_existence' do
-        expect(CompleteMoabHandler).not_to receive(:new)
+        allow(CompleteMoabHandler).to receive(:new)
         described_class.check_existence_for_druid(druid)
+        expect(CompleteMoabHandler).not_to have_received(:new)
       end
     end
   end
 
   describe '.check_existence_for_druid_list' do
-    it 'calls MoabToCatalog.check_existence_for_druid once per druid' do
-      csv_file_path = 'spec/fixtures/druid_list.csv'
+    let(:csv_file_path) { 'spec/fixtures/druid_list.csv' }
+
+    before do
       CSV.foreach(csv_file_path) do |row|
-        expect(described_class).to receive(:check_existence_for_druid).with(row.first)
+        allow(described_class).to receive(:check_existence_for_druid).with(row.first)
       end
+    end
+
+    it 'calls MoabToCatalog.check_existence_for_druid once per druid' do
       described_class.check_existence_for_druid_list(csv_file_path)
+      CSV.foreach(csv_file_path) do |row|
+        expect(described_class).to have_received(:check_existence_for_druid).with(row.first)
+      end
     end
   end
 
@@ -122,15 +127,19 @@ RSpec.describe Audit::MoabToCatalog do
     let(:druid) { 'bz514sm9647' }
 
     it "calls 'find_moab_paths' with appropriate argument" do
-      expect(MoabStorageDirectory).to receive(:find_moab_paths).with(storage_dir)
+      allow(MoabStorageDirectory).to receive(:find_moab_paths).with(storage_dir)
       described_class.seed_catalog_for_dir(storage_dir)
+      expect(MoabStorageDirectory).to have_received(:find_moab_paths).with(storage_dir)
     end
 
     it 'gets moab size and current version from Moab::StorageObject' do
-      expect(moab).to receive(:size).at_least(:once)
-      expect(moab).to receive(:current_version_id).at_least(:once)
-      expect(Moab::StorageServices).not_to receive(:new)
+      allow(moab).to receive(:size).at_least(:once)
+      allow(moab).to receive(:current_version_id).at_least(:once)
+      allow(Moab::StorageServices).to receive(:new)
       described_class.seed_catalog_for_dir(storage_dir)
+      expect(moab).to have_received(:size).at_least(:once)
+      expect(moab).to have_received(:current_version_id).at_least(:once)
+      expect(Moab::StorageServices).not_to have_received(:new)
     end
 
     context '(creates after validation)' do
@@ -152,18 +161,19 @@ RSpec.describe Audit::MoabToCatalog do
             instance_of(Integer),
             ms_root
           ).and_return(complete_moab_handler)
+          allow(arg_hash[:complete_moab_handler]).to receive(:create_after_validation)
         end
       end
 
-      it 'call #create_after_validation' do
-        expected_argument_list.each do |arg_hash|
-          expect(arg_hash[:complete_moab_handler]).to receive(:create_after_validation)
-        end
+      it 'calls #create_after_validation' do
         described_class.seed_catalog_for_dir(storage_dir)
+        expected_argument_list.each do |arg_hash|
+          expect(arg_hash[:complete_moab_handler]).to have_received(:create_after_validation)
+        end
       end
     end
 
-    it 'return correct number of results' do
+    it 'returns correct number of results' do
       expect(described_class.seed_catalog_for_dir(storage_dir).count).to eq 3
     end
 
@@ -173,8 +183,8 @@ RSpec.describe Audit::MoabToCatalog do
       expect(CompleteMoab.by_druid(druid).count).to eq 1
       expect(CompleteMoab.count).to eq 3
       expect(described_class.seed_catalog_for_dir(storage_dir_a).count).to eq 1
-      expect(CompleteMoab.by_druid(druid).count).to eq 2
-      expect(CompleteMoab.count).to eq 4
+      expect(CompleteMoab.by_druid(druid).count).to eq 1
+      expect(CompleteMoab.count).to eq 3
       expect(PreservedObject.count).to eq 3
     end
   end
@@ -183,16 +193,16 @@ RSpec.describe Audit::MoabToCatalog do
     before { described_class.seed_catalog_for_all_storage_roots }
 
     it "won't change objects in a fully seeded db" do
-      expect { described_class.populate_moab_storage_root('fixture_sr1') }.not_to change(CompleteMoab, :count).from(18)
-      expect(PreservedObject.count).to eq 17 # two moabs for bz514sm9647, hence difference in count between CompleteMoab & PreservedObject
+      expect { described_class.populate_moab_storage_root('fixture_sr1') }.not_to change(CompleteMoab, :count).from(17)
+      expect(PreservedObject.count).to eq 17
     end
 
     it 're-adds objects for a dropped MoabStorageRoot' do
       ZippedMoabVersion.destroy_all
       ms_root.complete_moabs.destroy_all
       PreservedObject.without_complete_moabs.destroy_all
-      expect(PreservedObject.count).to eq 15
-      expect { described_class.populate_moab_storage_root('fixture_sr1') }.to change(CompleteMoab, :count).from(15).to(18)
+      expect(PreservedObject.count).to eq 14
+      expect { described_class.populate_moab_storage_root('fixture_sr1') }.to change(CompleteMoab, :count).from(14).to(17)
       expect(PreservedObject.count).to eq 17
     end
   end

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe PreservedObject, type: :model do
-  # let!(:preservation_policy) { PreservationPolicy.default_policy }
   # let(:preservation_policy) { create(:preservation_policy, preservation_policy_name: 'large_dark_objects') }
   let(:preservation_policy) { PreservationPolicy.default_policy }
   let(:druid) { 'bc123df4567' }
@@ -116,9 +115,7 @@ RSpec.describe PreservedObject, type: :model do
     let!(:preserved_object) { create(:preserved_object, druid: druid, current_version: 3) }
     let(:current_version) { preserved_object.current_version }
     let!(:msr1) { create(:moab_storage_root) }
-    let!(:msr2) { create(:moab_storage_root) }
     let!(:cm1) { create(:complete_moab, preserved_object: preserved_object, version: current_version, moab_storage_root: msr1) }
-    let!(:cm2) { create(:complete_moab, preserved_object: preserved_object, version: current_version - 1, moab_storage_root: msr2) }
     let(:zmvs_by_druid) { ZippedMoabVersion.by_druid(druid) }
     let(:zip_endpoints) { preserved_object.preservation_policy.zip_endpoints }
     let!(:zip_ep) { zip_endpoints.first }
@@ -133,7 +130,6 @@ RSpec.describe PreservedObject, type: :model do
       expect(ZipmakerJob).to receive(:perform_later).with(preserved_object.druid, 1, cm1.moab_storage_root.storage_location)
       expect(ZipmakerJob).to receive(:perform_later).with(preserved_object.druid, 2, cm1.moab_storage_root.storage_location)
       expect(ZipmakerJob).to receive(:perform_later).with(preserved_object.druid, 3, cm1.moab_storage_root.storage_location)
-      expect(ZipmakerJob).not_to receive(:perform_later).with(anything, anything, cm2.moab_storage_root.storage_location)
       expect { preserved_object.create_zipped_moab_versions! }.to change {
         ZipEndpoint.which_need_archive_copy(druid, current_version).to_a.to_set
       }.from([zip_ep, zip_ep2].to_set).to([].to_set).and change {

--- a/spec/services/complete_moab_handler_confirm_version_spec.rb
+++ b/spec/services/complete_moab_handler_confirm_version_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe CompleteMoabHandler do
       let(:cm_version) { po_current_version }
       let!(:po) { create(:preserved_object, druid: druid, current_version: po_current_version) }
       let!(:cm) do
-        # Adds new complete moab with the same druid to confirm that tests pass
-        create(:complete_moab, preserved_object: po, moab_storage_root: create(:moab_storage_root))
         create(:complete_moab, preserved_object: po, version: cm_version, moab_storage_root: ms_root) do |primary_cm|
           PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: primary_cm)
         end

--- a/spec/services/complete_moab_handler_spec.rb
+++ b/spec/services/complete_moab_handler_spec.rb
@@ -11,11 +11,7 @@ RSpec.describe CompleteMoabHandler do
   let!(:default_prez_policy) { PreservationPolicy.default_policy }
   let(:po) { PreservedObject.find_by(druid: druid) }
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
-  let(:cm) {
-    # Adds new complete moab with the same druid to confirm that tests pass
-    create(:complete_moab, preserved_object: po, moab_storage_root: create(:moab_storage_root))
-    CompleteMoab.find_by(preserved_object: po, moab_storage_root: ms_root)
-  }
+  let(:cm) { CompleteMoab.find_by(preserved_object: po, moab_storage_root: ms_root) }
   let(:complete_moab_handler) { described_class.new(druid, incoming_version, incoming_size, ms_root) }
   let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil) }
   let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil) }

--- a/spec/services/complete_moab_handler_update_version_spec.rb
+++ b/spec/services/complete_moab_handler_update_version_spec.rb
@@ -12,11 +12,7 @@ RSpec.describe CompleteMoabHandler do
   let(:incoming_version) { 6 }
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
   let(:po) { PreservedObject.find_by(druid: druid) }
-  let(:cm) {
-    # Adds new complete moab with the same druid to confirm that tests pass
-    create(:complete_moab, preserved_object: po, moab_storage_root: create(:moab_storage_root))
-    complete_moab_handler.complete_moab
-  }
+  let(:cm) { complete_moab_handler.complete_moab }
   let(:complete_moab_handler) { described_class.new(druid, incoming_version, incoming_size, ms_root) }
   let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
   let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
@@ -34,9 +30,9 @@ RSpec.describe CompleteMoabHandler do
 
     context 'in Catalog' do
       before do
-        create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_prez_policy)
-        po.complete_moabs.create!(
-          version: po.current_version,
+        v2 = create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_prez_policy)
+        v2.complete_moabs.create!(
+          version: v2.current_version,
           size: 1,
           moab_storage_root: ms_root,
           status: 'ok', # pretending we checked for moab validation errs at create time


### PR DESCRIPTION
**HOLD FOR:**
- [ ] #1946 to be merged first and then this should be rebased
- [ ] check if migration will take a long time in prod
- [ ] will we need to touch objects or something?   I had to reseed the database for specs to run cleanly after this ...
- [ ] don't deploy with dependency updates

## Why was this change made? 🤔

"preserved_copy" is the old name for what is now "complete_moab". We have a vestigial database index name. The migration will probably look like this.

Closes #1947

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



