### PR TITLE
Refactor check existence service.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,7 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Exclude:
     - 'app/models/audit_results.rb'
+    - 'app/services/complete_moab_service/base.rb'
 
 Naming/FileName:
   Exclude:

--- a/app/services/complete_moab_service/base.rb
+++ b/app/services/complete_moab_service/base.rb
@@ -115,5 +115,22 @@ module CompleteMoabService
     def report_results!
       AuditResultsReporter.report_results(audit_results: results)
     end
+
+    def complete_moab_exists?
+      CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
+    end
+
+    def validation_errors?
+      moab_validator.moab_validation_errors.present?
+    end
+
+    def record_missing
+      results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, 'CompleteMoab')
+      if validation_errors?
+        create_db_objects('invalid_moab')
+      else
+        create_db_objects('validity_unknown')
+      end
+    end
   end
 end

--- a/app/services/complete_moab_service/check_existence.rb
+++ b/app/services/complete_moab_service/check_existence.rb
@@ -12,52 +12,49 @@ module CompleteMoabService
       super
     end
 
-    # rubocop:disable Metrics/BlockLength
     def execute
       perform_execute do
-        if CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
-          Rails.logger.debug "check_existence #{druid} called"
-
-          with_active_record_transaction_and_rescue do
-            raise_rollback_if_version_mismatch
-
-            return report_results! unless moab_validator.can_validate_current_comp_moab_status?
-
-            if incoming_version == complete_moab.version
-              moab_validator.set_status_as_seen_on_disk(true) unless complete_moab.status == 'ok'
-              results.add_result(AuditResults::VERSION_MATCHES, 'CompleteMoab')
-            elsif incoming_version > complete_moab.version
-              moab_validator.set_status_as_seen_on_disk(true) unless complete_moab.status == 'ok'
-              results.add_result(AuditResults::ACTUAL_VERS_GT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
-              update_complete_moab_preserved_object_or_set_status
-            else # incoming_version < complete_moab.version
-              moab_validator.set_status_as_seen_on_disk(false)
-              results.add_result(AuditResults::ACTUAL_VERS_LT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
-            end
-            complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, true)
-            complete_moab.save!
-          end
+        if complete_moab_exists?
+          check_versions
         else
-          results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, 'CompleteMoab')
-          if moab_validator.moab_validation_errors.empty?
-            create_db_objects('validity_unknown')
-          else
-            create_db_objects('invalid_moab')
-          end
+          record_missing
         end
       end
     end
-    # rubocop:enable Metrics/BlockLength
 
     private
 
     def update_complete_moab_preserved_object_or_set_status
-      if moab_validator.moab_validation_errors.empty?
+      if validation_errors?
+        moab_validator.update_status('invalid_moab')
+      else
         complete_moab.upd_audstamps_version_size(moab_validator.ran_moab_validation?, incoming_version, incoming_size)
         preserved_object.current_version = incoming_version if primary_moab? # we only want to track highest seen version based on primary
         preserved_object.save!
-      else
-        moab_validator.update_status('invalid_moab')
+      end
+    end
+
+    def check_versions
+      Rails.logger.debug "check_existence #{druid} called"
+
+      with_active_record_transaction_and_rescue do
+        raise_rollback_if_version_mismatch
+
+        return report_results! unless moab_validator.can_validate_current_comp_moab_status?
+
+        if incoming_version == complete_moab.version
+          moab_validator.set_status_as_seen_on_disk(true) unless complete_moab.status == 'ok'
+          results.add_result(AuditResults::VERSION_MATCHES, 'CompleteMoab')
+        elsif incoming_version > complete_moab.version
+          moab_validator.set_status_as_seen_on_disk(true) unless complete_moab.status == 'ok'
+          results.add_result(AuditResults::ACTUAL_VERS_GT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
+          update_complete_moab_preserved_object_or_set_status
+        else # incoming_version < complete_moab.version
+          moab_validator.set_status_as_seen_on_disk(false)
+          results.add_result(AuditResults::ACTUAL_VERS_LT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
+        end
+        complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, true)
+        complete_moab.save!
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
More readable?


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



