### PR TITLE
Refactor zip delivery

### DIFF
--- a/app/jobs/abstract_delivery_job.rb
+++ b/app/jobs/abstract_delivery_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Invokes `ZipDeliveryService`
+# Notify `ResultsRecorderJob`, if posted.
+class AbstractDeliveryJob < ZipPartJobBase
+  before_enqueue { |job| job.zip_info_check!(job.arguments.fourth) }
+
+  # @param [String] druid
+  # @param [Integer] version
+  # @param [String] part_s3_key
+  # @param [Hash<Symbol => String, Integer>] metadata Zip info
+  # @see PlexerJob#perform warning about why metadata must be passed
+  def perform(druid, version, part_s3_key, metadata)
+    return unless ZipDeliveryService.deliver(
+      s3_part: bucket.object(part_s3_key),
+      dvz_part: dvz_part, # defined in this class's parent: `ZipPartJobBase`
+      metadata: metadata
+    )
+
+    ResultsRecorderJob.perform_later(druid, version, part_s3_key, self.class.to_s)
+  end
+
+  def bucket
+    raise NotImplementedError, 'Child of abstract delivery job failed to override `#bucket` method'
+  end
+end

--- a/app/jobs/ibm_south_delivery_job.rb
+++ b/app/jobs/ibm_south_delivery_job.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Different provider than parent class
-# @note The IBM delivery job inherits from an AWS job because the mechanics only differ in bucket name lookup
-class IbmSouthDeliveryJob < S3WestDeliveryJob
+# @see PreservationCatalog::Aws for how S3 credentials and bucket are configured
+class IbmSouthDeliveryJob < AbstractDeliveryJob
   queue_as :ibm_us_south_delivery
 
   def bucket

--- a/app/jobs/s3_east_delivery_job.rb
+++ b/app/jobs/s3_east_delivery_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# Same as parent class, just a different queue.
+# @see PreservationCatalog::Aws for how S3 credentials and bucket are configured
 # @note This name is slightly misleading, as this class solely deals with AWS US East 1 endpoint
-class S3EastDeliveryJob < S3WestDeliveryJob
+class S3EastDeliveryJob < AbstractDeliveryJob
   queue_as :s3_us_east_1_delivery
 
   def bucket

--- a/app/jobs/s3_west_delivery_job.rb
+++ b/app/jobs/s3_west_delivery_job.rb
@@ -1,31 +1,9 @@
 # frozen_string_literal: true
 
-# Posts zips to S3, if needed.
-# Notify ResultsRecorderJob, if posted.
 # @see S3::Aws for how S3 credentials and bucket are configured
 # @note This name is slightly misleading, as this class solely deals with AWS US West 2 endpoint
-class S3WestDeliveryJob < ZipPartJobBase
+class S3WestDeliveryJob < AbstractDeliveryJob
   queue_as :s3_us_west_2_delivery
-  # NOTE: base class gives us `zip`, `dvz_part` (but not an instance of zip with the path to the moab used for creation)
-
-  before_enqueue { |job| job.zip_info_check!(job.arguments.fourth) }
-
-  # @param [String] druid
-  # @param [Integer] version
-  # @param [String] part_s3_key
-  # @param [Hash<Symbol => String, Integer>] metadata Zip info
-  # @see PlexerJob#perform warning about why metadata must be passed
-  def perform(druid, version, part_s3_key, metadata)
-    s3_part = bucket.object(part_s3_key) # ::Aws::S3::Object
-    return if s3_part.exists?
-
-    fresh_md5 = dvz_part.read_md5
-    given_md5 = metadata[:checksum_md5]
-    raise "#{part_s3_key} MD5 mismatch: passed #{given_md5}, computed #{fresh_md5}" unless fresh_md5 == given_md5
-
-    s3_part.upload_file(dvz_part.file_path, metadata: stringify_values(metadata))
-    ResultsRecorderJob.perform_later(druid, version, part_s3_key, self.class.to_s)
-  end
 
   def bucket
     S3::AwsProvider.new(
@@ -33,12 +11,5 @@ class S3WestDeliveryJob < ZipPartJobBase
       access_key_id: Settings.zip_endpoints.aws_s3_west_2.access_key_id,
       secret_access_key: Settings.zip_endpoints.aws_s3_west_2.secret_access_key
     ).bucket
