### PR TITLE
dashboard beginnings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::API
   # appropritaly small workgroup.
   def non_api_route?
     # no need to list /status (okcomputer) URLs here, because those aren't handled by ApplicationController
-    request.fullpath.match(%r{^/resque(/.*)?$})
+    request.fullpath.match(%r{^/(resque)|(dashboard)(/.*)?$})
   end
 
   def check_auth_token!

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Minimal controller for dashboard
+class DashboardController < ApplicationController
+  def index; end
+end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+# helper methods for dashboard
+module DashboardHelper # rubocop:disable Metrics/ModuleLength
+  # CompleteMoab.last_version_audit is the most recent of 3 separate audits:
+  #   moab_to_catalog - all CompleteMoabs are queued for this on the 1st of the month
+  #   catalog_to_moab - all CompleteMoabs are queued for this on the 15th of the month
+  #   checksum_validation - CompleteMoabs with expired checksums are queued weekly;  they expire after 90 days
+  # 18 days gives a little slop for either of the first 2 audit queues to die down.
+  MOAB_LAST_VERSION_AUDIT_THRESHOLD = 18.days
+
+  REPLICATION_AUDIT_THRESHOLD = 90.days # meant to be the same as PreservationPolicy.archive_ttl
+
+  def catalog_ok?
+    num_preserved_objects == num_complete_moabs &&
+      num_object_versions_per_preserved_object == num_object_versions_per_complete_moab
+  end
+
+  def replication_ok?
+    replication_info.each_value do |info|
+      return false if info[1] != num_object_versions_per_preserved_object
+    end
+    true
+  end
+
+  def validate_moab_audit_ok?
+    # NOTE: unsure if there needs to be more checking of CompleteMoab.status_details for more statuses to figure this out
+    (CompleteMoab.invalid_moab.count + CompleteMoab.online_moab_not_found.count).zero?
+  end
+
+  def catalog_to_moab_audit_ok?
+    # NOTE: unsure if there needs to be more checking of CompleteMoab.status_details for more statuses to figure this out
+    (CompleteMoab.online_moab_not_found.count + CompleteMoab.unexpected_version_on_storage.count).zero?
+  end
+
+  def moab_to_catalog_audit_ok?
+    # NOTE: unsure if there needs to be more checking of CompleteMoab.status_details for more statuses to figure this out
+    # I believe if there's a moab that's not in the catalog, it is added by this audit.
+    !any_complete_moab_errors?
+  end
+
+  def checksum_validation_audit_ok?
+    # NOTE: unsure if there needs to be more checking of CompleteMoab.status_details for more statuses to figure this out
+    CompleteMoab.invalid_checksum.count.zero?
+  end
+
+  def catalog_to_archive_audit_ok?
+    (ZipPart.count - ZipPart.ok.count).zero?
+  end
+
+  def storage_root_info
+    storage_root_info = {}
+    MoabStorageRoot.all.each do |storage_root|
+      storage_root_info[storage_root.name] =
+        [
+          storage_root.storage_location,
+          "#{storage_root.complete_moabs.sum(:size).fdiv(Numeric::TERABYTE).round(2)} Tb",
+          "#{(storage_root.complete_moabs.average(:size) || 0).fdiv(Numeric::MEGABYTE).round(2)} Mb",
+          storage_root.complete_moabs.count,
+          CompleteMoab::STATUSES.map { |status| storage_root.complete_moabs.where(status: status).count },
+          storage_root.complete_moabs.fixity_check_expired.count
+        ].flatten
+    end
+    storage_root_info
+  end
+
+  # @return [Array<Integer>] totals of counts from each storage root for:
+  #   total of counts of each CompleteMoab status (ok, invalid_checksum, etc.)
+  #   total of counts of fixity_check_expired
+  #   total of complete_moab counts - this is last element in array due to index shift to skip storage_location and stored size
+  def storage_root_totals
+    return [0] if storage_root_info.values.size.zero?
+
+    totals = Array.new(storage_root_info.values.first.size - 3, 0)
+    storage_root_info.each_key do |root_name|
+      storage_root_info[root_name][3..].each_with_index do |count, index|
+        totals[index] += count
+      end
+    end
+    totals
+  end
+
+  def storage_root_total_count
+    storage_root_totals.first
+  end
+
+  def storage_root_total_ok_count
+    storage_root_totals[1]
+  end
+
+  def complete_moab_total_size
+    "#{CompleteMoab.sum(:size).fdiv(Numeric::TERABYTE).round(2)} Tb"
+  end
+
+  def complete_moab_average_size
+    "#{CompleteMoab.average(:size).fdiv(Numeric::MEGABYTE).round(2)} Mb" unless num_complete_moabs.zero?
+  end
+
+  def complete_moab_status_counts
+    CompleteMoab::STATUSES.map { |status| CompleteMoab.where(status: status).count }
+  end
+
+  def status_labels
+    CompleteMoab::STATUSES.map { |status| status.tr('_', ' ') }
+  end
+
+  def moab_audit_age_threshold
+    (DateTime.now - MOAB_LAST_VERSION_AUDIT_THRESHOLD).to_s
+  end
+
+  def num_moab_audits_older_than_threshold
+    CompleteMoab.least_recent_version_audit(moab_audit_age_threshold).count
+  end
+
+  def moab_audits_older_than_threshold?
+    num_moab_audits_older_than_threshold.positive?
+  end
+
+  def num_expired_checksum_validation
+    CompleteMoab.fixity_check_expired.count
+  end
+
+  def any_complete_moab_errors?
+    num_complete_moab_not_ok.positive?
+  end
+
+  def num_complete_moab_not_ok
+    num_complete_moabs - CompleteMoab.ok.count
+  end
+
+  def replication_info
+    replication_info = {}
+    ZipEndpoint.all.each do |zip_endpoint|
+      replication_info[zip_endpoint.endpoint_name] =
+        [
+          zip_endpoint.delivery_class,
+          ZippedMoabVersion.where(zip_endpoint_id: zip_endpoint.id).count
+        ].flatten
+    end
+    replication_info
+  end
+
+  def zip_part_suffixes
+    ZipPart.group(:suffix).count
+  end
+
+  def zip_parts_total_size
+    "#{ZipPart.sum(:size).fdiv(Numeric::TERABYTE).round(2)} Tb"
+  end
+
+  def num_replication_errors
+    ZipPart.count - ZipPart.ok.count
+  end
+
+  def replication_audit_age_threshold
+    (DateTime.now - REPLICATION_AUDIT_THRESHOLD).to_s
+  end
+
+  def num_replication_audits_older_than_threshold
+    PreservedObject.archive_check_expired.count
+  end
+
+  def replication_audits_older_than_threshold?
+    num_replication_audits_older_than_threshold.positive?
+  end
+
+  def num_preserved_objects
+    PreservedObject.count
+  end
+
+  def preserved_object_highest_version
+    preserved_object_ordered_version_counts.keys.last
+  end
+
+  # total number of object versions according to PreservedObject table
+  def num_object_versions_per_preserved_object
+    total_version_count(preserved_object_ordered_version_counts)
+  end
+
+  def average_version_per_preserved_object
+    num_object_versions_per_preserved_object.fdiv(num_preserved_objects).to_f.round(2) unless num_preserved_objects.zero?
+  end
+
+  def num_complete_moabs
+    CompleteMoab.count
+  end
+
+  def complete_moab_highest_version
+    complete_moab_ordered_version_counts.keys.last
+  end
+
+  # total number of object versions according to CompleteMoab table
+  def num_object_versions_per_complete_moab
+    total_version_count(complete_moab_ordered_version_counts)
+  end
+
+  def average_version_per_complete_moab
+    num_object_versions_per_complete_moab.fdiv(num_complete_moabs).round(2) unless num_complete_moabs.zero?
+  end
+
+  private
+
+  def preserved_object_ordered_version_counts
+    PreservedObject.group(:current_version).count.sort.to_h
+  end
+
+  def complete_moab_ordered_version_counts
+    CompleteMoab.group(:version).count.sort.to_h
+  end
+
+  def total_version_count(version_counts)
+    result = 0
+    version_counts.each { |version, count_for_version| result += version * count_for_version }
+    result
+  end
+end

