### PR TITLE
Debreviates

### DIFF
--- a/app/services/complete_moab_service/update_version_after_validation.rb
+++ b/app/services/complete_moab_service/update_version_after_validation.rb
@@ -26,11 +26,11 @@ module CompleteMoabService
             if checksums_validated
               update_online_version(status: 'invalid_moab', checksums_validated: true)
               # for case when no db updates b/c pres_obj version != complete_moab version
-              update_cm_invalid_moab unless complete_moab.invalid_moab?
+              update_complete_moab_to_invalid_moab unless complete_moab.invalid_moab?
             else
               update_online_version(status: 'validity_unknown')
               # for case when no db updates b/c pres_obj version != complete_moab version
-              update_cm_validity_unknown unless complete_moab.validity_unknown?
+              update_complete_moab_to_validity_unknown unless complete_moab.validity_unknown?
             end
           end
         else
@@ -46,7 +46,7 @@ module CompleteMoabService
 
     private
 
-    def update_cm_validity_unknown
+    def update_complete_moab_to_validity_unknown
       transaction_ok = with_active_record_transaction_and_rescue do
         moab_validator.update_status('validity_unknown')
         complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, false)
@@ -55,7 +55,7 @@ module CompleteMoabService
       results.remove_db_updated_results unless transaction_ok
     end
 
-    def update_cm_invalid_moab
+    def update_complete_moab_to_invalid_moab
       transaction_ok = with_active_record_transaction_and_rescue do
         moab_validator.update_status('invalid_moab')
         complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, false)

--- a/spec/services/complete_moab_service/check_existence_spec.rb
+++ b/spec/services/complete_moab_service/check_existence_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe CompleteMoabService::CheckExistence do
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }
-  let(:po) { PreservedObject.find_by!(druid: druid) }
-  let(:ms_root) { MoabStorageRoot.find_by!(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
-  let(:cm) { CompleteMoab.find_by!(moab_storage_root: ms_root) }
+  let(:preserved_object) { PreservedObject.find_by!(druid: druid) }
+  let(:moab_storage_root) { MoabStorageRoot.find_by!(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
+  let(:complete_moab) { CompleteMoab.find_by!(moab_storage_root: moab_storage_root) }
   let(:db_update_failed_prefix) { 'db update failed' }
-  let(:complete_moab_handler) do
-    described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: incoming_size, moab_storage_root: ms_root)
+  let(:complete_moab_service) do
+    described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: incoming_size, moab_storage_root: moab_storage_root)
   end
 
-  let(:moab_validator) { complete_moab_handler.send(:moab_validator) }
+  let(:moab_validator) { complete_moab_service.send(:moab_validator) }
   let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil) }
   let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil) }
   let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
@@ -36,96 +36,96 @@ RSpec.describe CompleteMoabService::CheckExistence do
 
       before do
         create(:preserved_object, druid: druid, current_version: 2)
-        po.create_complete_moab!(
-          version: po.current_version,
+        preserved_object.create_complete_moab!(
+          version: preserved_object.current_version,
           size: 1,
-          moab_storage_root: ms_root,
+          moab_storage_root: moab_storage_root,
           status: 'ok' # NOTE: we are pretending we checked for moab validation errs
-        ) do |primary_cm|
-          PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: primary_cm)
+        ) do |primary_complete_moab|
+          PreservedObjectsPrimaryMoab.create!(preserved_object: preserved_object, complete_moab: primary_complete_moab)
         end
       end
 
       context 'incoming and db versions match' do
-        let(:complete_moab_handler) { described_class.new(druid: druid, incoming_version: 2, incoming_size: 1, moab_storage_root: ms_root) }
-        let(:version_matches_cm_msg) { 'actual version (2) matches CompleteMoab db version' }
+        let(:complete_moab_service) { described_class.new(druid: druid, incoming_version: 2, incoming_size: 1, moab_storage_root: moab_storage_root) }
+        let(:version_matches_complete_moab_msg) { 'actual version (2) matches CompleteMoab db version' }
 
         context 'CompleteMoab' do
           context 'changed' do
             it 'last_version_audit' do
-              orig = Time.current
-              cm.last_version_audit = orig
-              cm.save!
-              complete_moab_handler.execute
-              expect(cm.reload.last_version_audit).to be > orig
+              original_time = Time.current
+              complete_moab.last_version_audit = original_time
+              complete_moab.save!
+              complete_moab_service.execute
+              expect(complete_moab.reload.last_version_audit).to be > original_time
             end
 
             it 'updated_at' do
-              orig = cm.updated_at
-              complete_moab_handler.execute
-              expect(cm.reload.updated_at).to be > orig
+              original_time = complete_moab.updated_at
+              complete_moab_service.execute
+              expect(complete_moab.reload.updated_at).to be > original_time
             end
           end
 
           context 'unchanged' do
             it 'status' do
-              orig = cm.status
-              complete_moab_handler.execute
-              expect(cm.reload.status).to eq orig
+              original_time = complete_moab.status
+              complete_moab_service.execute
+              expect(complete_moab.reload.status).to eq original_time
             end
 
             it 'version' do
-              orig = cm.version
-              complete_moab_handler.execute
-              expect(cm.reload.version).to eq orig
+              original_time = complete_moab.version
+              complete_moab_service.execute
+              expect(complete_moab.reload.version).to eq original_time
             end
 
             it 'size' do
-              orig = cm.size
-              complete_moab_handler.execute
-              expect(cm.reload.size).to eq orig
+              original_time = complete_moab.size
+              complete_moab_service.execute
+              expect(complete_moab.reload.size).to eq original_time
             end
 
             it 'last_moab_validation' do
-              orig = cm.last_moab_validation
-              complete_moab_handler.execute
-              expect(cm.reload.last_moab_validation).to eq orig
+              original_time = complete_moab.last_moab_validation
+              complete_moab_service.execute
+              expect(complete_moab.reload.last_moab_validation).to eq original_time
             end
           end
         end
 
         it 'PreservedObject is not updated' do