-  end
-
-  # coerce size int to string (all values must be strings)
-  # @param [Hash<Symbol => #to_s>] metadata
-  # @return [Hash<Symbol => String>] metadata
-  def stringify_values(metadata)
-    metadata.merge(size: metadata[:size].to_s, parts_count: metadata[:parts_count].to_s)
   end
 end

--- a/app/services/zip_delivery_service.rb
+++ b/app/services/zip_delivery_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Posts zips to S3, if needed.
+class ZipDeliveryService
+  def self.deliver(...)
+    new(...).deliver
+  end
+
+  # @param [Aws::S3::Object] s3_part
+  # @param [DruidVersionZipPart] dvz_part
+  # @param [Hash<Symbol => String, Integer>] metadata Zip info
+  def initialize(s3_part:, dvz_part:, metadata:)
+    @s3_part = s3_part
+    @dvz_part = dvz_part
+    @metadata = stringify_values(metadata)
+  end
+
+  def deliver
+    return if s3_part.exists?
+
+    raise "#{s3_part.key} MD5 mismatch: passed #{given_md5}, computed #{fresh_md5}" if fresh_md5 != given_md5
+
+    s3_part.upload_file(dvz_part.file_path, metadata: metadata)
+  end
+
+  private
+
+  attr_reader :dvz_part, :metadata, :s3_part
+
+  # coerce size int to string (all values must be strings)
+  # @param [Hash<Symbol => #to_s>] metadata
+  # @return [Hash<Symbol => String>] metadata
+  def stringify_values(metadata)
+    metadata.merge(size: metadata[:size].to_s, parts_count: metadata[:parts_count].to_s)
+  end
+
+  def fresh_md5
+    dvz_part.read_md5
+  end
+
+  def given_md5
+    metadata[:checksum_md5]
+  end
+end

--- a/spec/jobs/abstract_delivery_job_spec.rb
+++ b/spec/jobs/abstract_delivery_job_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AbstractDeliveryJob, type: :job do
+  # NOTE: Test a concrete impl of the abstract job so the call to `#bucket` does not raise
+  subject(:job_implementation) do
+    Class.new(described_class) do
+      def bucket
+        Struct.new(:unused) do
+          def object(arg); end
+        end.new
+      end
+    end
+  end
+
+  let(:druid) { 'bj102hs9687' }
+  let(:version) { 1 }
+  let(:dvz) { DruidVersionZip.new(druid, version) }
+  let(:dvz_part) { DruidVersionZipPart.new(dvz, part_s3_key) }
+  let(:metadata) { dvz_part.metadata.merge(zip_version: 'Zip 3.0 (July 5th 2008)') }
+  let(:part_s3_key) { dvz.s3_key('.zip') }
+  let(:delivery_result) { true }
+
+  before do
+    allow(Settings).to receive(:zip_storage).and_return(Rails.root.join('spec', 'fixtures', 'zip_storage'))
+    allow(ResultsRecorderJob).to receive(:perform_later)
+    allow(ZipDeliveryService).to receive(:deliver).and_return(delivery_result)
+
+    job_implementation.perform_now(druid, version, part_s3_key, metadata)
+  end
+
+  context 'when zip delivery succeeds' do
+    it 'invokes ResultsRecorderJob' do
+      expect(ResultsRecorderJob).to have_received(:perform_later).with(druid, version, part_s3_key, job_implementation.to_s)
+    end
+  end
+
+  context 'when zip delivery fails' do
+    let(:delivery_result) { nil }
+
+    it 'does nothing' do
+      expect(ResultsRecorderJob).not_to have_received(:perform_later)
+    end
+  end
+
+  describe '#bucket' do
+    it 'raises NotImplementedError' do
+      expect { described_class.new.bucket }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/jobs/ibm_south_delivery_job_spec.rb
+++ b/spec/jobs/ibm_south_delivery_job_spec.rb
@@ -2,12 +2,12 @@
 
 require 'rails_helper'
 
