### PR TITLE
Refactor update_version and update_version_after_validation services.

### DIFF
--- a/app/services/complete_moab_service/base.rb
+++ b/app/services/complete_moab_service/base.rb
@@ -124,13 +124,10 @@ module CompleteMoabService
       moab_validator.moab_validation_errors.present?
     end
 
-    def record_missing
+    def create_missing_complete_moab
       results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, 'CompleteMoab')
-      if validation_errors?
-        create_db_objects('invalid_moab')
-      else
-        create_db_objects('validity_unknown')
-      end
+      status = moab_validator.moab_validation_errors.empty? ? 'validity_unknown' : 'invalid_moab'
+      create_db_objects(status)
     end
   end
 end

--- a/app/services/complete_moab_service/check_existence.rb
+++ b/app/services/complete_moab_service/check_existence.rb
@@ -17,7 +17,7 @@ module CompleteMoabService
         if complete_moab_exists?
           check_versions
         else
-          record_missing
+          create_missing_complete_moab
         end
       end
     end

--- a/app/services/complete_moab_service/update_version.rb
+++ b/app/services/complete_moab_service/update_version.rb
@@ -18,40 +18,44 @@ module CompleteMoabService
         Rails.logger.debug "update_version #{druid} called"
         # only change status if checksums_validated is false
         new_status = (checksums_validated ? nil : 'validity_unknown')
-        # NOTE: we deal with active record transactions in update_online_version, not here
-        update_online_version(status: new_status, set_status_to_unexpected_version: true, checksums_validated: checksums_validated)
+        # NOTE: we deal with active record transactions in update_catalog, not here
+        update_catalog(status: new_status, set_status_to_unexpected_version: true, checksums_validated: checksums_validated)
       end
     end
 
     protected
 
-    def update_online_version(status: nil, set_status_to_unexpected_version: false, checksums_validated: false)
+    def update_catalog(status: nil, set_status_to_unexpected_version: false, checksums_validated: false)
       with_active_record_transaction_and_rescue do
         raise_rollback_if_version_mismatch
 
         if incoming_version > complete_moab.version
