### PR TITLE
Perform daily auditing/validation.

### DIFF
--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -137,4 +137,9 @@ class CompleteMoab < ApplicationRecord
     # standard SQL doesn't have a NULLS FIRST sort built in.
     active_record_relation.order(Arel.sql('last_checksum_validation IS NOT NULL, last_checksum_validation ASC'))
   end
+
+  # Number of CompleteMoabs to validate on a daily basis.
+  def self.daily_check_count
+    CompleteMoab.count / (PreservationPolicy.default_policy.fixity_ttl / (60 * 60 * 24))
+  end
 end

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -61,6 +61,11 @@ class PreservedObject < ApplicationRecord
     MoabReplicationAuditJob.perform_later(self)
   end
 
+  # Number of PreservedObjects to audit on a daily basis.
+  def self.daily_check_count
+    PreservedObject.count / (PreservationPolicy.default_policy.fixity_ttl / (60 * 60 * 24))
+  end
+
   private
 
   # We need a specific copy of a moab from which to create the zip file(s) to send to the cloud.

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -18,9 +18,23 @@ every '0 11 15 * *', roles: [:queue_populator] do
   runner 'MoabStorageRoot.find_each(&:c2m_check!)'
 end
 
+# Proactivily audit to spread out load.
+# Any that are not validated but hit fixity TTL will be validated by weekly audit below.
+every :day, at: '8pm', roles: [:queue_populator] do
+  set :output, standard: nil, error: 'log/c2a-err.log'
+  runner 'PreservedObject.order(last_archive_audit: :asc).limit(PreservedObject.daily_check_count).find_each(&:audit_moab_version_replication!)'
+end
+
 every :wednesday, roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/c2a-err.log'
   runner 'PreservedObject.archive_check_expired.find_each(&:audit_moab_version_replication!)'
+end
+
+# Proactivily validate to spread out load.
+# Any that are not validated but hit fixity TTL will be validated by weekly validation below.
+every :day, at: '10pm', roles: [:queue_populator] do
+  set :output, standard: nil, error: 'log/cv-err.log'
+  runner 'CompleteMoab.order(last_checksum_validation: :asc).limit(CompleteMoab.daily_check_count).find_each(&:validate_checksums!)'
 end
 
 every :sunday, at: '1am', roles: [:queue_populator] do

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -352,4 +352,14 @@ RSpec.describe CompleteMoab, type: :model do
       cm.validity_unknown!
     end
   end
+
+  describe '#daily_check_count' do
+    before do
+      allow(described_class).to receive(:count).and_return(1000)
+    end
+
+    it 'calculates the number of objects to check per day' do
+      expect(described_class.daily_check_count).to eq 11
+    end
+  end
 end

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -189,4 +189,14 @@ RSpec.describe PreservedObject, type: :model do
       preserved_object.audit_moab_version_replication!
     end
   end
+
+  describe '#daily_check_count' do
+    before do
+      allow(described_class).to receive(:count).and_return(1000)
+    end
+
+    it 'calculates the number of objects to check per day' do
+      expect(described_class.daily_check_count).to eq 11
+    end
+  end
 end


### PR DESCRIPTION
closes #1939

## Why was this change made? 🤔
Even out auditing/validation load.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



