### PR TITLE
Extract common from Complete Moab services into base class

### DIFF
--- a/app/models/audit_results.rb
+++ b/app/models/audit_results.rb
@@ -85,8 +85,8 @@ class AuditResults
     CM_STATUS_CHANGED
   ].freeze
 
-  attr_accessor :actual_version, :check_name
-  attr_reader :druid, :moab_storage_root
+  attr_accessor :actual_version
+  attr_reader :druid, :moab_storage_root, :check_name
 
   def initialize(druid:, moab_storage_root:, actual_version: nil, check_name: nil)
     @druid = druid

--- a/app/services/audit/catalog_to_moab.rb
+++ b/app/services/audit/catalog_to_moab.rb
@@ -16,12 +16,11 @@ module Audit
       @complete_moab = complete_moab
       @druid = complete_moab.preserved_object.druid
       @logger = Logger.new(Rails.root.join('log', 'c2m.log'))
-      @results = AuditResults.new(druid: druid, moab_storage_root: complete_moab.moab_storage_root)
+      @results = AuditResults.new(druid: druid, moab_storage_root: complete_moab.moab_storage_root, check_name: 'check_catalog_version')
     end
 
     # shameless green implementation
     def check_catalog_version
-      results.check_name = 'check_catalog_version'
       unless complete_moab.matches_po_current_version?
         results.add_result(AuditResults::CM_PO_VERSION_MISMATCH,
                            cm_version: complete_moab.version,

--- a/app/services/complete_moab_service/base.rb
+++ b/app/services/complete_moab_service/base.rb
@@ -18,18 +18,20 @@ module CompleteMoabService
     delegate :storage_location, to: :moab_storage_root
     delegate :complete_moab, to: :moab_validator
 
-    def initialize(druid:, incoming_version:, incoming_size:, moab_storage_root:)
+    def initialize(druid:, incoming_version:, incoming_size:, moab_storage_root:, check_name:)
       @druid = druid
       @incoming_version = ApplicationController.helpers.version_string_to_int(incoming_version)
       @incoming_size = ApplicationController.helpers.string_to_int(incoming_size)
       @moab_storage_root = moab_storage_root
-      @results = AuditResults.new(druid: druid, actual_version: incoming_version, moab_storage_root: moab_storage_root)
+      @results = AuditResults.new(druid: druid, actual_version: incoming_version, moab_storage_root: moab_storage_root, check_name: check_name)
       @logger = PreservationCatalog::Application.logger
     end
 
     def pres_object
       @pres_object ||= PreservedObject.find_by!(druid: druid)
     end
+
+    def execute; end
 
     protected
 

--- a/app/services/complete_moab_service/base.rb
+++ b/app/services/complete_moab_service/base.rb
@@ -31,9 +31,19 @@ module CompleteMoabService
       @pres_object ||= PreservedObject.find_by!(druid: druid)
     end
 
-    def execute; end
-
     protected
+
+    # perform_execute wraps with common parts of the execute method for all complete moab services
+    def perform_execute
+      if invalid?
+        results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
+      elsif block_given?
+        yield
+      end
+
+      report_results!
+      results
+    end
 
     def moab_validator
       @moab_validator ||= MoabValidator.new(druid: druid, storage_location: storage_location, results: results)

--- a/app/services/complete_moab_service/check_existence.rb
+++ b/app/services/complete_moab_service/check_existence.rb
@@ -8,9 +8,11 @@ module CompleteMoabService
       new(druid: druid, incoming_version: incoming_version, incoming_size: incoming_size, moab_storage_root: moab_storage_root).execute
     end
 
-    def execute
-      results.check_name = 'check_existence'
+    def initialize(druid:, incoming_version:, incoming_size:, moab_storage_root:, check_name: 'check_existence')
+      super
+    end
 
+    def execute
       if invalid?
         results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
       elsif CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?

--- a/app/services/complete_moab_service/check_existence.rb
+++ b/app/services/complete_moab_service/check_existence.rb
@@ -12,43 +12,43 @@ module CompleteMoabService
       super
     end
 
+    # rubocop:disable Metrics/BlockLength
     def execute
-      if invalid?
-        results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
-      elsif CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
-        Rails.logger.debug "check_existence #{druid} called"
+      perform_execute do
+        if CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
+          Rails.logger.debug "check_existence #{druid} called"
 
-        transaction_ok = with_active_record_transaction_and_rescue do
-          raise_rollback_if_cm_po_version_mismatch
+          transaction_ok = with_active_record_transaction_and_rescue do
+            raise_rollback_if_cm_po_version_mismatch
 
-          return report_results! unless moab_validator.can_validate_current_comp_moab_status?
+            return report_results! unless moab_validator.can_validate_current_comp_moab_status?
 
-          if incoming_version == complete_moab.version
-            moab_validator.set_status_as_seen_on_disk(true) unless complete_moab.status == 'ok'
-            results.add_result(AuditResults::VERSION_MATCHES, 'CompleteMoab')
-          elsif incoming_version > complete_moab.version
-            moab_validator.set_status_as_seen_on_disk(true) unless complete_moab.status == 'ok'
-            results.add_result(AuditResults::ACTUAL_VERS_GT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
-            update_cm_po_set_status
-          else # incoming_version < complete_moab.version
-            moab_validator.set_status_as_seen_on_disk(false)
-            results.add_result(AuditResults::ACTUAL_VERS_LT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
+            if incoming_version == complete_moab.version
+              moab_validator.set_status_as_seen_on_disk(true) unless complete_moab.status == 'ok'
+              results.add_result(AuditResults::VERSION_MATCHES, 'CompleteMoab')
+            elsif incoming_version > complete_moab.version
+              moab_validator.set_status_as_seen_on_disk(true) unless complete_moab.status == 'ok'
+              results.add_result(AuditResults::ACTUAL_VERS_GT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
+              update_cm_po_set_status
+            else # incoming_version < complete_moab.version
+              moab_validator.set_status_as_seen_on_disk(false)
+              results.add_result(AuditResults::ACTUAL_VERS_LT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
+            end
+            complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, true)
+            complete_moab.save!
           end
-          complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, true)
-          complete_moab.save!
-        end
-        results.remove_db_updated_results unless transaction_ok
-      else
-        results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, 'CompleteMoab')
-        if moab_validator.moab_validation_errors.empty?
-          create_db_objects('validity_unknown')
+          results.remove_db_updated_results unless transaction_ok
         else
-          create_db_objects('invalid_moab')
+          results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, 'CompleteMoab')
+          if moab_validator.moab_validation_errors.empty?
+            create_db_objects('validity_unknown')
+          else
+            create_db_objects('invalid_moab')
+          end
         end
       end
-      report_results!
-      results
     end
+    # rubocop:enable Metrics/BlockLength
 
     private
 

--- a/app/services/complete_moab_service/create.rb
+++ b/app/services/complete_moab_service/create.rb
@@ -14,18 +14,15 @@ module CompleteMoabService
 
     # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
     def execute(checksums_validated: false)
-      if invalid?
-        results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
-      elsif CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
-        results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'CompleteMoab')
-      else
-        creation_status = (checksums_validated ? 'ok' : 'validity_unknown')
-        moab_validator.ran_moab_validation! if checksums_validated # ensure validation timestamps updated
-        create_db_objects(creation_status, checksums_validated: checksums_validated)
+      perform_execute do
+        if CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
+          results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'CompleteMoab')
+        else
+          creation_status = (checksums_validated ? 'ok' : 'validity_unknown')
+          moab_validator.ran_moab_validation! if checksums_validated # ensure validation timestamps updated
+          create_db_objects(creation_status, checksums_validated: checksums_validated)
+        end
       end