-          orig = po.updated_at
-          complete_moab_handler.execute
-          expect(po.reload.updated_at).to eq orig
+          original_time = preserved_object.updated_at
+          complete_moab_service.execute
+          expect(preserved_object.reload.updated_at).to eq original_time
         end
 
         it_behaves_like 'calls AuditResultsReporter.report_results'
         it 'does not validate moab' do
           expect(moab_validator).not_to receive(:moab_validation_errors)
-          complete_moab_handler.execute
+          complete_moab_service.execute
         end
 
         context 'returns' do
-          let(:audit_result) { complete_moab_handler.execute }
+          let(:audit_result) { complete_moab_service.execute }
           let(:results) { audit_result.results }
 
           it '1 VERSION_MATCHES result' do
             expect(audit_result).to be_an_instance_of AuditResults
             expect(results.size).to eq 1
-            expect(results).to include(a_hash_including(AuditResults::VERSION_MATCHES => version_matches_cm_msg))
+            expect(results).to include(a_hash_including(AuditResults::VERSION_MATCHES => version_matches_complete_moab_msg))
           end
         end
       end
 
       context 'incoming version > db version' do
-        let(:version_gt_cm_msg) { "actual version (#{incoming_version}) greater than CompleteMoab db version (2)" }
+        let(:version_gt_complete_moab_msg) { "actual version (#{incoming_version}) greater than CompleteMoab db version (2)" }
 
         it 'calls Stanford::StorageObjectValidator.validation_errors for moab' do
-          mock_sov = instance_double(Stanford::StorageObjectValidator)
-          expect(mock_sov).to receive(:validation_errors).and_return([])
-          allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
-          complete_moab_handler.execute
+          storage_object_validator = instance_double(Stanford::StorageObjectValidator)
+          expect(storage_object_validator).to receive(:validation_errors).and_return([])
+          allow(Stanford::StorageObjectValidator).to receive(:new).and_return(storage_object_validator)
+          complete_moab_service.execute
         end
 
         context 'when moab is valid' do
@@ -136,79 +136,79 @@ RSpec.describe CompleteMoabService::CheckExistence do
               before { allow(moab_validator).to receive(:ran_moab_validation?).and_return(true) }
 
               it 'version to incoming_version' do
-                orig = cm.version
-                complete_moab_handler.execute
-                expect(cm.reload.version).to be > orig
-                expect(cm.reload.version).to eq incoming_version
+                original_time = complete_moab.version
+                complete_moab_service.execute
+                expect(complete_moab.reload.version).to be > original_time
+                expect(complete_moab.reload.version).to eq incoming_version
               end
 
               it 'size if supplied' do
-                expect { complete_moab_handler.execute }.to change { complete_moab_handler.complete_moab.size }.to(incoming_size)
+                expect { complete_moab_service.execute }.to change { complete_moab_service.complete_moab.size }.to(incoming_size)
               end
 
               it 'last_moab_validation' do
-                complete_moab_handler.complete_moab.last_moab_validation = Time.current
-                complete_moab_handler.complete_moab.save!
-                expect { complete_moab_handler.execute }.to change { complete_moab_handler.complete_moab.last_moab_validation }
+                complete_moab_service.complete_moab.last_moab_validation = Time.current
+                complete_moab_service.complete_moab.save!
+                expect { complete_moab_service.execute }.to change { complete_moab_service.complete_moab.last_moab_validation }
               end
 
               it 'last_version_audit' do
-                complete_moab_handler.complete_moab.last_version_audit = Time.current
-                complete_moab_handler.complete_moab.save!
-                expect { complete_moab_handler.execute }.to change { complete_moab_handler.complete_moab.last_version_audit }
+                complete_moab_service.complete_moab.last_version_audit = Time.current
+                complete_moab_service.complete_moab.save!
+                expect { complete_moab_service.execute }.to change { complete_moab_service.complete_moab.last_version_audit }
               end
 
               it 'updated_at' do
-                orig = cm.updated_at
-                complete_moab_handler.execute
-                expect(cm.reload.updated_at).to be > orig
+                original_time = complete_moab.updated_at
+                complete_moab_service.execute
+                expect(complete_moab.reload.updated_at).to be > original_time
               end
 
               it 'status becomes "ok" if it was invalid_moab (b/c after validation)' do
-                cm.invalid_moab!
-                complete_moab_handler.execute
-                expect(cm.reload.status).to eq 'validity_unknown'
+                complete_moab.invalid_moab!
+                complete_moab_service.execute
+                expect(complete_moab.reload.status).to eq 'validity_unknown'
               end
             end
 
             context 'unchanged' do
               it 'status if former status was ok' do
-                complete_moab_handler.complete_moab.ok!
-                expect { complete_moab_handler.execute }.not_to change { complete_moab_handler.complete_moab.status }.from('ok')
+                complete_moab_service.complete_moab.ok!
+                expect { complete_moab_service.execute }.not_to change { complete_moab_service.complete_moab.status }.from('ok')
               end
 
               it 'size if incoming size is nil' do
-                orig = cm.size
-                complete_moab_handler = described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: nil,
-                                                            moab_storage_root: ms_root)
-                complete_moab_handler.execute
-                expect(cm.reload.size).to eq orig
+                original_size = complete_moab.size
+                complete_moab_service = described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: nil,
+                                                            moab_storage_root: moab_storage_root)
+                complete_moab_service.execute
+                expect(complete_moab.reload.size).to eq original_size
               end
             end
           end
 
           context 'PreservedObject changed' do
             it 'current_version' do
-              expect { complete_moab_handler.execute }.to change { complete_moab_handler.pres_object.current_version }
+              expect { complete_moab_service.execute }.to change { complete_moab_service.preserved_object.current_version }
                 .to(incoming_version)
             end
 
             it 'dependent CompleteMoab also updated' do