--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -3,6 +3,8 @@
 ##
 # CompleteMoab represents a concrete instance of a PreservedObject across ALL versions, in physical storage.
 class CompleteMoab < ApplicationRecord
+  STATUSES = %w[ok invalid_moab invalid_checksum online_moab_not_found unexpected_version_on_storage validity_unknown].freeze
+
   # @note Hash values cannot be modified without migrating any associated persisted data.
   # @see [enum docs] http://api.rubyonrails.org/classes/ActiveRecord/Enum.html
   enum status: {

--- a/app/views/dashboard/_audit_information.html.erb
+++ b/app/views/dashboard/_audit_information.html.erb
@@ -1,0 +1,63 @@
+<h3>Audit Information</h3>
+
+TBD:  make the audit check description into a tooltip?
+<table class="table table-bordered border-dark table-hover table-sm">
+  <thead class="table-info">
+    <tr>
+      <th class="col-sm-2"/>
+      <th class="col-sm-1">redis queue name</th>
+      <th class="col-sm-3">expected frequency<br/>(from app/config/schedule.rb)</th>
+      <th class="col-sm-1">how many objects get queued</th>
+      <th class="col-sm-2">objects with audit timestamps older than threshold</th>
+      <th>objects with errors</th>
+      <th>expired checks</th>
+    </tr>
+  </thead>
+  <tbody class="table-group-divider">
+    <tr>
+      <td><strong>Validate Moab</strong><br/>moab-versioning integrity checks run for locally stored Moabs.</td>
+      <td>validate_moab</td>
+      <td><strong>on demand</strong></td>
+      <td><strong>one</strong>:<br/>queued by preservation robot step after updating a Moab</td>
+      <td class="text-end<%= ' table-danger' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
+      <td class="text-end<%= ' table-danger' if any_complete_moab_errors? %>"><%= num_complete_moab_not_ok %></td>
+      <td class="table-secondary"/>
+    </tr>
+    <tr>
+      <td><strong>Moab to Catalog</strong><br/>moab-versioning integrity checks run for locally stored Moabs and verified against database info.</td>
+      <td>m2c</td>
+      <td><strong>Monthly</strong>: 11 am on the 1st of every month</td>
+      <td><strong>all</strong>:<br/>queued by walking directories on MoabStorageRoot.storage_location</td>
+      <td class="text-end<%= ' table-danger' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
+      <td class="text-end<%= ' table-danger' if any_complete_moab_errors? %>"><%= num_complete_moab_not_ok %></td>
+      <td class="table-secondary"/>
+    </tr>
+    <tr>
+      <td><strong>Catalog to Moab</strong><br/>Database info verified against locally stored Moabs and moab-versioning integrity checks for Moabs.</td>
+      <td>c2m</td>
+      <td><strong>Monthly</strong>: 11 am on the 15th of every month</td>
+      <td><strong>all</strong>:<br/>queued by associated MoabStorageRoot</td>
+      <td class="text-end<%= ' table-danger' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
+      <td class="text-end<%= ' table-danger' if any_complete_moab_errors? %>"><%= num_complete_moab_not_ok %></td>
+      <td class="table-secondary"/>
+    </tr>
+    <tr>
+      <td><strong>Checksum Validation (CV)</strong><br/>Compare checksums in Moab metadata files on local storage with computed checksums for Moab metadata and content files.</td>
+      <td>checksum_validation</td>
+      <td><strong>Weekly</strong>: 1am on Sunday<br/><em>for CompleteMoabs with expired checks</em></td>
+      <td><strong>subset</strong>:<br/>expired checksums queued by associated MoabStorageRoot</td>
+      <td class="text-end<%= ' table-danger' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
+      <td class="text-end<%= ' table-danger' if CompleteMoab.invalid_checksum.count != 0 %>"><%= CompleteMoab.invalid_checksum.count %></td>
+      <td class="text-center"><%= num_expired_checksum_validation %><br/><br/>(passing checks expire 90 days after they are run)</td>
+    </tr>
+    <tr>
+      <td><strong>Catalog to Archive</strong><br/>Confirm a PreservedObject has all versions/parts replicated for each of its target endpoints and attempts to backfill missing ones</td>
+      <td>moab_replication_audit<br/>part_audit_aws_s3_east_1<br/>part_audit_aws_s3_west_2<br/>part_audit_ibm_us_south</td>
+      <td><strong>Weekly</strong>: 12am on Wednesday<br/><em>for PreservedObjects with expired checks</em></td>
+      <td><strong>subset</strong>:<br/>expired archive checks for PreservedObjects and their associated ZipParts are queued</td>
+      <td class="text-end<%= ' table-danger' if replication_audits_older_than_threshold? %>">PreservedObject replication audits older than <%= replication_audit_age_threshold %>:<hr/><%= num_replication_audits_older_than_threshold %></td>
+      <td class="text-end<%= ' table-danger' if num_replication_errors != 0 %>"><%= num_replication_errors %></td>
+      <td class="text-center"><%= PreservedObject.archive_check_expired.count %><br/><br/>(passing checks expire 90 days after they are run)</td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/dashboard/_audit_status.html.erb
+++ b/app/views/dashboard/_audit_status.html.erb
@@ -1,0 +1,57 @@
+<div class="card border border-4 border-secondary text-center">
+  <div class="card-body row" />
+    <h2 class="card-title">Audit Status</h2>
+    <span class="row row-cols-5">
+      <div class="nav-link card border border-3" id="audit-tab" data-bs-toggle="tab" data-bs-target="#audit-tab-pane" type="button" role="tab" aria-controls="audit-tab-pane" aria-selected="false">
+          <h4 class="card-title">Validate Moab Status</h4>
+          <h3>
+            <% if validate_moab_audit_ok? %>
+              <span class="badge bg-success rounded-pill">OK</span>
+            <% else %>
+              <span class="badge bg-danger">Error</span>
+            <% end %>
+          </h3>
+      </div>
+      <div class="nav-link card border border-3" id="audit-tab" data-bs-toggle="tab" data-bs-target="#audit-tab-pane" type="button" role="tab" aria-controls="audit-tab-pane" aria-selected="false">
+          <h4 class="card-title">Moab to Catalog Status</h4>
+          <h3>
+          <% if moab_to_catalog_audit_ok? %>
+            <span class="badge bg-success rounded-pill">OK</span>
+          <% else %>
+            <span class="badge bg-danger">Error</span>
+          <% end %>
+          </h3>
+      </div>
+      <div class="nav-link card border border-3 col"  id="audit-tab" data-bs-toggle="tab" data-bs-target="#audit-tab-pane" type="button" role="tab" aria-controls="audit-tab-pane" aria-selected="false">
+          <h4 class="card-title">Catalog to Moab Status</h4>
+          <h3>
+          <% if catalog_to_moab_audit_ok? %>
+            <span class="badge bg-success rounded-pill">OK</span>
+          <% else %>
+            <span class="badge bg-danger">Error</span>
+          <% end %>
+          </h3>
+      </div>
+      <div class="nav-link card border border-3 col"  id="audit-tab" data-bs-toggle="tab" data-bs-target="#audit-tab-pane" type="button" role="tab" aria-controls="audit-tab-pane" aria-selected="false">
+          <h4 class="card-title">Checksum Validation Status</h4>
+          <h3>
+          <% if checksum_validation_audit_ok? %>
+            <span class="badge bg-success rounded-pill">OK</span>
+          <% else %>
+            <span class="badge bg-danger">Error</span>
+          <% end %>
+          </h3>
+      </div>
+      <div class="nav-link card border border-3 col"  id="audit-tab" data-bs-toggle="tab" data-bs-target="#audit-tab-pane" type="button" role="tab" aria-controls="audit-tab-pane" aria-selected="false">
+          <h4 class="card-title">Catalog to Archive Status</h4>
+          <h3>
+          <% if catalog_to_archive_audit_ok? %>
+            <span class="badge bg-success rounded-pill">OK</span>
+          <% else %>
+            <span class="badge bg-danger">Error</span>
+          <% end %>
+          </h3>
+      </div>
+    </span>
+  </div>
+</div>

--- a/app/views/dashboard/_catalog_information.html.erb
+++ b/app/views/dashboard/_catalog_information.html.erb
@@ -1,0 +1,13 @@
+<h2>Catalog Status Information</h2>
+<div>
+  <p class="lead">The Preservation Catalog database keeps track of the state of SDR objects preserved on prem and in the cloud.</p>
+</div>
+<p><strong class="fs-4">PreservedObject</strong> is where we store the druid and links to both the on prem Moab object and all the replicated instances in the cloud.</p>
+<p><strong class="fs-4">CompleteMoab</strong> is about the on prem Moab.</p>
+<hr/>
+<div class="row row-cols-2">
+  <div class="column col-5"><%= render partial: 'object_versions' %></div>
+  <div class="column col-7"><%= render partial: 'complete_moab_status_counts' %></div>
+</div>
+<hr/>
+<%= render partial: 'moab_storage_root_data' %>

--- a/app/views/dashboard/_catalog_status.html.erb
+++ b/app/views/dashboard/_catalog_status.html.erb
@@ -1,0 +1,12 @@
+<div class="card border border-4 border-secondary text-center">
+  <div class="card-body" />
+    <h2 class="card-title">Catalog Status</h2>
+    <h1>
+      <% if catalog_ok? %>
+        <span class="badge bg-success rounded-pill">OK</span>
+      <% else %>
+        <span class="badge bg-danger">Error</span>
+      <% end %>
+    </h1>
+  </div>
+</div>

--- a/app/views/dashboard/_complete_moab_status_counts.html.erb
+++ b/app/views/dashboard/_complete_moab_status_counts.html.erb
@@ -1,0 +1,31 @@
+<div>
+  <h3>CompleteMoab Information</h3>
+  <div class="col-sm-5">
+    TBD: make tooltips for the different statuses?
+    <table class="table table-bordered table-hover">
+      <thead class="table-info">
+        <tr>
+          <th>count</th>
+          <th>total size</th>
+          <th>average size</th>
+          <%status_labels.map do |status| %>
+            <th class="text-center"><%=status %></th>
+          <% end %>
+          <th>expired checksum audit</th>
+        </tr>
+      </thead>
+      <tbody class="table-group-divider">
+        <tr class="text-end">
+          <td><%= num_preserved_objects %></td>
+          <td><%= complete_moab_total_size %></td>
+          <td><%= complete_moab_average_size %></td>
+          <td><%= complete_moab_status_counts[0] %>
+          <% complete_moab_status_counts[1..].map do |val| %>
+            <td class="<%= 'table-danger' if val != 0 %>"><%= val %></td>
+          <% end %>
+          <td><%= num_expired_checksum_validation %></td>
+          </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/dashboard/_endpoint_data.html.erb
+++ b/app/views/dashboard/_endpoint_data.html.erb
@@ -1,0 +1,28 @@
+<div>
+  <h4>Endpoint Data</h4>
+  <p>The database uses ZippedMoabVersion to track which versions of which Moabs have been replicated to which replication endpoints.</p>
+  <div class="col-sm-4">
+    <table class="table table-bordered table-hover">
+      <thead class="table-info">
+        <tr>
+          <th>endpoint name</th>
+          <th>ActiveJob class for replication</th>
+          <th class="text-center">ZippedMoabVersion replicated count<br/>(according to database)</th>
+          <th class="text-center">Number of Object Versions<br/>(per PreservedObject)</th>
+        </tr>
+      </thead>
+      <tbody class="table-group-divider">
+        <% replication_info.each do |endpoint_name, info| %>
+          <tr>
+            <td><%= endpoint_name %></td>
+            <td><%= info[0] %></td>
+            <% info[1..].map do |val| %>
+              <td class="text-end<%= ' table-danger' if val != num_object_versions_per_preserved_object%>"><%= val %></td>
+            <% end %>
+            <td class="text-end"><%= num_object_versions_per_preserved_object %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/dashboard/_moab_storage_root_data.html.erb
+++ b/app/views/dashboard/_moab_storage_root_data.html.erb
@@ -1,0 +1,52 @@
+<div class="col-sm-12">
+  <h3>MoabStorageRoot Information</h3>
+
+  <p><strong class="fs-5">MoabStorageRoot</strong> represents an on prem storage location for a Moab.</p>
+
+  <div class="col-sm-11">
+    TBD: make tooltips for the different statuses?
+    <table class="table table-bordered table-hover table-sm">
+      <thead class="table-info">
+        <tr>
+          <th class="col-2">root name</th>
+          <th class="col-4">storage location</th>
+          <th class="col-1">total size</th>
+          <th class="col-1">average size</th>
+          <th class="col-1">moab count</th>
+          <% status_labels.map do |status| %>
+            <th class="col-sm-1 text-center"><%=status %></th>
+          <% end %>
+          <th class="col-sm-1">expired checksum audit</th>
+        </tr>
+      </thead>
+      <tbody class="table-group-divider">
+        <% storage_root_info.each do |root_name, info| %>
+          <tr>
+            <td><%= root_name %></td>
+            <td><%= info[0] %></td><%# storage location %>
+            <td><%= info[1] %></td><%# total size %>
+            <td><%= info[2] %></td><%# average size %>
+            <td class="text-end"><%= info[3] %></td><%# moab count %>
+            <td class="text-end"><%= info[4] %></td><%# ok status %>
+            <% info[5..].map do |val| %>
+              <td class="text-end<%= ' table-danger' if val != 0 %>"><%= val %></td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+      <tfoot  class="table-group-divider">
+        <tr>
+          <th>totals</th>
+          <td class="table-secondary"/>
+          <td class="table-secondary"/>
+          <td class="table-secondary"/>
+          <td class="text-end<%= ' table-danger' if storage_root_total_count != num_complete_moabs %>"><%= storage_root_total_count %></td>
+          <td class="text-end"><%= storage_root_total_ok_count %></td>
+          <% storage_root_totals[2..]&.each do |count| %>
+            <td class="text-end<%= ' table-danger' if count != 0 %>"><%= count %></td>
+          <% end %>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+</div>

--- a/app/views/dashboard/_object_versions.html.erb
+++ b/app/views/dashboard/_object_versions.html.erb
@@ -1,0 +1,31 @@
+<h3>Counts and Version Information</h3>
+
+<div class="col-sm-4">
+  <table class="table table-bordered table-hover table-sm">
+    <thead class="table-info">
+      <tr>
+        <th/>
+        <th>count</th>
+        <th>object version count</th>
+        <th>highest version</th>
+        <th>average version</th>
+      </tr>
+    </thead>
+    <tbody class="table-group-divider">
+      <tr>
+        <td>PreservedObject</td>
+        <td class="text-end<%= ' table-danger' if num_preserved_objects != num_complete_moabs %>"><%= num_preserved_objects %></td>
+        <td class="text-end<%= ' table-danger' if num_object_versions_per_preserved_object != num_object_versions_per_complete_moab %>"><%= num_object_versions_per_preserved_object %></td>
+        <td class="text-end<%= ' table-danger' if preserved_object_highest_version != complete_moab_highest_version %>"><%= preserved_object_highest_version %></td>
+        <td class="text-end"><%= average_version_per_preserved_object %></td>
+      </tr>
+      <tr>
+        <td>CompleteMoab</td>
+        <td class="text-end<%= ' table-danger' if num_preserved_objects != num_complete_moabs %>"><%= num_complete_moabs %></td>
+        <td class="text-end<%= ' table-danger' if num_object_versions_per_preserved_object != num_object_versions_per_complete_moab %>"><%= num_object_versions_per_complete_moab %></td>
+        <td class="text-end<%= ' table-danger' if preserved_object_highest_version != complete_moab_highest_version %>"><%= complete_moab_highest_version %></td>
+        <td class="text-end"><%= average_version_per_complete_moab %></td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/dashboard/_replicated_files.html.erb
+++ b/app/views/dashboard/_replicated_files.html.erb
@@ -1,0 +1,30 @@
+<div>
+  <h4>Replication Files</h4>
+
+  <p>Zipped files for an object are split into parts of no more than 10G.</p>
+
+  <div class="col-sm-6">
+    <table class="table table-bordered table-hover">
+      <thead class="table-info">
+        <tr>
+          <th>Total ZipParts (count)</th>
+          <th>Total Size of all ZipParts</th>
+          <th class="text-center">ok</th>
+          <th class="text-center">replicated checksum mismatch</th>
+          <th class="text-center">unreplicated</th>
+          <th class="text-center">not found</th>
+        </tr>
+      </thead>
+      <tbody class="table-group-divider">
+        <tr>
+          <td><%= ZipPart.count %></td>
+          <td><%= zip_parts_total_size %></td>
+          <td class="text-end"><%= ZipPart.ok.count %></td>
+          <td class="text-end<%= ' table-danger' if ZipPart.replicated_checksum_mismatch.count != 0 %>"><%= ZipPart.replicated_checksum_mismatch.count %></td>
+          <td class="text-end<%= ' table-warning' if ZipPart.unreplicated.count != 0 %>"><%= ZipPart.unreplicated.count %></td>
+          <td class="text-end<%= ' table-danger' if ZipPart.not_found.count != 0 %>"><%= ZipPart.not_found.count %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/dashboard/_replication_flow.html.erb
+++ b/app/views/dashboard/_replication_flow.html.erb
@@ -1,0 +1,69 @@
+<h4>Replication Flow</h4>
+
+<p>See also <a href="https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md">app/jobs/README.md</a>
+for a diagram and a few words about replication queues/job flow.</p>
+
+<div>
+  <table class="table table-bordered border-dark table-hover">
+    <thead class="table-info">
+      <tr>
+        <th class="col-sm-2">job name / class or method</th>
+        <th class="col-sm-3">description</th>
+        <th class="col-sm-1">redis queue name</th>
+        <th class="col-sm-1">next job(s) called</th>
+        <th class="col-sm-3">where to find job failures</th>
+      </tr>
+    </thead>
+    <tbody class="table-group-divider">
+      <tr>
+        <td><strong>PreservedObject.update</strong> as well as <strong>CreateMoab.create and .update</strong></td>
+        <td>after_xxx hooks are used to ensure new and updated druids are replicated.</td>
+        <td class="table-secondary"/>
+        <td>PreservedObject.create_zipped_moab_versions!</td>
+        <td>Honeybadger</td>
+      </tr>
+      <tr>
+        <td class="fw-bold">PreservedObject.create_zipped_moab_versions!</td>
+        <td>ensure we have ZippedMoabVersion db table rows for <em>every ZipEndpoint for each Moab version</em> by calling ZipmakerJob for any missing moab version on a zip endpoint</td>
+        <td class="table-secondary"/>
+        <td>ZipmakerJob per missing version per endpoint</td>
+        <td>Honeybadger</td>
+      </tr>
+      <tr>
+        <td class="fw-bold">ZipmakerJob</td>
+        <td>creates a new DruidVersionZip for S3 endpoint if it doesn't exist. If needed, write zip file(s) to temporary zip storage and calculate checksum(s); otherwise, touch the file(s).</td>
+        <td>zipmaker</td>
+        <td>DruidVersionZip.find_or_create_zip!; any returned partkeys each call PlexerJob</td>
+        <td>See resque/failed.</td>
+      </tr>
+      <tr>
+        <td class="fw-bold">DruidVersionZip.find_or_create_zip!</td>
+        <td>if zip file to be replicated exists, touch it. If it doesn't exist, create it.</td>
+        <td class="table-secondary"/>
+        <td>DruidVersionZipParts.new if zip is over threshhold of 10g.</td>
+        <td>Honeybadger</td>
+      </tr>
+      <tr>
+        <td class="fw-bold">PlexerJob</td>
+        <td>If necessary, record zip part metadata info in DB. <br/>Call endpoint jobs for zip (parts)</td>
+        <td>zips_made</td>
+        <td>S3WestDeliveryJob<br/>S3EastDeliveryJob<br/>IbmSouthDeliveryJob</td>
+        <td>See resque/failed.</td>
+      </tr>
+      <tr>
+        <td>S3 endpoint jobs:<br/><strong>S3EastDeliveryJob</strong><br/><strong>S3WeDeliveryJob</strong><br/><strong>IBMSouthDeliveryJob</strong></td>
+        <td>Posts individual zip (part) to S3 endpoint if not there already.</td>
+        <td><br/>s3_us_east_1_delivery<br/>s3_us_west_2_delivery<br/>ibm_us_south_delivery</td>
+        <td>ResultsRecorderJob if zip (part) posted</td>
+        <td>See resque/failed.</td>
+      </tr>
+      <tr>
+        <td class="fw-bold">ResultsRecorderJob</td>
+        <td>If this completes the replication of a ZippedMoabVersion to an S3 endpoint, send message to event service.  If full ZippedMoabVersion is replicated to all zip_endpoints, "publish" with redis.</td>
+        <td>zip_endpoint_events</td>
+        <td class="table-secondary"/>
+        <td>See resque/failed.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/dashboard/_replication_information.html.erb
+++ b/app/views/dashboard/_replication_information.html.erb
@@ -1,0 +1,8 @@
+<h3>S3 Replication Information</h3>
+
+<%= render partial: 'endpoint_data' %>
+<div class="row row-cols-2">
+  <div class="column"><%= render partial: 'replicated_files' %></div>
+  <div class="column"><%= render partial: 'zip_parts_suffix_counts' %></div>
+</div>
+<%= render partial: 'replication_flow' %>

--- a/app/views/dashboard/_replication_status.html.erb
+++ b/app/views/dashboard/_replication_status.html.erb
@@ -1,0 +1,12 @@
+<div class="card border border-4 border-secondary text-center">
+  <div class="card-body" />
+    <h2 class="card-title">Replication Status</h2>
+    <h1>
+      <% if replication_ok? %>
+        <span class="badge bg-success rounded-pill">OK</span>
+      <% else %>
+        <span class="badge bg-danger">Error</span>
+      <% end %>
+    </h1>
+  </div>
+</div>

--- a/app/views/dashboard/_zip_parts_suffix_counts.html.erb
+++ b/app/views/dashboard/_zip_parts_suffix_counts.html.erb
@@ -1,0 +1,26 @@
+<div>
+  <h4>ZipPart suffix counts</h4>
+  <p>The first ZipPart suffix will always be .zip. If a zip is over 10g, the suffixes of the parts will be .zip, .z01, .z02, etc.</p>
+  <div class="col-sm-2">
+    <table class="table table-bordered table-hover table-sm">
+      <thead class="table-info">
+        <tr>
+          <th>suffix</th>
+          <th>count</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>.zip</td>
+          <td class="text-end">0<%= zip_part_suffixes['.zip'] %></td>
+        </tr>
+        <% zip_part_suffixes.keys[0..-2]&.map do |suffix| %>
+          <tr>
+            <td><%= suffix %></td>
+            <td class="text-end"><%= zip_part_suffixes[suffix] %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Preservation Dashboard</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
+  </head>
+  <body>
+    <div class="px-5 col-12">
+      <h1>Preservation Dashboard</h1>
+      <nav>
+        <div class="nav nav-tabs row row-cols-3" id="statusTab" role="tablist">
+          <button class="nav-link column col-2 active" id="status-tab" data-bs-toggle="tab" data-bs-target="#status-tab-pane" type="button" role="tab" aria-controls="status-tab-pane" aria-selected="true"><%= render partial: 'catalog_status' %></button>
+          <button class="nav-link column col-2" id="replication-tab" data-bs-toggle="tab" data-bs-target="#replication-tab-pane" type="button" role="tab" aria-controls="replication-tab-pane" aria-selected="false"><%= render partial: 'replication_status' %></button>
+          <div class="column col-8"><button class="nav-link" id="audit-tab" data-bs-toggle="tab" data-bs-target="#audit-tab-pane" type="button" role="tab" aria-controls="audit-tab-pane" aria-selected="false"><%= render partial: 'audit_status' %></button></div>
+        </div>
+      </nav>
+      <div class="tab-content" id="statusTabContent">
+        <div class="tab-pane fade show active" id="status-tab-pane" role="tabpanel" aria-labelledby="status-tab" tabindex="0"><%= render partial: 'catalog_information' %></div>
+        <div class="tab-pane fade" id="replication-tab-pane" role="tabpanel" aria-labelledby="replication-tab" tabindex="0"><%= render partial: 'replication_information' %></div>
+        <div class="tab-pane fade" id="audit-tab-pane" role="tabpanel" aria-labelledby="audit-tab" tabindex="0"><%= render partial: 'audit_information' %></div>
+      </div>
+      <hr style="opacity:1"/>
+      <div>
+        <h2>TBD: Forms for admins to do stuff?</h2>
+
+        <p>TBD: form for <b>checking state</b> of a particluar druid or set of druids - status, number of versions ...</p>
+        <p>TBD: form for doing <b>audit checks by druid</b> for one or more druids</p>
+        <p>TBD: form for doing <b>audit checks by storage root</b></p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <title>SUL - Preservation Catalog</title>
+  </head>
+
+  <body>
+    <div class="container">
+      <% if flash[:notice] %>
+        <div class="alert alert-primary" role="alert">
+          <%= flash[:notice] %>
+        </div>
+      <% end %>
+      <% if flash[:alert] %>
+        <div class="alert alert-warning" role="alert">
+          <%= flash[:alert] %>
+        </div>
+      <% end %>
+
+      <%= yield %>
+      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
+    </div>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
         at: '/resque',
         constraints: ->(req) { Settings.resque_dashboard_hostnames.include?(req.host) }
 
+  get 'dashboard', to: 'dashboard#index', defaults: { format: 'html' }
+
   scope 'v1' do
     resources :catalog, param: :druid, only: %i[create update]
 

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -1,0 +1,677 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DashboardHelper do
+  let(:storage_root) { create(:moab_storage_root) }
+
+  describe '#catalog_ok?' do
+    context 'when PreservedObject and CompleteMoab counts are different' do
+      before do
+        po1 = create(:preserved_object)
+        create(:preserved_object)
+        create(:complete_moab, preserved_object: po1, moab_storage_root: storage_root)
+      end
+
+      it 'returns false' do
+        expect(helper.catalog_ok?).to be false
+      end
+    end
+
+    context 'when version counts for PreservedObject and CompleteMoab are different' do
+      before do
+        po1 = create(:preserved_object, current_version: 2)
+        po2 = create(:preserved_object, current_version: 2)
+        create(:complete_moab, preserved_object: po1, version: 3)
+        create(:complete_moab, preserved_object: po2, version: 2)
+      end
+
+      it 'returns false' do
+        expect(helper.catalog_ok?).to be false
+      end
+    end
+
+    context 'when PreservedObject and CompleteMoab counts match and version counts match' do
+      before do
+        po1 = create(:preserved_object, current_version: 3)
+        po2 = create(:preserved_object, current_version: 2)
+        create(:complete_moab, preserved_object: po1, version: 3)
+        create(:complete_moab, preserved_object: po2, version: 2)
+      end
+
+      it 'returns true' do
+        expect(helper.catalog_ok?).to be true
+      end
+    end
+  end
+
+  describe '#replication_ok?' do
+    let(:po1) { create(:preserved_object, current_version: 2) }
+    let(:po2) { create(:preserved_object, current_version: 1) }
+
+    before do
+      # test seeds have 2 ZipEndpoints
+      create(:zipped_moab_version, preserved_object: po1, zip_endpoint: ZipEndpoint.first)
+      create(:zipped_moab_version, preserved_object: po1, zip_endpoint: ZipEndpoint.last)
+      create(:zipped_moab_version, preserved_object: po2, zip_endpoint: ZipEndpoint.first)
+      create(:zipped_moab_version, preserved_object: po2, zip_endpoint: ZipEndpoint.last)
+    end
+
+    context 'when a ZipEndpoint count does not match num_object_versions_per_preserved_object' do
+      it 'returns false' do
+        expect(helper.replication_ok?).to be false
+      end
+    end
+
+    context 'when ZipEndpoint counts match num_object_versions_per_preserved_object' do
+      before do
+        # test seeds have 2 ZipEndpoints
+        create(:zipped_moab_version, preserved_object: po1, version: 2, zip_endpoint: ZipEndpoint.first)
+        create(:zipped_moab_version, preserved_object: po1, version: 2, zip_endpoint: ZipEndpoint.last)
+      end
+
+      it 'returns true' do
+        expect(helper.replication_ok?).to be true
+      end
+    end
+  end
+
+  describe '#validate_moab_audit_ok?' do
+    context 'when there are CompleteMoabs with invalid_moab status' do
+      before do
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'invalid_moab')
+        create(:complete_moab, status: 'ok')
+      end
+
+      it 'returns false' do
+        expect(helper.validate_moab_audit_ok?).to be false
+      end
+    end
+
+    context 'when there are CompleteMoabs with online_moab_not_found status' do
+      before do
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'online_moab_not_found')
+      end
+
+      it 'returns false' do
+        expect(helper.validate_moab_audit_ok?).to be false
+      end
+    end
+
+    context 'when there are no CompleteMoabs with either online_moab_not_found or invalid_moab status' do
+      before do
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'invalid_checksum')
+      end
+
+      it 'returns true' do
+        expect(helper.validate_moab_audit_ok?).to be true
+      end
+    end
+  end
+
+  describe '#catalog_to_moab_audit_ok?' do
+    context 'when there are CompleteMoabs with unexpected_version_on_storage status' do
+      before do
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'unexpected_version_on_storage')
+        create(:complete_moab, status: 'ok')
+      end
+
+      it 'returns false' do
+        expect(helper.catalog_to_moab_audit_ok?).to be false
+      end
+    end
+
+    context 'when there are CompleteMoabs with online_moab_not_found status' do
+      before do
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'online_moab_not_found')
+      end
+
+      it 'returns false' do
+        expect(helper.catalog_to_moab_audit_ok?).to be false
+      end
+    end
+
+    context 'when there are no CompleteMoabs with either online_moab_not_found or unexpected_version_on_storage status' do
+      before do
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'invalid_checksum')
+      end
+
+      it 'returns true' do
+        expect(helper.catalog_to_moab_audit_ok?).to be true
+      end
+    end
+  end
+
+  describe '#moab_to_catalog_audit_ok?' do
+    before do
+      create(:complete_moab, status: 'ok')
+      create(:complete_moab, status: 'ok')
+    end
+
+    context 'when status other than ok for at least one CompleteMoab' do
+      before do
+        create(:complete_moab, status: 'unexpected_version_on_storage')
+      end
+
+      it 'returns false' do
+        expect(helper.moab_to_catalog_audit_ok?).to be false
+      end
+    end
+
+    context 'when all CompleteMoabs have status ok' do
+      it 'returns true' do
+        expect(helper.moab_to_catalog_audit_ok?).to be true
+      end
+    end
+  end
+
+  describe '#checksum_validation_audit_ok?' do
+    context 'when there are CompleteMoabs with online_moab_not_found status' do
+      before do
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'invalid_checksum')
+      end
+
+      it 'returns false' do
+        expect(helper.checksum_validation_audit_ok?).to be false
+      end
+    end
+
+    context 'when there are no CompleteMoabs with either online_moab_not_found or unexpected_version_on_storage status' do
+      before do
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'unexpected_version_on_storage')
+      end
+
+      it 'returns true' do
+        expect(helper.checksum_validation_audit_ok?).to be true
+      end
+    end
+  end
+
+  describe '#catalog_to_archive_audit_ok?' do
+    before do
+      create(:zip_part, status: 'ok')
+      create(:zip_part, status: 'ok')
+    end
+
+    context 'when all ZipParts have ok status' do
+      it 'is true' do
+        expect(helper.catalog_to_archive_audit_ok?).to be true
+      end
+    end
+
+    context 'when all ZipParts do not have ok status' do
+      before do
+        create(:zip_part, status: 'replicated_checksum_mismatch')
+      end
+
+      it 'is false' do
+        expect(helper.catalog_to_archive_audit_ok?).to be false
+      end
+    end
+  end
+
+  describe '#storage_root_info' do
+    skip('FIXME: intend to change this internal structure soon; not testing yet')
+    # storage_root_info = {}
+    # MoabStorageRoot.all.each do |storage_root|
+    #   storage_root_info[storage_root.name] =
+    #     [
+    #       storage_root.storage_location,
+    #       "#{(storage_root.complete_moabs.sum(:size) / Numeric::TERABYTE).to_f.round(2)} Tb",
+    #       "#{((storage_root.complete_moabs.average(:size) || 0) / Numeric::MEGABYTE).to_f.round(2)} Mb",
+    #       storage_root.complete_moabs.count,
+    #       CompleteMoab::STATUSES.map { |status| storage_root.complete_moabs.where(status: status).count },
+    #       storage_root.complete_moabs.fixity_check_expired.count
+    #     ].flatten
+    # end
+    # storage_root_info
+  end
+
+  # @return [Array<Integer>] totals of counts from each storage root for:
+  #   total of counts of each CompleteMoab status (ok, invalid_checksum, etc.)
+  #   total of counts of fixity_check_expired
+  #   total of complete_moab counts - this is last element in array due to index shift to skip storage_location and stored size
+  describe '#storage_root_totals' do
+    skip('FIXME: intend to change storage_root_info internal structure soon; not testing yet')
+    # return [0] if storage_root_info.values.size.zero?
+
+    # totals = Array.new(storage_root_info.values.first.size - 3, 0)
+    # storage_root_info.each_key do |root_name|
+    #   storage_root_info[root_name][3..].each_with_index do |count, index|
+    #     totals[index] += count
+    #   end
+    # end
+    # totals
+  end
+
+  describe '#storage_root_total_count' do
+    before do
+      create(:complete_moab, moab_storage_root: storage_root)
+      create(:complete_moab, moab_storage_root: storage_root, status: 'invalid_checksum')
+      create(:complete_moab, moab_storage_root: create(:moab_storage_root))
+    end
+
+    it 'returns total number of Moabs on all storage roots' do
+      expect(helper.storage_root_total_count).to eq 3
+    end
+  end
+
+  describe '#storage_root_total_ok_count' do
+    before do
+      create(:complete_moab, moab_storage_root: storage_root)
+      create(:complete_moab, moab_storage_root: storage_root, status: 'invalid_checksum')
+      create(:complete_moab, moab_storage_root: create(:moab_storage_root))
+    end
+
+    it 'returns total number of Moabs with status ok on all storage roots' do
+      expect(helper.storage_root_total_ok_count).to eq 2
+    end
+  end
+
+  describe '#complete_moab_total_size' do
+    before do
+      create(:complete_moab, size: 1 * Numeric::TERABYTE)
+      create(:complete_moab, size: (2 * Numeric::TERABYTE) + (500 * Numeric::GIGABYTE))
+      create(:complete_moab, size: (3 * Numeric::TERABYTE))
+    end
+
+    it 'returns the total size of CompleteMoabs in Terabytes as a string' do
+      expect(helper.complete_moab_total_size).to eq '6.49 Tb'
+    end
+  end
+
+  describe '#complete_moab_average_size' do
+    context 'when there are CompleteMoabs' do
+      before do
+        create(:complete_moab, size: 1 * Numeric::MEGABYTE)
+        create(:complete_moab, size: (2 * Numeric::KILOBYTE))
+        create(:complete_moab, size: (3 * Numeric::MEGABYTE))
+      end
+      # "#{(CompleteMoab.average(:size) / Numeric::MEGABYTE).to_f.round(2)} Mb" unless num_complete_moabs.zero?
+
+      it 'returns the average size of CompleteMoabs in Megabytes as a string' do
+        expect(helper.complete_moab_average_size).to eq '1.33 Mb'
+      end
+    end
+
+    context 'when num_complete_moabs is 0' do
+      # this avoids a divide by zero error when running locally
+      before do
+        allow(helper).to receive(:num_complete_moabs).and_return(0)
+      end
+
+      it 'returns nil' do
+        expect(helper.complete_moab_average_size).to be_nil
+      end
+    end
+  end
+
+  describe '#complete_moab_status_counts' do
+    before do
+      create(:complete_moab, status: 'ok')
+      create(:complete_moab, status: 'ok')
+      create(:complete_moab, status: 'invalid_moab')
+      create(:complete_moab, status: 'invalid_checksum')
+      create(:complete_moab, status: 'invalid_checksum')
+      create(:complete_moab, status: 'online_moab_not_found')
+      create(:complete_moab, status: 'invalid_checksum')
+      create(:complete_moab, status: 'unexpected_version_on_storage')
+      create(:complete_moab, status: 'validity_unknown')
+      create(:complete_moab, status: 'validity_unknown')
+    end
+
+    it 'returns array of counts for each CompleteMoab status' do
+      expect(helper.complete_moab_status_counts).to eq [2, 1, 3, 1, 1, 2]
+    end
+  end
+
+  describe '#status_labels' do
+    it 'returns CompleteMoab::STATUSES with blanks instead of underscores' do
+      expect(helper.status_labels).to eq ['ok',
+                                          'invalid moab',
+                                          'invalid checksum',
+                                          'online moab not found',
+                                          'unexpected version on storage',
+                                          'validity unknown']
+    end
+  end
+
+  describe '#moab_audit_age_threshold' do
+    it 'returns string version of MOAB_LAST_VERSION_AUDIT_THRESHOLD ago' do
+      expect(helper.moab_audit_age_threshold).to be_a(String)
+      result = DateTime.parse(helper.moab_audit_age_threshold)
+      expect(result).to be <= DateTime.now - DashboardHelper::MOAB_LAST_VERSION_AUDIT_THRESHOLD
+    end
+  end
+
+  context 'when at least one CompleteMoab has last_version_audit older than MOAB_LAST_VERSION_AUDIT_THRESHOLD' do
+    before do
+      create(:complete_moab, last_version_audit: 45.days.ago)
+      create(:complete_moab, last_version_audit: 1.day.ago)
+      create(:complete_moab, last_version_audit: 2.days.ago)
+      create(:complete_moab, last_version_audit: 30.days.ago)
+    end
+
+    describe '#num_moab_audits_older_than_threshold' do
+      it 'returns a number greater than 0' do
+        expect(helper.num_moab_audits_older_than_threshold).to be > 0
+        expect(helper.num_moab_audits_older_than_threshold).to eq 2
+      end
+    end
+
+    describe '#moab_audits_older_than_threshold?' do
+      it 'is true' do
+        expect(helper.moab_audits_older_than_threshold?).to be true
+      end
+    end
+  end
+
+  context 'when no CompleteMoabs have last_version_audit older than MOAB_LAST_VERSION_AUDIT_THRESHOLD' do
+    before do
+      create(:complete_moab, last_version_audit: 5.days.ago)
+    end
+
+    describe '#num_moab_audits_older_than_threshold' do
+      it 'returns 0' do
+        expect(helper.num_moab_audits_older_than_threshold).to eq 0
+      end
+    end
+
+    describe '#moab_audits_older_than_threshold?' do
+      it 'is false' do
+        expect(helper.moab_audits_older_than_threshold?).to be false
+      end
+    end
+  end
+
+  describe '#num_expired_checksum_validation' do
+    before do
+      create(:complete_moab, moab_storage_root: storage_root, last_checksum_validation: Time.zone.now)
+      create(:complete_moab, preserved_object: create(:preserved_object), last_checksum_validation: 4.months.ago)
+      create(:complete_moab, moab_storage_root: storage_root)
+    end
+
+    it 'returns CompleteMoab.fixity_check_expired.count and includes nil in the count' do
+      expect(helper.num_expired_checksum_validation).to eq(2)
+    end
+  end
+
+  describe '#any_complete_moab_errors?' do
+    before do
+      create(:complete_moab, status: 'ok')
+      create(:complete_moab, status: 'ok')
+    end
+
+    context 'when there are no errors' do
+      it 'returns false' do
+        expect(helper.any_complete_moab_errors?).to be false
+      end
+    end
+
+    context 'when there are errors' do
+      before do
+        create(:complete_moab, status: 'invalid_moab')
+      end
+
+      it 'returns true' do
+        expect(helper.any_complete_moab_errors?).to be true
+      end
+    end
+  end
+
+  describe '#num_complete_moab_not_ok' do
+    before do
+      create(:complete_moab, status: 'ok')
+      create(:complete_moab, status: 'ok')
+    end
+
+    context 'when all CompleteMoabs are status ok' do
+      it 'is 0' do
+        expect(helper.num_complete_moab_not_ok).to eq 0
+      end
+    end
+
+    context 'when a CompleteMoab has status other than ok' do
+      before do
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'ok')
+        create(:complete_moab, status: 'invalid_moab')
+        create(:complete_moab, status: 'invalid_checksum')
+        create(:complete_moab, status: 'online_moab_not_found')
+        create(:complete_moab, status: 'unexpected_version_on_storage')
+        create(:complete_moab, status: 'validity_unknown')
+      end
+
+      it 'is not 0' do
+        expect(helper.num_complete_moab_not_ok).to eq 5
+      end
+    end
+  end
+
+  describe '#replication_info' do
+    skip('FIXME: intend to change this internal structure soon; not testing yet')
+    # replication_info = {}
+    # ZipEndpoint.all.each do |zip_endpoint|
+    #   replication_info[zip_endpoint.endpoint_name] =
+    #     [
+    #       zip_endpoint.delivery_class,
+    #       ZippedMoabVersion.where(zip_endpoint_id: zip_endpoint.id).count
+    #     ].flatten
+    # end
+    # replication_info
+  end
+
+  describe '#zip_part_suffixes' do
+    before do
+      create(:zip_part, size: 1 * Numeric::TERABYTE)
+      create(:zip_part, size: (2 * Numeric::TERABYTE))
+      create(:zip_part, size: (3 * Numeric::TERABYTE))
+    end
+
+    it 'returns a hash of suffies as keys and values as counts' do
+      expect(helper.zip_part_suffixes).to eq('.zip' => 3)
+    end
+  end
+
+  describe '#zip_parts_total_size' do
+    before do
+      create(:zip_part, size: 1 * Numeric::TERABYTE)
+      create(:zip_part, size: ((2 * Numeric::TERABYTE) + (500 * Numeric::GIGABYTE)))
+      create(:zip_part, size: (3 * Numeric::TERABYTE))
+    end
+
+    it 'returns the total size of ZipParts in Terabytes as a string' do
+      expect(helper.zip_parts_total_size).to eq '6.49 Tb'
+    end
+  end
+
+  describe '#num_replication_errors' do
+    before do
+      create(:zip_part, status: 'unreplicated')
+      create(:zip_part, status: 'ok')
+      create(:zip_part, status: 'ok')
+      create(:zip_part, status: 'replicated_checksum_mismatch')
+      create(:zip_part, status: 'not_found')
+    end
+
+    it 'returns ZipPart.count - ZipPart.ok.count' do
+      expect(ZipPart.count).to eq 5
+      expect(helper.num_replication_errors).to eq 3
+    end
+  end
+
+  describe '#replication_audit_age_threshold' do
+    it 'returns string version of REPLICATION_AUDIT_THRESHOLD ago' do
+      expect(helper.replication_audit_age_threshold).to be_a(String)
+      result = DateTime.parse(helper.replication_audit_age_threshold)
+      expect(result).to be <= DateTime.now - DashboardHelper::REPLICATION_AUDIT_THRESHOLD
+    end
+  end
+
+  context 'when at least one PreservedObject has archive_check_expired' do
+    before do
+      create(:preserved_object, last_archive_audit: 95.days.ago)
+      create(:preserved_object) # last_archive_audit is nil so it counts
+      create(:preserved_object, last_archive_audit: 132.days.ago)
+      create(:preserved_object, last_archive_audit: 5.days.ago)
+    end
+
+    describe '#num_replication_audits_older_than_threshold' do
+      it 'returns a number greater than 0' do
+        expect(helper.num_replication_audits_older_than_threshold).to be > 0
+        expect(helper.num_replication_audits_older_than_threshold).to eq 3
+      end
+    end
+
+    describe '#replication_audits_older_than_threshold?' do
+      it 'is true' do
+        expect(helper.replication_audits_older_than_threshold?).to be true
+      end
+    end
+  end
+
+  context 'when no PreservedObjects have last_version_audit older than archive_check_expired' do
+    before do
+      create(:preserved_object, last_archive_audit: 5.days.ago)
+      create(:preserved_object, last_archive_audit: 2.days.ago)
+    end
+
+    describe '#num_replication_audits_older_than_threshold' do
+      it 'returns 0' do
+        expect(helper.num_replication_audits_older_than_threshold).to eq 0
+      end
+    end
+
+    describe '#replication_audits_older_than_threshold?' do
+      it 'is false' do
+        expect(helper.replication_audits_older_than_threshold?).to be false
+      end
+    end
+  end
+
+  describe '#num_preserved_objects' do
+    before do
+      create_list(:preserved_object, 2)
+    end
+
+    it 'returns PreservedObject.count' do
+      expect(helper.num_preserved_objects).to eq(PreservedObject.count)
+      expect(helper.num_preserved_objects).to eq 2
+    end
+  end
+
+  describe '#preserved_object_highest_version' do
+    before do
+      create(:preserved_object, current_version: 1)
+      create(:preserved_object, current_version: 67)
+      create(:preserved_object, current_version: 3)
+    end
+
+    it 'returns the highest current_version value of any PreservedObject' do
+      expect(helper.preserved_object_highest_version).to eq 67
+    end
+  end
+
+  describe '#num_object_versions_per_preserved_object' do
+    before do
+      create(:preserved_object, current_version: 1)
+      create(:preserved_object, current_version: 67)
+      create(:preserved_object, current_version: 3)
+    end
+
+    it 'returns the total number of object versions according to PreservedObject table' do
+      expect(helper.num_object_versions_per_preserved_object).to eq 71
+    end
+  end
+
+  describe '#average_version_per_preserved_object' do
+    context 'when there are PreservedObjects' do
+      before do
+        create(:preserved_object, current_version: 1)
+        create(:preserved_object, current_version: 67)
+        create(:preserved_object, current_version: 3)
+      end
+
+      it 'returns the average number of versions per object according to the PreservedObject table' do
+        expect(helper.average_version_per_preserved_object).to eq 23.67
+      end
+    end
+
+    context 'when there are no PreservedObjects' do
+      # this avoids a divide by zero error when running locally
+      it 'returns nil' do
+        expect(helper.average_version_per_preserved_object).to be_nil
+      end
+    end
+  end
+
+  describe '#num_complete_moabs' do
+    before do
+      storage_root.complete_moabs = build_list(:complete_moab, 2)
+    end
+
+    it 'returns CompleteMoab.count' do
+      expect(helper.num_complete_moabs).to eq(CompleteMoab.count)
+      expect(helper.num_complete_moabs).to eq 2
+    end
+  end
+
+  describe '#complete_moab_highest_version' do
+    before do
+      create(:complete_moab, version: 1)
+      create(:complete_moab, version: 67)
+      create(:complete_moab, version: 3)
+    end
+
+    it 'returns the highest version value of any CompleteMoab' do
+      expect(helper.complete_moab_highest_version).to eq 67
+    end
+  end
+
+  describe '#num_object_versions_per_complete_moab' do
+    before do
+      create(:complete_moab, version: 1)
+      create(:complete_moab, version: 67)
+      create(:complete_moab, version: 3)
+    end
+
+    it 'returns the total number of object versions according to CompleteMoab table' do
+      expect(helper.num_object_versions_per_complete_moab).to eq 71
+    end
+  end
+
+  describe '#average_version_per_complete_moab' do
+    context 'when there are CompleteMoabs' do
+      before do
+        create(:complete_moab, version: 1)
+        create(:complete_moab, version: 67)
+        create(:complete_moab, version: 3)
+      end
+
+      it 'returns the average number of versions per object accrding to the CompleteMoab table' do
+        expect(helper.average_version_per_complete_moab).to eq 23.67
+      end
+    end
+
+    context 'when there are no CompleteMoabs' do
+      # this avoids a divide by zero error when running locally
+      it 'returns nil' do
+        expect(helper.average_version_per_complete_moab).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Dashboard Nav Bar' do
+  describe 'GET #index' do
+    before do
+      get dashboard_url
+    end
+
+    it 'returns a success response with html content' do
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq('text/html; charset=utf-8')
+      expect(response.body).to match(/Preservation Dashboard/)
+    end
+
+    describe 'nav bar' do
+      it 'renders _catalog_status template' do
+        expect(response).to render_template('dashboard/_catalog_status')
+        expect(response.body).to match(/Catalog Status/)
+      end
+
+      it 'renders _audit_status template' do
+        expect(response).to render_template('dashboard/_audit_status')
+        expect(response.body).to match(/Audit Status/)
+      end
+
+      it 'renders _replication_status template' do
+        expect(response).to render_template('dashboard/_replication_status')
+        expect(response.body).to match(/Replication Status/)
+      end
+    end
+
+    describe 'catalog information' do
+      it 'renders _catalog_information template' do
+        expect(response).to render_template('dashboard/_catalog_information')
+        expect(response.body).to match(/Catalog Status Information/)
+      end
+
+      it 'renders _object_versions template' do
+        expect(response).to render_template('dashboard/_object_versions')
+        expect(response.body).to match(/Counts and Version Information/)
+        expect(response.body).to match(/highest version/) # table header
+      end
+
+      it 'renders _complete_moab_status_counts template' do
+        expect(response).to render_template('dashboard/_complete_moab_status_counts')
+        expect(response.body).to match(/CompleteMoab Information/)
+        expect(response.body).to match(/total size/) # table header
+        expect(response.body).to match(/Tb/)
+      end
+
+      it 'renders _moab_storage_root_data template' do
+        expect(response).to render_template('dashboard/_moab_storage_root_data')
+        expect(response.body).to match(/MoabStorageRoot Information/)
+        expect(response.body).to match(/storage location/) # table header
+        expect(response.body).to match(MoabStorageRoot.first.storage_location) # table data
+        expect(response.body).to match(/Mb/) # table data
+      end
+    end
+
+    describe 'replication information' do
+      it 'renders _replication_information template' do
+        expect(response).to render_template('dashboard/_replication_information')
+        expect(response.body).to match(/S3 Replication Information/)
+      end
+
+      it 'renders _endpoint_data template' do
+        expect(response).to render_template('dashboard/_endpoint_data')
+        expect(response.body).to match(/Endpoint Data/)
+        expect(response.body).to match(/ActiveJob class for replication/) # table header
+        expect(response.body).to match(/S3WestDeliveryJob/) # table data
+      end
+
+      it 'renders _replicated_files template' do
+        expect(response).to render_template('dashboard/_replicated_files')
+        expect(response.body).to match(/Replication Files/)
+        expect(response.body).to match(/Total ZipParts/) # table header
+      end
+
+      it 'renders _replication_flow template' do
+        expect(response).to render_template('dashboard/_replication_flow')
+        expect(response.body).to match(/Replication Flow/)
+        # all content is static, so no need to check for specific content
+      end
+    end
+
+    describe 'audit information' do
+      it 'renders _audit_information template' do
+        expect(response).to render_template('dashboard/_audit_information')
+        expect(response.body).to match(/Audit Information/)
+        expect(response.body).to match(/objects with errors/) # table header
+        expect(response.body).to match(/0/) # table data
+      end
+    end
+  end
+end

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -38,4 +38,10 @@ RSpec.describe 'routes' do
       expect(post: content_diff_object_path(id: id)).to route_to(controller: 'objects', action: 'content_diff', id: id)
     end
   end
+
+  describe 'dashboard' do
+    it 'routes to dashboard controller index action' do
+      expect(get: dashboard_path).to route_to(controller: 'dashboard', action: 'index', format: 'html')
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1962 

See https://preservation-catalog-web-stage-01.stanford.edu/dashboard

This is, essentially, some ideas with first pass implemetations.  I would expect:
- more, better ideas to come
- better display of information
- potential implementation improvements

Once this PR is merged, we can have multiple folks simultaneously work on improving the PR.  So it is less important that this code is close to perfect, and more important that the functionality has tests, as lots of refactors are expected.

There are already a bunch of tickets with label dashbaord for improvements;  I am about to make more from the notes from storytime last week.

#### Catalog Status clicked:

![image](https://user-images.githubusercontent.com/96775/200360664-613dd73d-03f5-4b98-b970-523a586e4fae.png)

#### Replication Status clicked:

![image](https://user-images.githubusercontent.com/96775/200360795-7b69a2b5-53ba-4c9d-b6e5-e418352a5e89.png)

#### Audit Status clicked:

![image](https://user-images.githubusercontent.com/96775/200360871-5cbe6e86-e112-4b00-bd24-45287998e1e3.png)


## How was this change tested? 🤨

specs and in situ

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