-
-      report_results!
-      results
     end
   end
 end

--- a/app/services/complete_moab_service/create.rb
+++ b/app/services/complete_moab_service/create.rb
@@ -8,9 +8,12 @@ module CompleteMoabService
           moab_storage_root: moab_storage_root).execute(checksums_validated: checksums_validated)
     end
 
+    def initialize(druid:, incoming_version:, incoming_size:, moab_storage_root:, check_name: 'create')
+      super
+    end
+
     # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
     def execute(checksums_validated: false)
-      results.check_name = 'create'
       if invalid?
         results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
       elsif CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?

--- a/app/services/complete_moab_service/create_after_validation.rb
+++ b/app/services/complete_moab_service/create_after_validation.rb
@@ -14,19 +14,16 @@ module CompleteMoabService
 
     # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
     def execute(checksums_validated: false)
-      if invalid?
-        results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
-      elsif CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
-        results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'CompleteMoab')
-      elsif moab_validator.moab_validation_errors.empty?
-        creation_status = (checksums_validated ? 'ok' : 'validity_unknown')
-        create_db_objects(creation_status, checksums_validated: checksums_validated)
-      else
-        create_db_objects('invalid_moab', checksums_validated: checksums_validated)
+      perform_execute do
+        if CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
+          results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'CompleteMoab')
+        elsif moab_validator.moab_validation_errors.empty?
+          creation_status = (checksums_validated ? 'ok' : 'validity_unknown')
+          create_db_objects(creation_status, checksums_validated: checksums_validated)
+        else
+          create_db_objects('invalid_moab', checksums_validated: checksums_validated)
+        end
       end