-              expect { complete_moab_handler.execute }.to change { complete_moab_handler.complete_moab.updated_at }
+              expect { complete_moab_service.execute }.to change { complete_moab_service.complete_moab.updated_at }
             end
           end
 
           it_behaves_like 'calls AuditResultsReporter.report_results'
 
           context 'returns' do
-            let(:results) { complete_moab_handler.execute.results }
+            let(:results) { complete_moab_service.execute.results }
 
             before { allow(moab_validator).to receive(:moab_validation_errors).and_return([]) }
 
             it 'ACTUAL_VERS_GT_DB_OBJ results' do
               expect(results).to be_an Array
               expect(results.size).to eq 1
-              expect(results.first).to include(AuditResults::ACTUAL_VERS_GT_DB_OBJ => version_gt_cm_msg)
+              expect(results.first).to include(AuditResults::ACTUAL_VERS_GT_DB_OBJ => version_gt_complete_moab_msg)
             end
           end
         end
@@ -217,23 +217,23 @@ RSpec.describe CompleteMoabService::CheckExistence do
           let(:invalid_druid) { 'xx000xx0000' }
           let(:invalid_storage_dir) { 'spec/fixtures/bad_root01/bad_moab_storage_trunk' }
           let(:invalid_root) { MoabStorageRoot.find_by(storage_location: invalid_storage_dir) }
-          let(:invalid_complete_moab_handler) do
+          let(:invalid_complete_moab_service) do
             described_class.new(druid: invalid_druid, incoming_version: incoming_version, incoming_size: incoming_size,
                                 moab_storage_root: invalid_root)
           end
-          let(:invalid_po) { PreservedObject.find_by(druid: invalid_druid) }
-          let(:invalid_cm) { CompleteMoab.find_by(preserved_object: invalid_po) }
+          let(:invalid_preserved_object) { PreservedObject.find_by(druid: invalid_druid) }
+          let(:invalid_complete_moab) { CompleteMoab.find_by(preserved_object: invalid_preserved_object) }
 
           before do
             # add storage root with the invalid moab to the MoabStorageRoots table
-            MoabStorageRoot.find_or_create_by!(name: 'bad_fixture_dir') do |msr|
-              msr.storage_location = invalid_storage_dir
+            MoabStorageRoot.find_or_create_by!(name: 'bad_fixture_dir') do |moab_storage_root|
+              moab_storage_root.storage_location = invalid_storage_dir
             end
             # these need to be in before loop so it happens before each context below
-            invalid_po = create(:preserved_object, druid: invalid_druid, current_version: 2)
+            invalid_preserved_object = create(:preserved_object, druid: invalid_druid, current_version: 2)
             t = Time.current
