### PR TITLE
Move remove_db_updated_results to transaction method.

### DIFF
--- a/app/services/complete_moab_service/base.rb
+++ b/app/services/complete_moab_service/base.rb
@@ -51,7 +51,9 @@ module CompleteMoabService
 
     # this wrapper reads a little nicer in this class, since CompleteMoabHandler is always doing this the same way
     def with_active_record_transaction_and_rescue
-      ActiveRecordUtils.with_transaction_and_rescue(results) { yield }
+      transaction_ok = ActiveRecordUtils.with_transaction_and_rescue(results) { yield }
+      results.remove_db_updated_results unless transaction_ok
+      transaction_ok
     end
 
     def raise_rollback_if_version_mismatch

--- a/app/services/complete_moab_service/check_existence.rb
+++ b/app/services/complete_moab_service/check_existence.rb
@@ -18,7 +18,7 @@ module CompleteMoabService
         if CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
           Rails.logger.debug "check_existence #{druid} called"
 
-          transaction_ok = with_active_record_transaction_and_rescue do
+          with_active_record_transaction_and_rescue do
             raise_rollback_if_version_mismatch
 
             return report_results! unless moab_validator.can_validate_current_comp_moab_status?
@@ -37,7 +37,6 @@ module CompleteMoabService
             complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, true)
             complete_moab.save!
           end
-          results.remove_db_updated_results unless transaction_ok
         else
           results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, 'CompleteMoab')
           if moab_validator.moab_validation_errors.empty?

--- a/app/services/complete_moab_service/update_version.rb
+++ b/app/services/complete_moab_service/update_version.rb
@@ -26,7 +26,7 @@ module CompleteMoabService
     protected
 
     def update_online_version(status: nil, set_status_to_unexpected_version: false, checksums_validated: false)
-      transaction_ok = with_active_record_transaction_and_rescue do
+      with_active_record_transaction_and_rescue do
         raise_rollback_if_version_mismatch
 
         if incoming_version > complete_moab.version
@@ -45,8 +45,6 @@ module CompleteMoabService
           update_complete_moab_to_unexpected_version(status)
         end
       end
-
-      results.remove_db_updated_results unless transaction_ok
     end
 
     def update_complete_moab_to_unexpected_version(new_status)

--- a/app/services/complete_moab_service/update_version_after_validation.rb
+++ b/app/services/complete_moab_service/update_version_after_validation.rb
@@ -47,21 +47,19 @@ module CompleteMoabService
     private
 
     def update_complete_moab_to_validity_unknown
-      transaction_ok = with_active_record_transaction_and_rescue do
+      with_active_record_transaction_and_rescue do
         moab_validator.update_status('validity_unknown')
         complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, false)
         complete_moab.save!
       end
-      results.remove_db_updated_results unless transaction_ok
     end
 
     def update_complete_moab_to_invalid_moab
-      transaction_ok = with_active_record_transaction_and_rescue do
+      with_active_record_transaction_and_rescue do
         moab_validator.update_status('invalid_moab')
         complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, false)
         complete_moab.save!
       end
-      results.remove_db_updated_results unless transaction_ok
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Remove redundant code.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