-
-      report_results!
-      results
     end
   end
 end

--- a/app/services/complete_moab_service/create_after_validation.rb
+++ b/app/services/complete_moab_service/create_after_validation.rb
@@ -8,9 +8,12 @@ module CompleteMoabService
           moab_storage_root: moab_storage_root).execute(checksums_validated: checksums_validated)
     end
 
+    def initialize(druid:, incoming_version:, incoming_size:, moab_storage_root:, check_name: 'create_after_validation')
+      super
+    end
+
     # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
     def execute(checksums_validated: false)
-      results.check_name = 'create_after_validation'
       if invalid?
         results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
       elsif CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?

--- a/app/services/complete_moab_service/update_version.rb
+++ b/app/services/complete_moab_service/update_version.rb
@@ -8,9 +8,12 @@ module CompleteMoabService
           moab_storage_root: moab_storage_root).execute(checksums_validated: checksums_validated)
     end
 
+    def initialize(druid:, incoming_version:, incoming_size:, moab_storage_root:, check_name: 'update')
+      super
+    end
+
     # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
     def execute(checksums_validated: false)
-      results.check_name = 'update_version'
       if invalid?
         results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
       else

--- a/app/services/complete_moab_service/update_version.rb
+++ b/app/services/complete_moab_service/update_version.rb
@@ -14,18 +14,13 @@ module CompleteMoabService
 
     # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
     def execute(checksums_validated: false)
-      if invalid?
-        results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
-      else
+      perform_execute do
         Rails.logger.debug "update_version #{druid} called"
         # only change status if checksums_validated is false
         new_status = (checksums_validated ? nil : 'validity_unknown')
         # NOTE: we deal with active record transactions in update_online_version, not here
         update_online_version(status: new_status, set_status_to_unexp_version: true, checksums_validated: checksums_validated)
       end
-
-      report_results!
-      results
     end
 
     protected

--- a/app/services/complete_moab_service/update_version_after_validation.rb
+++ b/app/services/complete_moab_service/update_version_after_validation.rb
@@ -14,37 +14,34 @@ module CompleteMoabService
 
     # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
     def execute(checksums_validated: false)
-      if invalid?
-        results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
-      elsif CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
-        Rails.logger.debug "update_version_after_validation #{druid} called"
-        if moab_validator.moab_validation_errors.empty?
-          # NOTE: we deal with active record transactions in update_online_version, not here
-          new_status = (checksums_validated ? 'ok' : 'validity_unknown')
-          update_online_version(status: new_status, checksums_validated: checksums_validated)
-        else
-          Rails.logger.debug "update_version_after_validation #{druid} found validation errors"
-          if checksums_validated
-            update_online_version(status: 'invalid_moab', checksums_validated: true)
-            # for case when no db updates b/c pres_obj version != complete_moab version
-            update_cm_invalid_moab unless complete_moab.invalid_moab?
+      perform_execute do
+        if CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
+          Rails.logger.debug "update_version_after_validation #{druid} called"
+          if moab_validator.moab_validation_errors.empty?
+            # NOTE: we deal with active record transactions in update_online_version, not here
+            new_status = (checksums_validated ? 'ok' : 'validity_unknown')
+            update_online_version(status: new_status, checksums_validated: checksums_validated)
           else