-            invalid_po.create_complete_moab!(
-              version: invalid_po.current_version,
+            invalid_preserved_object.create_complete_moab!(
+              version: invalid_preserved_object.current_version,
               size: 1,
               moab_storage_root: invalid_root,
               status: 'ok', # NOTE: we are pretending we checked for moab validation errs
@@ -245,61 +245,61 @@ RSpec.describe CompleteMoabService::CheckExistence do
           context 'CompleteMoab' do
             context 'changed' do
               it 'last_version_audit' do
-                orig = invalid_cm.last_version_audit
-                invalid_complete_moab_handler.execute
-                expect(invalid_cm.reload.last_version_audit).to be > orig
+                original_last_version_audit = invalid_complete_moab.last_version_audit
+                invalid_complete_moab_service.execute
+                expect(invalid_complete_moab.reload.last_version_audit).to be > original_last_version_audit
               end
 
               it 'last_moab_validation' do
-                orig = invalid_cm.last_moab_validation
-                invalid_complete_moab_handler.execute
-                expect(invalid_cm.reload.last_moab_validation).to be > orig
+                original_last_moab_validation = invalid_complete_moab.last_moab_validation
+                invalid_complete_moab_service.execute
+                expect(invalid_complete_moab.reload.last_moab_validation).to be > original_last_moab_validation
               end
 
               it 'updated_at' do
-                orig = invalid_cm.updated_at
-                invalid_complete_moab_handler.execute
-                expect(invalid_cm.reload.updated_at).to be > orig
+                original_updated_at = invalid_complete_moab.updated_at
+                invalid_complete_moab_service.execute
+                expect(invalid_complete_moab.reload.updated_at).to be > original_updated_at
               end
 
               it 'ensures status becomes invalid_moab from ok' do
-                invalid_cm.ok!
-                invalid_complete_moab_handler.execute
-                expect(invalid_cm.reload.status).to eq 'invalid_moab'
+                invalid_complete_moab.ok!
+                invalid_complete_moab_service.execute
+                expect(invalid_complete_moab.reload.status).to eq 'invalid_moab'
               end
 
               it 'ensures status becomes invalid_moab from unexpected_version_on_storage' do
-                invalid_cm.unexpected_version_on_storage!
-                invalid_complete_moab_handler.execute
-                expect(invalid_cm.reload.status).to eq 'invalid_moab'
+                invalid_complete_moab.unexpected_version_on_storage!
+                invalid_complete_moab_service.execute
+                expect(invalid_complete_moab.reload.status).to eq 'invalid_moab'
               end
             end
 
             context 'unchanged' do
               it 'version' do
-                orig = invalid_cm.version
-                invalid_complete_moab_handler.execute
-                expect(invalid_cm.reload.version).to eq orig
+                original_version = invalid_complete_moab.version
+                invalid_complete_moab_service.execute
+                expect(invalid_complete_moab.reload.version).to eq original_version
               end
 
               it 'size' do
-                orig = invalid_cm.size
-                invalid_complete_moab_handler.execute
-                expect(invalid_cm.reload.size).to eq orig
+                original_size = invalid_complete_moab.size
+                invalid_complete_moab_service.execute
+                expect(invalid_complete_moab.reload.size).to eq original_size
               end
             end
           end
 
           it 'PreservedObject is not updated' do
-            orig_timestamp = invalid_po.updated_at
-            invalid_complete_moab_handler.execute
-            expect(invalid_po.reload.updated_at).to eq orig_timestamp
+            original_updated_at = invalid_preserved_object.updated_at
+            invalid_complete_moab_service.execute
+            expect(invalid_preserved_object.reload.updated_at).to eq original_updated_at
           end
 
           it_behaves_like 'calls AuditResultsReporter.report_results'
 
           context 'returns' do
-            let(:results) { invalid_complete_moab_handler.execute.results }
+            let(:results) { invalid_complete_moab_service.execute.results }
 
             it '3 results' do
               expect(results).to be_an_instance_of Array
@@ -308,7 +308,7 @@ RSpec.describe CompleteMoabService::CheckExistence do
 
             it 'ACTUAL_VERS_GT_DB_OBJ results' do
               code = AuditResults::ACTUAL_VERS_GT_DB_OBJ
-              expect(results).to include(a_hash_including(code => version_gt_cm_msg))
+              expect(results).to include(a_hash_including(code => version_gt_complete_moab_msg))
             end
 
             it 'INVALID_MOAB result' do
@@ -320,45 +320,45 @@ RSpec.describe CompleteMoabService::CheckExistence do
 
       context 'incoming version < db version' do
         let(:druid) { 'bp628nk4868' }
-        let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root02/sdr2objects') }
+        let(:moab_storage_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root02/sdr2objects') }
 
         it_behaves_like 'unexpected version with validation', :check_existence, 1, 'unexpected_version_on_storage'
       end
 
       context 'CompleteMoab already has a status other than OK_STATUS' do
-        it_behaves_like 'CompleteMoab may have its status checked when incoming_version == cm.version'
+        it_behaves_like 'CompleteMoab may have its status checked when incoming_version == complete_moab.version'
 
-        it_behaves_like 'CompleteMoab may have its status checked when incoming_version < cm.version'
+        it_behaves_like 'CompleteMoab may have its status checked when incoming_version < complete_moab.version'
 
         context 'incoming_version > db version' do
-          let(:incoming_version) { cm.version + 1 }
+          let(:incoming_version) { complete_moab.version + 1 }
 
           before { allow(moab_validator).to receive(:moab_validation_errors).and_return([]) }
 
           it 'had OK_STATUS, version increased, should still have OK_STATUS' do
-            cm.ok!
-            complete_moab_handler.execute
-            expect(cm.reload.status).to eq 'ok'
+            complete_moab.ok!
+            complete_moab_service.execute
+            expect(complete_moab.reload.status).to eq 'ok'
           end
 
           it 'had INVALID_MOAB_STATUS, was remediated, should now have VALIDITY_UNKNOWN_STATUS' do
-            cm.invalid_moab!
-            complete_moab_handler.execute
-            expect(cm.reload.status).to eq 'validity_unknown'
+            complete_moab.invalid_moab!
+            complete_moab_service.execute
+            expect(complete_moab.reload.status).to eq 'validity_unknown'
           end
 
           it 'had UNEXPECTED_VERSION_ON_STORAGE_STATUS, seems to have an acceptable version now' do
-            cm.unexpected_version_on_storage!
-            complete_moab_handler.execute
-            expect(cm.reload.status).to eq 'validity_unknown'
+            complete_moab.unexpected_version_on_storage!
+            complete_moab_service.execute
+            expect(complete_moab.reload.status).to eq 'validity_unknown'
           end
         end
       end
 
       context 'CompleteMoab version does NOT match PreservedObject current_version (online Moab)' do
         before do
-          po.current_version = 8
-          po.save!
+          preserved_object.current_version = 8
+          preserved_object.save!
         end
 
         it_behaves_like 'PreservedObject current_version does not match online CM version', 3, 2, 8
@@ -374,16 +374,16 @@ RSpec.describe CompleteMoabService::CheckExistence do
 
           context 'transaction is rolled back' do
             it 'CompleteMoab is not updated' do
-              expect { complete_moab_handler.execute }.not_to change { complete_moab_handler.complete_moab.reload.updated_at }
+              expect { complete_moab_service.execute }.not_to change { complete_moab_service.complete_moab.reload.updated_at }
             end
 
             it 'PreservedObject is not updated' do
-              expect { complete_moab_handler.execute }.not_to change { complete_moab_handler.pres_object.reload.updated_at }
+              expect { complete_moab_service.execute }.not_to change { complete_moab_service.preserved_object.reload.updated_at }
             end
           end
 
           context 'DB_UPDATE_FAILED error' do
-            let(:results) { complete_moab_handler.execute.results }
+            let(:results) { complete_moab_service.execute.results }
             let(:result_code) { AuditResults::DB_UPDATE_FAILED }
 
             it 'returns expected message(s)' do
@@ -398,16 +398,16 @@ RSpec.describe CompleteMoabService::CheckExistence do
       it 'calls CompleteMoab.save! (but not PreservedObject.save!) if the existing record is NOT altered' do
         druid = 'zy987xw6543'
         pres_obj = create(:preserved_object, druid: druid)
-        comp_moab = create(:complete_moab, preserved_object: pres_obj, moab_storage_root: ms_root)
+        comp_moab = create(:complete_moab, preserved_object: pres_obj, moab_storage_root: moab_storage_root)
         expect do
           described_class.new(druid: druid, incoming_version: 1,
-                              incoming_size: 1, moab_storage_root: ms_root).execute
+                              incoming_size: 1, moab_storage_root: moab_storage_root).execute
         end.not_to change {
                      pres_obj.reload.updated_at
                    }
         expect do
           described_class.new(druid: druid, incoming_version: 1,
-                              incoming_size: 1, moab_storage_root: ms_root).execute
+                              incoming_size: 1, moab_storage_root: moab_storage_root).execute
         end.to change {
                  comp_moab.reload.updated_at
                }
@@ -416,13 +416,13 @@ RSpec.describe CompleteMoabService::CheckExistence do
       it 'logs a debug message' do
         allow(Rails.logger).to receive(:debug)
         allow(moab_validator).to receive(:moab_validation_errors).and_return([])
-        complete_moab_handler.execute
+        complete_moab_service.execute
         expect(Rails.logger).to have_received(:debug).with("check_existence #{druid} called")
       end
     end
 
     context 'object not in db' do
-      let(:exp_cm_not_exist_msg) { 'CompleteMoab db object does not exist' }
+      let(:exp_complete_moab_not_exist_msg) { 'CompleteMoab db object does not exist' }
       let(:exp_obj_created_msg) { 'added object to db as it did not exist' }
 
       context 'presume validity and test other common behavior' do
@@ -446,17 +446,18 @@ RSpec.describe CompleteMoabService::CheckExistence do
       context 'adds to catalog after validation' do
         let(:valid_druid) { 'bp628nk4868' }
         let(:storage_dir) { 'spec/fixtures/storage_root02/sdr2objects' }
-        let(:ms_root) { MoabStorageRoot.find_by(storage_location: storage_dir) }
+        let(:moab_storage_root) { MoabStorageRoot.find_by(storage_location: storage_dir) }
         let(:incoming_version) { 2 }
-        let(:complete_moab_handler) do
-          described_class.new(druid: valid_druid, incoming_version: incoming_version, incoming_size: incoming_size, moab_storage_root: ms_root)
+        let(:complete_moab_service) do
+          described_class.new(druid: valid_druid, incoming_version: incoming_version, incoming_size: incoming_size,
+                              moab_storage_root: moab_storage_root)
         end
 
         it 'calls Stanford::StorageObjectValidator.validation_errors for moab' do
-          mock_sov = instance_double(Stanford::StorageObjectValidator)
-          expect(mock_sov).to receive(:validation_errors).and_return([])
-          allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
-          complete_moab_handler.execute
+          storage_object_validator = instance_double(Stanford::StorageObjectValidator)
+          expect(storage_object_validator).to receive(:validation_errors).and_return([])
+          allow(Stanford::StorageObjectValidator).to receive(:new).and_return(storage_object_validator)
+          complete_moab_service.execute
         end
 
         context 'moab is valid' do
@@ -466,27 +467,27 @@ RSpec.describe CompleteMoabService::CheckExistence do
               current_version: incoming_version,
               preservation_policy_id: PreservationPolicy.default_policy.id
             }
