### PR TITLE
follow-on to one-moab-per-druid DB constraint

### DIFF
--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -32,7 +32,7 @@ class CompleteMoab < ApplicationRecord
   has_one :preserved_objects_primary_moab, dependent: :destroy
 
   validates :status, :version, presence: true
-  validates :preserved_object_id, uniqueness: { scope: [:moab_storage_root_id] }
+  validates :preserved_object_id, uniqueness: true
   # NOTE: size here is approximate and not used for fixity checking
   validates :size, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
 

--- a/spec/lib/audit/moab_to_catalog_spec.rb
+++ b/spec/lib/audit/moab_to_catalog_spec.rb
@@ -185,10 +185,7 @@ RSpec.describe Audit::MoabToCatalog do
 
       storage_dir_a_seed_result_lists = described_class.seed_catalog_for_dir(storage_dir_a)
       expect(storage_dir_a_seed_result_lists.count).to eq 1
-      extant_preserved_object_id = PreservedObject.find_by!(druid: 'bz514sm9647').id # druid on storage_rootA was already cataloged on storage_root01
-      expected_result_msg = 'db update failed: #<ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique ' \
-                            "constraint \"index_complete_moabs_on_preserved_object_id\"\nDETAIL:  Key (preserved_object_id)=" \
-                            "(#{extant_preserved_object_id}) already exists.\n>"
+      expected_result_msg = 'db update failed: #<ActiveRecord::RecordInvalid: Validation failed: Preserved object has already been taken>'
       expect(storage_dir_a_seed_result_lists.first).to eq([{ db_update_failed: expected_result_msg }])
       expect(CompleteMoab.by_druid(druid).count).to eq 1
       expect(CompleteMoab.count).to eq 3

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -208,12 +208,13 @@ RSpec.describe CompleteMoab, type: :model do
     end
   end
 
-  describe 'preserved_object_id and moab_storage_root_id combination' do
+  describe 'enforcement of uniqueness on druid (PreservedObject) across all storage roots' do
     context 'at the model level' do
       it 'must be unique' do
+        pending('Need to add Rails model constraint')
         expect {
           create(:complete_moab, preserved_object_id: preserved_object.id,
-                                 moab_storage_root_id: cm.moab_storage_root_id)
+                                 moab_storage_root: create(:moab_storage_root))
         }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
@@ -221,7 +222,7 @@ RSpec.describe CompleteMoab, type: :model do
     context 'at the db level' do
       it 'must be unique' do
         dup_complete_moab = described_class.new(preserved_object_id: preserved_object.id,
-                                                moab_storage_root_id: cm.moab_storage_root_id,
+                                                moab_storage_root: create(:moab_storage_root),
                                                 status: status,
                                                 version: cm_version)
         expect { dup_complete_moab.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe CompleteMoab, type: :model do
   it { is_expected.to have_db_index(:moab_storage_root_id) }
   it { is_expected.to have_db_index(:preserved_object_id) }
   it { is_expected.to validate_presence_of(:version) }
-  it { is_expected.to validate_uniqueness_of(:preserved_object_id).scoped_to(:moab_storage_root_id) }
+  it { is_expected.to validate_uniqueness_of(:preserved_object_id) }
 
   describe '#validate_checksums!' do
     it 'passes self to ChecksumValidationJob' do
@@ -211,7 +211,6 @@ RSpec.describe CompleteMoab, type: :model do
   describe 'enforcement of uniqueness on druid (PreservedObject) across all storage roots' do
     context 'at the model level' do
       it 'must be unique' do
-        pending('Need to add Rails model constraint')
         expect {
           create(:complete_moab, preserved_object_id: preserved_object.id,
                                  moab_storage_root: create(:moab_storage_root))

--- a/spec/services/complete_moab_handler_update_version_spec.rb
+++ b/spec/services/complete_moab_handler_update_version_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe CompleteMoabHandler do
 
     context 'in Catalog' do
       before do
-        v2 = create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_prez_policy)
-        v2.complete_moabs.create!(
-          version: v2.current_version,
+        create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_prez_policy)
+        po.complete_moabs.create!(
+          version: po.current_version,
           size: 1,
           moab_storage_root: ms_root,
           status: 'ok', # pretending we checked for moab validation errs at create time


### PR DESCRIPTION
## Why was this change made? 🤔

* follow on from review of #1946
* connects with #1891 ("change complete_moab to `validates :preserved_object_id, uniqueness: true` from `validates :preserved_object_id, uniqueness: { scope: [:moab_storage_root_id] }`")

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



