### PR TITLE
Refactor create and create_after validation services.

### DIFF
--- a/app/services/complete_moab_service/create.rb
+++ b/app/services/complete_moab_service/create.rb
@@ -15,14 +15,23 @@ module CompleteMoabService
     # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
     def execute(checksums_validated: false)
       perform_execute do
-        if CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
-          results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'CompleteMoab')
+        if complete_moab_exists?
+          report_already_exists
         else
-          creation_status = (checksums_validated ? 'ok' : 'validity_unknown')
           moab_validator.ran_moab_validation! if checksums_validated # ensure validation timestamps updated
-          create_db_objects(creation_status, checksums_validated: checksums_validated)
+          create_db_objects(creation_status(checksums_validated), checksums_validated: checksums_validated)
         end
       end
+    end
+
+    protected
+
+    def report_already_exists
+      results.add_result(AuditResults::DB_OBJ_ALREADY_EXISTS, 'CompleteMoab')
+    end
+
+    def creation_status(checksums_validated)
+      checksums_validated ? 'ok' : 'validity_unknown'
     end
   end
 end


### PR DESCRIPTION
refs #1964

## Why was this change made? 🤔
Less code.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