-            complete_moab_handler.execute
+            complete_moab_service.execute
             expect(PreservedObject.where(po_args)).to exist
           end
 
           it 'CompleteMoab created' do
-            complete_moab_handler.execute
-            new_cm = CompleteMoab.find_by(version: incoming_version, size: incoming_size, moab_storage_root: ms_root)
-            expect(new_cm).not_to be_nil
-            expect(new_cm.status).to eq 'validity_unknown'
+            complete_moab_service.execute
+            new_complete_moab = CompleteMoab.find_by(version: incoming_version, size: incoming_size, moab_storage_root: moab_storage_root)
+            expect(new_complete_moab).not_to be_nil
+            expect(new_complete_moab.status).to eq 'validity_unknown'
           end
 
           it_behaves_like 'calls AuditResultsReporter.report_results'
 
           context 'returns' do
-            let(:audit_result) { complete_moab_handler.execute }
+            let(:audit_result) { complete_moab_service.execute }
             let(:results) { audit_result.results }
 
             it 'returns 2 results including expected messages' do
               expect(audit_result).to be_an_instance_of AuditResults
               expect(results.size).to eq 2
-              expect(results).to include(a_hash_including(AuditResults::DB_OBJ_DOES_NOT_EXIST => exp_cm_not_exist_msg))
+              expect(results).to include(a_hash_including(AuditResults::DB_OBJ_DOES_NOT_EXIST => exp_complete_moab_not_exist_msg))
               expect(results).to include(a_hash_including(AuditResults::CREATED_NEW_OBJECT => exp_obj_created_msg))
             end
           end
@@ -494,14 +495,14 @@ RSpec.describe CompleteMoabService::CheckExistence do
           context 'db update error (ActiveRecordError)' do
             let(:results) do
               allow(Rails.logger).to receive(:log)
