### PR TITLE
Add unique index to ZippedMoabVersions.

### DIFF
--- a/db/migrate/20221018143200_add_unique_zipped_moab_versions.rb
+++ b/db/migrate/20221018143200_add_unique_zipped_moab_versions.rb
@@ -1,0 +1,5 @@
+class AddUniqueZippedMoabVersions < ActiveRecord::Migration[6.1]
+  def change
+    add_index :zipped_moab_versions, [:preserved_object_id, :zip_endpoint_id, :version], unique: true, name: 'index_unique_on_zipped_moab_versions'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_07_185705) do
+ActiveRecord::Schema.define(version: 2022_10_18_143200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 2022_10_07_185705) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "preserved_object_id", null: false
+    t.index ["preserved_object_id", "zip_endpoint_id", "version"], name: "index_unique_on_zipped_moab_versions", unique: true
     t.index ["preserved_object_id"], name: "index_zipped_moab_versions_on_preserved_object_id"
     t.index ["zip_endpoint_id"], name: "index_zipped_moab_versions_on_zip_endpoint_id"
   end


### PR DESCRIPTION
closes #1831

## Why was this change made? 🤔
Safety.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

Verified that no existing zipped moab versions violate this constraint in all environments.