-describe S3WestDeliveryJob, type: :job do
+describe IbmSouthDeliveryJob, type: :job do
   it 'descends from AbstractDeliveryJob' do
     expect(described_class.new).to be_an(AbstractDeliveryJob)
   end
 
   it 'uses its own queue' do
-    expect(described_class.new.queue_name).to eq 's3_us_west_2_delivery'
+    expect(described_class.new.queue_name).to eq 'ibm_us_south_delivery'
   end
 end

--- a/spec/jobs/s3_east_delivery_job_spec.rb
+++ b/spec/jobs/s3_east_delivery_job_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 describe S3EastDeliveryJob, type: :job do
-  it 'descends from S3WestDeliveryJob' do
-    expect(described_class.new).to be_an(S3WestDeliveryJob)
+  it 'descends from AbstractDeliveryJob' do
+    expect(described_class.new).to be_an(AbstractDeliveryJob)
   end
 
-  it 'uses a different queue' do
+  it 'uses its own queue' do
     expect(described_class.new.queue_name).to eq 's3_us_east_1_delivery'
   end
 end

--- a/spec/services/zip_delivery_service_spec.rb
+++ b/spec/services/zip_delivery_service_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ZipDeliveryService do
+  let(:instance) { described_class.new(s3_part: s3_part, dvz_part: dvz_part, metadata: metadata) }
+  let(:druid) { 'bj102hs9687' }
+  let(:version) { 1 }
+  let(:dvz) { DruidVersionZip.new(druid, version) }
+  let(:dvz_part) { DruidVersionZipPart.new(dvz, part_s3_key) }
+  let(:s3_part) { instance_double(::Aws::S3::Object, exists?: part_exists, upload_file: true, key: part_s3_key) }
+  let(:part_exists) { false }
+  let(:md5) { '4f98f59e877ecb84ff75ef0fab45bac5' }
+  let(:base64) { dvz.hex_to_base64(md5) }
+  let(:metadata) { dvz_part.metadata.merge(zip_version: 'Zip 3.0 (July 5th 2008)') }
+  let(:part_s3_key) { dvz.s3_key('.zip') }
+
+  before do
+    allow(Settings).to receive(:zip_storage).and_return(Rails.root.join('spec', 'fixtures', 'zip_storage'))
+    allow(IO).to receive(:read).with(dvz_part.md5_path).and_return(md5)
+  end
+
+  describe '.deliver' do
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+      allow(instance).to receive(:deliver)
+    end
+
+    it 'invokes #deliver on a new instance' do
+      described_class.deliver(s3_part: s3_part, dvz_part: dvz_part, metadata: metadata)
+      expect(instance).to have_received(:deliver).once
+    end
+  end
+
+  describe '#deliver' do
+    context 'when s3 part exists' do
+      let(:part_exists) { true }
+
+      it 'returns nil and does not upload the file' do
+        expect(instance.deliver).to be_nil
+        expect(s3_part).not_to have_received(:upload_file)
+      end
+    end
+
+    context 'when s3 part does not exist' do
+      context 'when checksums do not match' do
+        let(:md5) { nil }
+
+        it 'raises a RuntimeError' do
+          expect { instance.deliver }.to raise_error(/bj102hs9687.v0001.zip MD5 mismatch/)
+          expect(s3_part).not_to have_received(:upload_file)
+        end
+      end
+
+      it 'delivers the zip' do
+        instance.deliver
+        expect(s3_part).to have_received(:upload_file).with(
+          dvz_part.file_path, metadata: a_hash_including(checksum_md5: md5)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1922

This commit refactors zip delivery in the following ways:

* Move zip delivery into its own small service class
* Invoke zip delivery service from a new abstract delivery job
* Base all three delivery jobs on the abstract delivery job


## How was this change tested? 🤨

CI