-              po = instance_double(PreservedObject)
-              allow(po).to receive(:create_complete_moab!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
-              allow(PreservedObject).to receive(:create!).with(hash_including(druid: valid_druid)).and_return(po)
-              complete_moab_handler.execute.results
+              preserved_object = instance_double(PreservedObject)
+              allow(preserved_object).to receive(:create_complete_moab!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+              allow(PreservedObject).to receive(:create!).with(hash_including(druid: valid_druid)).and_return(preserved_object)
+              complete_moab_service.execute.results
             end
 
             it 'transaction is rolled back' do
-              expect(CompleteMoab.find_by(moab_storage_root: ms_root)).to be_nil
+              expect(CompleteMoab.find_by(moab_storage_root: moab_storage_root)).to be_nil
               expect(PreservedObject.find_by(druid: valid_druid)).to be_nil
             end
 
@@ -519,10 +520,11 @@ RSpec.describe CompleteMoabService::CheckExistence do
 
         context 'moab is invalid' do
           let(:storage_dir) { 'spec/fixtures/bad_root01/bad_moab_storage_trunk' }
-          let(:ms_root) { MoabStorageRoot.find_by(storage_location: storage_dir) }
+          let(:moab_storage_root) { MoabStorageRoot.find_by(storage_location: storage_dir) }
           let(:invalid_druid) { 'xx000xx0000' }
-          let(:complete_moab_handler) do
-            described_class.new(druid: invalid_druid, incoming_version: incoming_version, incoming_size: incoming_size, moab_storage_root: ms_root)
+          let(:complete_moab_service) do
+            described_class.new(druid: invalid_druid, incoming_version: incoming_version, incoming_size: incoming_size,
+                                moab_storage_root: moab_storage_root)
           end
 
           before do
@@ -533,17 +535,17 @@ RSpec.describe CompleteMoabService::CheckExistence do
           end
 
           it 'creates PreservedObject; CompleteMoab with "invalid_moab" status' do
-            complete_moab_handler.execute
-            new_cm = CompleteMoab.find_by(size: incoming_size, moab_storage_root: ms_root, version: incoming_version)
-            expect(new_cm).to be_a(CompleteMoab)
-            expect(new_cm.status).to eq('invalid_moab')
-            expect(new_cm.preserved_object.druid).to eq(invalid_druid)
+            complete_moab_service.execute
+            new_complete_moab = CompleteMoab.find_by(size: incoming_size, moab_storage_root: moab_storage_root, version: incoming_version)
+            expect(new_complete_moab).to be_a(CompleteMoab)
+            expect(new_complete_moab.status).to eq('invalid_moab')
+            expect(new_complete_moab.preserved_object.druid).to eq(invalid_druid)
           end
 
           it_behaves_like 'calls AuditResultsReporter.report_results'
 
           context 'returns' do
-            let(:audit_result) { complete_moab_handler.execute }
+            let(:audit_result) { complete_moab_service.execute }
             let(:results) { audit_result.results }
 
             it '3 results with expected messages' do
@@ -551,7 +553,7 @@ RSpec.describe CompleteMoabService::CheckExistence do
               expect(audit_result).to be_an_instance_of AuditResults
               expect(results.size).to eq 3
               expect(results).to include(a_hash_including(AuditResults::INVALID_MOAB => exp_moab_errs_msg))
-              expect(results).to include(a_hash_including(AuditResults::DB_OBJ_DOES_NOT_EXIST => exp_cm_not_exist_msg))
+              expect(results).to include(a_hash_including(AuditResults::DB_OBJ_DOES_NOT_EXIST => exp_complete_moab_not_exist_msg))
               expect(results).to include(a_hash_including(AuditResults::CREATED_NEW_OBJECT => exp_obj_created_msg))
             end
           end
@@ -559,16 +561,16 @@ RSpec.describe CompleteMoabService::CheckExistence do
           context 'db update error (ActiveRecordError)' do
             let(:result_code) { AuditResults::DB_UPDATE_FAILED }
             let(:results) do
-              po = instance_double(PreservedObject)
-              allow(po).to receive(:create_complete_moab!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
-              allow(PreservedObject).to receive(:create!).with(hash_including(druid: invalid_druid)).and_return(po)
-              complete_moab_handler.execute.results
+              preserved_object = instance_double(PreservedObject)
+              allow(preserved_object).to receive(:create_complete_moab!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+              allow(PreservedObject).to receive(:create!).with(hash_including(druid: invalid_druid)).and_return(preserved_object)
+              complete_moab_service.execute.results
             end
 
             before { allow(Rails.logger).to receive(:log) }
 
             it 'transaction is rolled back' do
-              expect(CompleteMoab.find_by(moab_storage_root: ms_root)).to be_nil
+              expect(CompleteMoab.find_by(moab_storage_root: moab_storage_root)).to be_nil
               expect(PreservedObject.find_by(druid: invalid_druid)).to be_nil
             end
 

--- a/spec/services/complete_moab_service/update_version_spec.rb
+++ b/spec/services/complete_moab_service/update_version_spec.rb
@@ -6,15 +6,15 @@ require 'services/complete_moab_service/shared_examples'
 RSpec.describe CompleteMoabService::UpdateVersion do
   let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
   let(:db_update_failed_prefix) { 'db update failed' }
-  let(:default_prez_policy) { PreservationPolicy.default_policy }
+  let(:default_preservation_policy) { PreservationPolicy.default_policy }
   let(:druid) { 'ab123cd4567' }
   let(:incoming_size) { 9876 }
   let(:incoming_version) { 6 }
-  let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
-  let(:po) { PreservedObject.find_by(druid: druid) }
-  let(:cm) { complete_moab_handler.complete_moab }
-  let(:complete_moab_handler) do
-    described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: incoming_size, moab_storage_root: ms_root)
+  let(:moab_storage_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
+  let(:preserved_object) { PreservedObject.find_by(druid: druid) }
+  let(:complete_moab) { complete_moab_service.complete_moab }
+  let(:complete_moab_service) do
+    described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: incoming_size, moab_storage_root: moab_storage_root)
   end
   let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
   let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
@@ -32,16 +32,16 @@ RSpec.describe CompleteMoabService::UpdateVersion do
 
     context 'in Catalog' do
       before do
-        create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_prez_policy)
-        po.create_complete_moab!(
-          version: po.current_version,
+        create(:preserved_object, druid: druid, current_version: 2, preservation_policy: default_preservation_policy)
+        preserved_object.create_complete_moab!(
+          version: preserved_object.current_version,
           size: 1,
-          moab_storage_root: ms_root,
+          moab_storage_root: moab_storage_root,
           status: 'ok', # pretending we checked for moab validation errs at create time
           last_version_audit: Time.current,
           last_moab_validation: Time.current
-        ) do |primary_cm|
-          PreservedObjectsPrimaryMoab.create!(preserved_object: po, complete_moab: primary_cm)
+        ) do |primary_complete_moab|
+          PreservedObjectsPrimaryMoab.create!(preserved_object: preserved_object, complete_moab: primary_complete_moab)
         end
       end
 
@@ -49,75 +49,75 @@ RSpec.describe CompleteMoabService::UpdateVersion do
         context 'CompleteMoab' do
           context 'changed' do
             it 'version becomes incoming_version' do
-              expect { complete_moab_handler.execute }.to change(cm, :version).to be(incoming_version)
+              expect { complete_moab_service.execute }.to change(complete_moab, :version).to be(incoming_version)
             end
 
             it 'last_version_audit' do
-              expect { complete_moab_handler.execute }.to change(cm, :last_version_audit)
+              expect { complete_moab_service.execute }.to change(complete_moab, :last_version_audit)
             end
 
             it 'size if supplied' do
-              expect { complete_moab_handler.execute }.to change(cm, :size)
+              expect { complete_moab_service.execute }.to change(complete_moab, :size)
             end
           end
 
           context 'unchanged' do
             it 'size if incoming size is nil' do
-              complete_moab_handler = described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: nil,
-                                                          moab_storage_root: ms_root)
-              expect { complete_moab_handler.execute }.not_to change { complete_moab_handler.complete_moab.size }
+              complete_moab_service = described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: nil,
+                                                          moab_storage_root: moab_storage_root)
+              expect { complete_moab_service.execute }.not_to change { complete_moab_service.complete_moab.size }
             end
 
             it 'last_moab_validation' do