-          # add results without db updates
-          code = AuditResults::ACTUAL_VERS_GT_DB_OBJ
-          results.add_result(code, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
-
-          complete_moab.upd_audstamps_version_size(moab_validator.ran_moab_validation?, incoming_version, incoming_size)
-          complete_moab.last_checksum_validation = Time.current if checksums_validated && complete_moab.last_checksum_validation
-          moab_validator.update_status(status) if status
-          complete_moab.save!
-          preserved_object.current_version = incoming_version if primary_moab? # we only want to track highest seen version based on primary
-          preserved_object.save!
+          update_complete_moab_to_expected_version(status: status, checksums_validated: checksums_validated)
         else
           status = 'unexpected_version_on_storage' if set_status_to_unexpected_version
-          update_complete_moab_to_unexpected_version(status)
+          update_complete_moab_to_unexpected_version(status: status)
         end
       end
     end
 
-    def update_complete_moab_to_unexpected_version(new_status)
+    def update_complete_moab_to_expected_version(status:, checksums_validated:)
+      # add results without db updates
+      results.add_result(AuditResults::ACTUAL_VERS_GT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
+
+      complete_moab.upd_audstamps_version_size(moab_validator.ran_moab_validation?, incoming_version, incoming_size)
+      complete_moab.last_checksum_validation = Time.current if checksums_validated && complete_moab.last_checksum_validation
+      moab_validator.update_status(status) if status
+      complete_moab.save!
+
+      preserved_object.current_version = incoming_version if primary_moab? # we only want to track highest seen version based on primary
+      preserved_object.save!
+    end
+
+    def update_complete_moab_to_unexpected_version(status:)
       results.add_result(AuditResults::UNEXPECTED_VERSION, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
       version_comparison_results
 
-      moab_validator.update_status(new_status) if new_status
+      moab_validator.update_status(status) if status
       complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, true)
       complete_moab.save!
     end

--- a/app/services/complete_moab_service/update_version_after_validation.rb
+++ b/app/services/complete_moab_service/update_version_after_validation.rb
@@ -15,36 +15,42 @@ module CompleteMoabService
     # checksums_validated may be set to true if the caller takes responsibility for having validated the checksums
     def execute(checksums_validated: false)
       perform_execute do
-        if CompleteMoab.by_druid(druid).by_storage_root(moab_storage_root).exists?
+        if complete_moab_exists?
           Rails.logger.debug "update_version_after_validation #{druid} called"
-          if moab_validator.moab_validation_errors.empty?
-            # NOTE: we deal with active record transactions in update_online_version, not here
-            new_status = (checksums_validated ? 'ok' : 'validity_unknown')
-            update_online_version(status: new_status, checksums_validated: checksums_validated)
-          else
+          if validation_errors?
             Rails.logger.debug "update_version_after_validation #{druid} found validation errors"
             if checksums_validated
-              update_online_version(status: 'invalid_moab', checksums_validated: true)
-              # for case when no db updates b/c pres_obj version != complete_moab version
-              update_complete_moab_to_invalid_moab unless complete_moab.invalid_moab?
+              record_invalid
             else
-              update_online_version(status: 'validity_unknown')
-              # for case when no db updates b/c pres_obj version != complete_moab version
-              update_complete_moab_to_validity_unknown unless complete_moab.validity_unknown?
+              record_validity_unknown
             end
+          else
+            record_no_validation_errors(checksums_validated)
           end
         else
-          results.add_result(AuditResults::DB_OBJ_DOES_NOT_EXIST, 'CompleteMoab')
-          if moab_validator.moab_validation_errors.empty?
-            create_db_objects('validity_unknown')
-          else
-            create_db_objects('invalid_moab')
-          end
+          create_missing_complete_moab
         end
       end
     end
 
     private
+
+    def record_no_validation_errors(checksums_validated)
+      new_status = (checksums_validated ? 'ok' : 'validity_unknown')
+      update_catalog(status: new_status, checksums_validated: checksums_validated)
+    end
+
+    def record_validity_unknown
+      update_catalog(status: 'validity_unknown')
+      # for case when no db updates b/c pres_obj version != complete_moab version
+      update_complete_moab_to_validity_unknown unless complete_moab.validity_unknown?
+    end
+
+    def record_invalid
+      update_catalog(status: 'invalid_moab', checksums_validated: true)
+      # for case when no db updates b/c pres_obj version != complete_moab version
+      update_complete_moab_to_invalid_moab unless complete_moab.invalid_moab?
+    end
 
     def update_complete_moab_to_validity_unknown
       with_active_record_transaction_and_rescue do

--- a/spec/services/complete_moab_service/update_version_after_validation_spec.rb
+++ b/spec/services/complete_moab_service/update_version_after_validation_spec.rb
@@ -165,18 +165,18 @@ RSpec.describe CompleteMoabService::UpdateVersionAfterValidation do
           end
         end
 
-        context 'calls #update_online_version with' do
+        context 'calls #update_catalog with' do
           it 'status = "validity_unknown" for checksums_validated = false' do
-            expect(complete_moab_service).to receive(:update_online_version).with(status: 'validity_unknown',
-                                                                                  checksums_validated: false).and_call_original
+            expect(complete_moab_service).to receive(:update_catalog).with(status: 'validity_unknown',
+                                                                           checksums_validated: false).and_call_original
             complete_moab_service.execute(checksums_validated: false)
-            skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
+            skip 'test is weak b/c we only indirectly show the effects of #update_catalog in #update_version specs'
           end
 
           it 'status = "ok" and checksums_validated = true for checksums_validated = true' do
-            expect(complete_moab_service).to receive(:update_online_version).with(status: 'ok', checksums_validated: true).and_call_original
+            expect(complete_moab_service).to receive(:update_catalog).with(status: 'ok', checksums_validated: true).and_call_original
             complete_moab_service.execute(checksums_validated: true)
-            skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
+            skip 'test is weak b/c we only indirectly show the effects of #update_catalog in #update_version specs'
           end
         end
       end
@@ -326,17 +326,17 @@ RSpec.describe CompleteMoabService::UpdateVersionAfterValidation do
           end
         end
 
-        context 'calls #update_online_version with' do
+        context 'calls #update_catalog with' do
           it 'status = "validity_unknown" for checksums_validated = false' do
-            expect(complete_moab_service).to receive(:update_online_version).with(status: 'validity_unknown').and_call_original
+            expect(complete_moab_service).to receive(:update_catalog).with(status: 'validity_unknown').and_call_original
             complete_moab_service.execute
-            skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
+            skip 'test is weak b/c we only indirectly show the effects of #update_catalog in #update_version specs'
           end
 
           it 'status = "invalid_moab" and checksums_validated = true for checksums_validated = true' do
-            expect(complete_moab_service).to receive(:update_online_version).with(status: 'invalid_moab', checksums_validated: true).and_call_original
+            expect(complete_moab_service).to receive(:update_catalog).with(status: 'invalid_moab', checksums_validated: true).and_call_original
             complete_moab_service.execute(checksums_validated: true)
-            skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
+            skip 'test is weak b/c we only indirectly show the effects of #update_catalog in #update_version specs'
           end
         end
 

--- a/spec/services/complete_moab_service/update_version_spec.rb
+++ b/spec/services/complete_moab_service/update_version_spec.rb
@@ -123,19 +123,19 @@ RSpec.describe CompleteMoabService::UpdateVersion do
           end
         end
 
-        context 'calls #update_online_version with' do
+        context 'calls #update_catalog with' do
           it 'status = "validity_unknown" for checksums_validated = false' do
-            expect(complete_moab_service).to receive(:update_online_version).with(status: 'validity_unknown', set_status_to_unexpected_version: true,
-                                                                                  checksums_validated: false).and_call_original
+            expect(complete_moab_service).to receive(:update_catalog).with(status: 'validity_unknown', set_status_to_unexpected_version: true,
+                                                                           checksums_validated: false).and_call_original
             complete_moab_service.execute
-            skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
+            skip 'test is weak b/c we only indirectly show the effects of #update_catalog in #update_version specs'
           end
 
           it 'status = "ok" and checksums_validated = true for checksums_validated = true' do
-            expect(complete_moab_service).to receive(:update_online_version).with(status: nil, set_status_to_unexpected_version: true,
-                                                                                  checksums_validated: true).and_call_original
+            expect(complete_moab_service).to receive(:update_catalog).with(status: nil, set_status_to_unexpected_version: true,
+                                                                           checksums_validated: true).and_call_original
             complete_moab_service.execute(checksums_validated: true)
-            skip 'test is weak b/c we only indirectly show the effects of #update_online_version in #update_version specs'
+            skip 'test is weak b/c we only indirectly show the effects of #update_catalog in #update_version specs'
           end
         end
 


### PR DESCRIPTION
refs #1964

## Why was this change made? 🤔
Cleaner?


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



