### PR TITLE
Rubocop updates.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,7 @@ RSpec/ContextWording:
 RSpec/DescribeClass:
   Exclude:
     - 'spec/requests/auth_spec.rb' # technically testing ApplicationController, but rubocop complains even if you provide that
+    - 'spec/jobs/integration_spec.rb'
 
 RSpec/ExampleLength:
   Max: 29
@@ -85,7 +86,6 @@ RSpec/NestedGroups:
     - 'spec/requests/objects_controller_content_diff_spec.rb'
     - 'spec/requests/objects_controller_file_spec.rb'
     - 'spec/services/checksum_validator_spec.rb'
-    - 'spec/services/complete_moab_handler_*.rb'
     - 'spec/services/complete_moab_service/*.rb'
 
 Style/AccessModifierDeclarations:
@@ -476,4 +476,27 @@ RSpec/Capybara/SpecificFinders: # new in 2.13
 RSpec/Capybara/SpecificMatcher: # new in 2.12
   Enabled: true
 RSpec/Rails/HaveHttpStatus: # new in 2.12
+  Enabled: true
+
+Lint/DuplicateMagicComment: # new in 1.37
+  Enabled: true
+Style/OperatorMethodCall: # new in 1.37
+  Enabled: true
+Style/RedundantStringEscape: # new in 1.37
+  Enabled: true
+Rails/ActionOrder: # new in 2.17
+  Enabled: true
+Rails/IgnoredColumnsAssignment: # new in 2.17
+  Enabled: true
+Rails/WhereNotWithMultipleConditions: # new in 2.17
+  Enabled: true
+RSpec/SortMetadata: # new in 2.14
+  Enabled: true
+RSpec/Capybara/NegationMatcher: # new in 2.14
+  Enabled: true
+RSpec/Capybara/SpecificActions: # new in 2.14
+  Enabled: true
+RSpec/FactoryBot/ConsistentParenthesesStyle: # new in 2.14
+  Enabled: true
+RSpec/Rails/InferredSpecType: # new in 2.14
   Enabled: true

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -136,10 +136,10 @@ end
 class VersionAuditWindowCheck < OkComputer::Check
   def check
     if CompleteMoab.least_recent_version_audit(clause).first
-      mark_message "CompleteMoab\#last_version_audit older than #{clause}. "
+      mark_message "CompleteMoab#last_version_audit older than #{clause}. "
       mark_failure
     else
-      mark_message "CompleteMoab\#last_version_audit all newer than #{clause}. "
+      mark_message "CompleteMoab#last_version_audit all newer than #{clause}. "
     end
   end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-RSpec.describe CatalogController, type: :controller do
+RSpec.describe CatalogController do
   let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
   let(:size) { 2342 }
   let(:ver) { 3 }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe ApplicationHelper, type: :helper do