-            update_online_version(status: 'validity_unknown')
-            # for case when no db updates b/c pres_obj version != complete_moab version
-            update_cm_validity_unknown unless complete_moab.validity_unknown?
+            Rails.logger.debug "update_version_after_validation #{druid} found validation errors"
+            if checksums_validated
+              update_online_version(status: 'invalid_moab', checksums_validated: true)
+              # for case when no db updates b/c pres_obj version != complete_moab version
+              update_cm_invalid_moab unless complete_moab.invalid_moab?
+            else
+              update_online_version(status: 'validity_unknown')
+              # for case when no db updates b/c pres_obj version != complete_moab version
+              update_cm_validity_unknown unless complete_moab.validity_unknown?
+            end
+          end
+        else
+          results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, 'CompleteMoab')
+          if moab_validator.moab_validation_errors.empty?
+            create_db_objects('validity_unknown')
+          else
+            create_db_objects('invalid_moab')
           end
         end
-      else
-        results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, 'CompleteMoab')
-        if moab_validator.moab_validation_errors.empty?
-          create_db_objects('validity_unknown')
-        else
-          create_db_objects('invalid_moab')
-        end
       end
-
-      report_results!
-      results
     end
 
     private

--- a/app/services/complete_moab_service/update_version_after_validation.rb
+++ b/app/services/complete_moab_service/update_version_after_validation.rb
@@ -8,9 +8,12 @@ module CompleteMoabService
           moab_storage_root: moab_storage_root).execute(checksums_validated: checksums_validated)
     end
 
+    def initialize(druid:, incoming_version:, incoming_size:, moab_storage_root:, check_name: 'update_after_validation')
+      super
+    end
+
     # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
     def execute(checksums_validated: false)
-      results.check_name = 'update_version_after_validation'
       if invalid?
         results.add_result(AuditResults::INVALID_ARGUMENTS, errors.full_messages)
       elsif CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?

--- a/spec/services/audit/catalog_to_moab_spec.rb
+++ b/spec/services/audit/catalog_to_moab_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Audit::CatalogToMoab do
     instance_double(AuditResults,
                     add_result: nil,
                     :actual_version= => nil,
-                    :check_name= => nil,
                     results: [],
                     results_as_string: nil)
   end
@@ -449,7 +448,6 @@ RSpec.describe Audit::CatalogToMoab do
           my_results_double = instance_double(AuditResults,
                                               add_result: nil,
                                               :actual_version= => nil,
-                                              :check_name= => nil,
                                               results: [],
                                               results_as_string: 'mock results as string')
           c2m.instance_variable_set(:@results, my_results_double)
@@ -477,7 +475,6 @@ RSpec.describe Audit::CatalogToMoab do
           my_results_double = instance_double(AuditResults,
                                               add_result: nil,
                                               :actual_version= => nil,
-                                              :check_name= => nil,
                                               results: [],
                                               results_as_string: 'mock results as string')
           c2m.instance_variable_set(:@results, my_results_double)

--- a/spec/services/complete_moab_service/shared_examples.rb
+++ b/spec/services/complete_moab_service/shared_examples.rb
@@ -57,7 +57,6 @@ RSpec.shared_examples 'calls AuditResultsReporter.report_results' do
   it 'outputs results to Rails.logger and sends errors to WorkflowErrorReporter' do
     mock_results = instance_double(AuditResults,
                                    add_result: nil,
-                                   :check_name= => nil,
                                    results: [],
                                    results_as_string: nil)
     expect(AuditResultsReporter).to receive(:report_results).with(audit_results: mock_results)


### PR DESCRIPTION
## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