-              expect { complete_moab_handler.execute }.not_to change(cm, :last_moab_validation)
+              expect { complete_moab_service.execute }.not_to change(complete_moab, :last_moab_validation)
             end
           end
 
           context 'status' do
             context 'checksums_validated = false' do
               it 'starting status validity_unknown unchanged' do
-                cm.update!(status: 'validity_unknown')
-                expect { complete_moab_handler.execute }.not_to change(cm, :status).from('validity_unknown')
+                complete_moab.update!(status: 'validity_unknown')
+                expect { complete_moab_service.execute }.not_to change(complete_moab, :status).from('validity_unknown')
               end
 
               context 'starting status not validity_unknown' do
-                shared_examples 'CMH#update_version changes status to "validity_unknown"' do |orig_status|
-                  before { cm.update!(status: orig_status) }
+                shared_examples '#update_version changes status to "validity_unknown"' do |orig_status|
+                  before { complete_moab.update!(status: orig_status) }
 
                   it "original status #{orig_status}" do
-                    expect { complete_moab_handler.execute }.to change(cm, :status)
+                    expect { complete_moab_service.execute }.to change(complete_moab, :status)
                       .from(orig_status).to('validity_unknown')
                   end
                 end
 
-                it_behaves_like 'CMH#update_version changes status to "validity_unknown"', 'ok'
-                it_behaves_like 'CMH#update_version changes status to "validity_unknown"', 'invalid_moab'
-                it_behaves_like 'CMH#update_version changes status to "validity_unknown"', 'invalid_checksum'
-                it_behaves_like 'CMH#update_version changes status to "validity_unknown"', 'online_moab_not_found'
-                it_behaves_like 'CMH#update_version changes status to "validity_unknown"', 'unexpected_version_on_storage'
+                it_behaves_like '#update_version changes status to "validity_unknown"', 'ok'
+                it_behaves_like '#update_version changes status to "validity_unknown"', 'invalid_moab'
+                it_behaves_like '#update_version changes status to "validity_unknown"', 'invalid_checksum'
+                it_behaves_like '#update_version changes status to "validity_unknown"', 'online_moab_not_found'
+                it_behaves_like '#update_version changes status to "validity_unknown"', 'unexpected_version_on_storage'
               end
             end
 
             context 'checksums_validated = true' do
               it 'starting status ok unchanged' do
-                expect { complete_moab_handler.execute(checksums_validated: true) }.not_to change(cm, :status).from('ok')
+                expect { complete_moab_service.execute(checksums_validated: true) }.not_to change(complete_moab, :status).from('ok')
               end
 
               context 'original status was not ok' do
-                shared_examples 'CMH#update_version(true) does not change status' do |orig_status|
-                  before { cm.update!(status: orig_status) }
+                shared_examples '#update_version(true) does not change status' do |orig_status|
+                  before { complete_moab.update!(status: orig_status) }
 
                   it "original status #{orig_status}" do
-                    expect { complete_moab_handler.execute(checksums_validated: true) }.not_to change(cm, :status)
+                    expect { complete_moab_service.execute(checksums_validated: true) }.not_to change(complete_moab, :status)
                   end
                 end
 
-                it_behaves_like 'CMH#update_version(true) does not change status', 'validity_unknown'
-                it_behaves_like 'CMH#update_version(true) does not change status', 'invalid_moab'
-                it_behaves_like 'CMH#update_version(true) does not change status', 'invalid_checksum'
+                it_behaves_like '#update_version(true) does not change status', 'validity_unknown'
+                it_behaves_like '#update_version(true) does not change status', 'invalid_moab'
+                it_behaves_like '#update_version(true) does not change status', 'invalid_checksum'
                 # TODO: do these statuses change?
-                it_behaves_like 'CMH#update_version(true) does not change status', 'online_moab_not_found'
-                it_behaves_like 'CMH#update_version(true) does not change status', 'unexpected_version_on_storage'
+                it_behaves_like '#update_version(true) does not change status', 'online_moab_not_found'
+                it_behaves_like '#update_version(true) does not change status', 'unexpected_version_on_storage'
               end
             end
           end
@@ -125,23 +125,23 @@ RSpec.describe CompleteMoabService::UpdateVersion do
 
         context 'calls #update_online_version with' do
           it 'status = "validity_unknown" for checksums_validated = false' do