+RSpec.describe ApplicationHelper do
   describe '#version_string_to_int' do
     { # passed value => expected parsed value
       6 => 6,

--- a/spec/jobs/abstract_delivery_job_spec.rb
+++ b/spec/jobs/abstract_delivery_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AbstractDeliveryJob, type: :job do
+describe AbstractDeliveryJob do
   # NOTE: Test a concrete impl of the abstract job so the call to `#bucket` does not raise
   subject(:job_implementation) do
     Class.new(described_class) do

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -16,7 +16,7 @@ class RegularParameterJob < ApplicationJob
   end
 end
 
-RSpec.describe ApplicationJob, type: :job do
+RSpec.describe ApplicationJob do
   include ActiveJob::TestHelper
 
   around do |example|
@@ -80,8 +80,8 @@ RSpec.describe ApplicationJob, type: :job do
   end
 
   context 'a subclass that has an ActiveRecord parameter with message(s) queued' do
-    let(:cm) { create :complete_moab }
-    let(:cm2) { create :complete_moab }
+    let(:cm) { create(:complete_moab) }
+    let(:cm2) { create(:complete_moab) }
 
     before do
       CatalogToMoabJob.perform_later(cm)

--- a/spec/jobs/catalog_to_moab_job_spec.rb
+++ b/spec/jobs/catalog_to_moab_job_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe CatalogToMoabJob, type: :job do
+describe CatalogToMoabJob do
   let(:job) { described_class.new(cm) }
-  let(:cm) { create :complete_moab }
+  let(:cm) { create(:complete_moab) }
 
   describe '#perform' do
     let(:validator) { instance_double(Audit::CatalogToMoab) }

--- a/spec/jobs/checksum_validation_job_spec.rb
+++ b/spec/jobs/checksum_validation_job_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe ChecksumValidationJob, type: :job do
+describe ChecksumValidationJob do
   let(:job) { described_class.new(cm) }
-  let(:cm) { create :complete_moab }
+  let(:cm) { create(:complete_moab) }
 
   describe '#perform' do
     let(:validator) { instance_double(ChecksumValidator) }

--- a/spec/jobs/ibm_south_delivery_job_spec.rb
+++ b/spec/jobs/ibm_south_delivery_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe IbmSouthDeliveryJob, type: :job do
+describe IbmSouthDeliveryJob do
   it 'descends from AbstractDeliveryJob' do
     expect(described_class.new).to be_an(AbstractDeliveryJob)
   end

--- a/spec/jobs/integration_spec.rb
+++ b/spec/jobs/integration_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'the whole replication pipeline', type: :job do
+describe 'the whole replication pipeline' do
   let(:aws_s3_object) { instance_double(::Aws::S3::Object, exists?: false, upload_file: true) }
   let(:ibm_s3_object) { instance_double(::Aws::S3::Object, exists?: false, upload_file: true) }
   let(:aws_bucket) { instance_double(::Aws::S3::Bucket, object: aws_s3_object) }

--- a/spec/jobs/moab_replication_audit_job_spec.rb
+++ b/spec/jobs/moab_replication_audit_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe MoabReplicationAuditJob, type: :job do
+describe MoabReplicationAuditJob do
   let(:preserved_object) { create(:preserved_object, current_version: 2) }
   let(:job) { described_class.new(preserved_object) }
   let(:logger) { instance_double(Logger) }

--- a/spec/jobs/moab_to_catalog_job_spec.rb
+++ b/spec/jobs/moab_to_catalog_job_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe MoabToCatalogJob, type: :job do
+describe MoabToCatalogJob do
   let(:job) { described_class.new(msr, druid, path) }
-  let(:msr) { create :moab_storage_root }
+  let(:msr) { create(:moab_storage_root) }
   let(:druid) { 'bj102hs9687' }
   let(:path) { "#{msr.storage_location}/bj/102/hs/9687/bj102hs9687" }
   let(:moab) { instance_double(Moab::StorageObject, size: 22, current_version_id: 3) }

--- a/spec/jobs/part_replication_audit_job_spec.rb
+++ b/spec/jobs/part_replication_audit_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PartReplicationAuditJob, type: :job do
+describe PartReplicationAuditJob do
   let(:preserved_object) { create(:preserved_object, current_version: 2) }
   let(:job) { described_class.new(preserved_object, endpoint) }
   let(:endpoints) { preserved_object.zipped_moab_versions.map(&:zip_endpoint).uniq }

--- a/spec/jobs/plexer_job_spec.rb
+++ b/spec/jobs/plexer_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PlexerJob, type: :job do
+describe PlexerJob do
   let(:dvz) { DruidVersionZip.new(druid, version) }
   let(:druid) { 'bj102hs9687' }
   let(:version) { 1 }

--- a/spec/jobs/results_recorder_job_spec.rb
+++ b/spec/jobs/results_recorder_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ResultsRecorderJob, type: :job do
+describe ResultsRecorderJob do
   let(:preserved_object) { create(:preserved_object) }
   let(:zmv) { preserved_object.zipped_moab_versions.first }
   let(:zmv2) { preserved_object.zipped_moab_versions.second }

--- a/spec/jobs/s3_east_delivery_job_spec.rb
+++ b/spec/jobs/s3_east_delivery_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe S3EastDeliveryJob, type: :job do
+describe S3EastDeliveryJob do
   it 'descends from AbstractDeliveryJob' do
     expect(described_class.new).to be_an(AbstractDeliveryJob)
   end

--- a/spec/jobs/s3_west_delivery_job_spec.rb
+++ b/spec/jobs/s3_west_delivery_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe S3WestDeliveryJob, type: :job do
+describe S3WestDeliveryJob do
   it 'descends from AbstractDeliveryJob' do
     expect(described_class.new).to be_an(AbstractDeliveryJob)
   end

--- a/spec/jobs/validate_moab_job_spec.rb
+++ b/spec/jobs/validate_moab_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ValidateMoabJob, type: :job do
+describe ValidateMoabJob do
   let(:job) { described_class.new }
   let(:bare_druid) { 'bj102hs9687' }
   let(:druid) { "druid:#{bare_druid}" }

--- a/spec/jobs/zipmaker_job_spec.rb
+++ b/spec/jobs/zipmaker_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ZipmakerJob, type: :job do
+describe ZipmakerJob do
   let(:druid) { 'bj102hs9687' }
   let(:dvz_part) { instance_double(DruidVersionZipPart, metadata: { fake: 1 }) }
   let(:version) { 3 }

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe CompleteMoab, type: :model do
+RSpec.describe CompleteMoab do
   let(:druid) { 'ab123cd4567' }
   let(:preserved_object) { create(:preserved_object, druid: druid) }
   let(:status) { 'validity_unknown' }

--- a/spec/models/moab_storage_root_spec.rb
+++ b/spec/models/moab_storage_root_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe MoabStorageRoot, type: :model do
+RSpec.describe MoabStorageRoot do
   let(:default_pres_policies) { [PreservationPolicy.default_policy] }
   let(:druid) { 'ab123cd4567' }
   let!(:moab_storage_root) do

--- a/spec/models/preservation_policy_spec.rb
+++ b/spec/models/preservation_policy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe PreservationPolicy, type: :model do
+RSpec.describe PreservationPolicy do
   it 'is valid with valid attributes' do
     preservation_policy = described_class.find_by(preservation_policy_name: 'default')
     expect(preservation_policy).to be_valid

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe PreservedObject, type: :model do
+RSpec.describe PreservedObject do
   # let(:preservation_policy) { create(:preservation_policy, preservation_policy_name: 'large_dark_objects') }
   let(:preservation_policy) { PreservationPolicy.default_policy }
   let(:druid) { 'bc123df4567' }

--- a/spec/models/preserved_objects_primary_moab_spec.rb
+++ b/spec/models/preserved_objects_primary_moab_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe PreservedObjectsPrimaryMoab, type: :model do
+RSpec.describe PreservedObjectsPrimaryMoab do
   let(:cm) { create(:complete_moab) }
   let(:po) { cm.preserved_object }
   let(:alt_po) { create(:preserved_object) }

--- a/spec/models/zip_endpoint_spec.rb
+++ b/spec/models/zip_endpoint_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ZipEndpoint, type: :model do
+RSpec.describe ZipEndpoint do
   let(:default_pres_policies) { [PreservationPolicy.default_policy] }
   let(:druid) { 'ab123cd4567' }
   let!(:zip_endpoint) { create(:zip_endpoint, endpoint_name: 'zip-endpoint', endpoint_node: 'us-west-01') }

--- a/spec/models/zip_part_spec.rb
+++ b/spec/models/zip_part_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ZipPart, type: :model do
+RSpec.describe ZipPart do
   let(:zmv) { build(:zipped_moab_version) }
   let(:args) { attributes_for(:zip_part).merge(zipped_moab_version: zmv) }
 

--- a/spec/models/zipped_moab_version_spec.rb
+++ b/spec/models/zipped_moab_version_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ZippedMoabVersion, type: :model do
+RSpec.describe ZippedMoabVersion do
   let(:preserved_object) { create(:preserved_object) }
   let(:zmv) { create(:zipped_moab_version, preserved_object: preserved_object) }
 

--- a/spec/requests/objects_controller_checksums_spec.rb
+++ b/spec/requests/objects_controller_checksums_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-RSpec.describe ObjectsController, type: :request do
+RSpec.describe ObjectsController do
   let(:prefixed_druid) { 'druid:bj102hs9687' }
   let(:prefixed_druid2) { 'druid:bz514sm9647' }
   let(:bare_druid) { 'bj102hs9687' }

--- a/spec/requests/objects_controller_content_diff_spec.rb
+++ b/spec/requests/objects_controller_content_diff_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ObjectsController, type: :request do
+RSpec.describe ObjectsController do
   let(:prefixed_druid) { 'druid:bj102hs9687' }
   let(:bare_druid) { 'bj102hs9687' }
   let(:content_md) { '<contentMetadata>yer stuff here</contentMetadata>' }

--- a/spec/requests/objects_controller_file_spec.rb
+++ b/spec/requests/objects_controller_file_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ObjectsController, type: :request do
+RSpec.describe ObjectsController do
   let(:prefixed_druid) { 'druid:bj102hs9687' }
   let(:bare_druid) { 'bj102hs9687' }
 

--- a/spec/requests/objects_controller_object_spec.rb
+++ b/spec/requests/objects_controller_object_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-RSpec.describe ObjectsController, type: :request do
+RSpec.describe ObjectsController do
   let(:pres_obj) { create(:preserved_object) }
 
   describe 'GET #show' do

--- a/spec/requests/objects_controller_primary_moab_spec.rb
+++ b/spec/requests/objects_controller_primary_moab_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ObjectsController, type: :request do
+RSpec.describe ObjectsController do
   let(:pres_obj) { primary_moab.preserved_object }
   let(:primary_moab) do
     create(:complete_moab) do |cm|

--- a/spec/requests/objects_controller_validate_moab_spec.rb
+++ b/spec/requests/objects_controller_validate_moab_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-RSpec.describe ObjectsController, type: :request do
+RSpec.describe ObjectsController do
   let(:prefixed_druid) { 'druid:bj102hs9687' }
   let(:bare_druid) { 'bj102hs9687' }
   let(:post_headers) { valid_auth_header.merge('Content-Type' => 'application/json') }

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'routes', type: :routing do
+RSpec.describe 'routes' do
   let(:id) { 'druid:ab123cd4567' }
 
   describe 'objects/:id' do


### PR DESCRIPTION
## Why was this change made? 🤔
Hire more cops.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