-            expect(complete_moab_handler).to receive(:update_online_version).with(status: 'validity_unknown', set_status_to_unexp_version: true,
+            expect(complete_moab_service).to receive(:update_online_version).with(status: 'validity_unknown', set_status_to_unexpected_version: true,
                                                                                   checksums_validated: false).and_call_original
-            complete_moab_handler.execute
+            complete_moab_service.execute
             skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
           end
 
           it 'status = "ok" and checksums_validated = true for checksums_validated = true' do
-            expect(complete_moab_handler).to receive(:update_online_version).with(status: nil, set_status_to_unexp_version: true,
+            expect(complete_moab_service).to receive(:update_online_version).with(status: nil, set_status_to_unexpected_version: true,
                                                                                   checksums_validated: true).and_call_original
-            complete_moab_handler.execute(checksums_validated: true)
+            complete_moab_service.execute(checksums_validated: true)
             skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
           end
         end
 
         context 'PreservedObject changed' do
           it 'current_version becomes incoming version' do
-            expect { complete_moab_handler.execute }.to change(complete_moab_handler.pres_object, :current_version)
+            expect { complete_moab_service.execute }.to change(complete_moab_service.preserved_object, :current_version)
               .to(incoming_version)
           end
         end
@@ -149,7 +149,7 @@ RSpec.describe CompleteMoabService::UpdateVersion do
         it_behaves_like 'calls AuditResultsReporter.report_results'
 
         context 'returns' do
-          let!(:results) { complete_moab_handler.execute(checksums_validated: true).results }
+          let!(:results) { complete_moab_service.execute(checksums_validated: true).results }
 
           it '1 results' do
             expect(results).to be_an_instance_of Array
@@ -158,14 +158,14 @@ RSpec.describe CompleteMoabService::UpdateVersion do
 
           it 'ACTUAL_VERS_GT_DB_OBJ results' do
             code = AuditResults::ACTUAL_VERS_GT_DB_OBJ
-            version_gt_cm_msg = "actual version (#{incoming_version}) greater than CompleteMoab db version (2)"
-            expect(results).to include(a_hash_including(code => version_gt_cm_msg))
+            version_greater_than_complete_moab_msg = "actual version (#{incoming_version}) greater than CompleteMoab db version (2)"
+            expect(results).to include(a_hash_including(code => version_greater_than_complete_moab_msg))
           end
         end
       end
 
       context 'CompleteMoab and PreservedObject versions do not match' do
-        before { cm.update(version: cm.version + 1) }
+        before { complete_moab.update(version: complete_moab.version + 1) }
 
         it_behaves_like 'PreservedObject current_version does not match online CM version', 3, 3, 2
       end
@@ -185,10 +185,10 @@ RSpec.describe CompleteMoabService::UpdateVersion do
           context 'ActiveRecordError' do
             let(:results) do
               allow(Rails.logger).to receive(:log)
-              allow(complete_moab_handler).to receive(:pres_object).and_return(po)
-              allow(complete_moab_handler).to receive(:complete_moab).and_return(cm)
-              allow(cm).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
-              complete_moab_handler.execute.results
+              allow(complete_moab_service).to receive(:preserved_object).and_return(preserved_object)
+              allow(complete_moab_service).to receive(:complete_moab).and_return(complete_moab)
+              allow(complete_moab).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+              complete_moab_service.execute.results
             end
 
             context 'DB_UPDATE_FAILED error' do
@@ -212,9 +212,9 @@ RSpec.describe CompleteMoabService::UpdateVersion do
             let(:druid) { 'zy666xw4567' }
             let(:results) do
               allow(Rails.logger).to receive(:log)
-              allow(complete_moab_handler).to receive(:pres_object).and_return(po)
-              allow(po).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
-              complete_moab_handler.execute.results
+              allow(complete_moab_service).to receive(:preserved_object).and_return(preserved_object)
+              allow(preserved_object).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+              complete_moab_service.execute.results
             end
 
             context 'DB_UPDATE_FAILED error' do
@@ -235,28 +235,28 @@ RSpec.describe CompleteMoabService::UpdateVersion do
       end
 
       it 'calls PreservedObject.save! and CompleteMoab.save! if the records are altered' do
-        allow(complete_moab_handler).to receive(:pres_object).and_return(po)
-        allow(complete_moab_handler.pres_object).to receive(:complete_moab).and_return(cm)
-        expect(po).to receive(:save!)
-        expect(cm).to receive(:save!)
-        complete_moab_handler.execute
+        allow(complete_moab_service).to receive(:preserved_object).and_return(preserved_object)
+        allow(complete_moab_service.preserved_object).to receive(:complete_moab).and_return(complete_moab)
+        expect(preserved_object).to receive(:save!)
+        expect(complete_moab).to receive(:save!)
+        complete_moab_service.execute
       end
 
       context '' do
-        let(:complete_moab_handler) { described_class.new(druid: druid, incoming_version: 1, incoming_size: 1, moab_storage_root: ms_root) }
+        let(:complete_moab_service) { described_class.new(druid: druid, incoming_version: 1, incoming_size: 1, moab_storage_root: moab_storage_root) }
 
         it 'does not call PreservedObject.save when CompleteMoab only has timestamp updates' do
-          allow(complete_moab_handler).to receive(:pres_object).and_return(po)
-          allow(complete_moab_handler.pres_object).to receive(:complete_moab).and_return(cm)
-          expect(cm).to receive(:save!)
-          expect(po).not_to receive(:save!)
-          complete_moab_handler.execute
+          allow(complete_moab_service).to receive(:preserved_object).and_return(preserved_object)
+          allow(complete_moab_service.preserved_object).to receive(:complete_moab).and_return(complete_moab)
+          expect(complete_moab).to receive(:save!)
+          expect(preserved_object).not_to receive(:save!)
+          complete_moab_service.execute
         end
       end
 
       it 'logs a debug message' do
         allow(Rails.logger).to receive(:debug)
-        complete_moab_handler.execute
+        complete_moab_service.execute
         expect(Rails.logger).to have_received(:debug).with("update_version #{druid} called")
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔
More readable code.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



