### PR TITLE
Removes primary moab related code.

### DIFF
--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -71,10 +71,6 @@ class CompleteMoab < ApplicationRecord
     ok?
   end
 
-  def primary?
-    PreservedObjectsPrimaryMoab.exists?(preserved_object: preserved_object, complete_moab: self)
-  end
-
   def update_audit_timestamps(moab_validated, version_audited)
     t = Time.current
     self.last_moab_validation = t if moab_validated

--- a/app/services/complete_moab_service/base.rb
+++ b/app/services/complete_moab_service/base.rb
@@ -57,8 +57,6 @@ module CompleteMoabService
     end
 
     def raise_rollback_if_version_mismatch
-      return unless primary_moab?
-
       return if complete_moab.matches_po_current_version?
 
       results.add_result(AuditResults::CM_PO_VERSION_MISMATCH, cm_version: complete_moab_version, po_version: preserved_object_version)
@@ -71,10 +69,6 @@ module CompleteMoabService
 
     def preserved_object_version
       complete_moab.preserved_object.current_version
-    end
-
-    def primary_moab?
-      @primary_moab ||= complete_moab.primary?
     end
 
     # Note that this may be called by running M2C on a storage root and discovering a second copy of a Moab,

--- a/app/services/complete_moab_service/check_existence.rb
+++ b/app/services/complete_moab_service/check_existence.rb
@@ -29,7 +29,7 @@ module CompleteMoabService
         moab_validator.update_status('invalid_moab')
       else
         complete_moab.upd_audstamps_version_size(moab_validator.ran_moab_validation?, incoming_version, incoming_size)
-        preserved_object.current_version = incoming_version if primary_moab? # we only want to track highest seen version based on primary
+        preserved_object.current_version = incoming_version
         preserved_object.save!
       end
     end

--- a/app/services/complete_moab_service/update_version.rb
+++ b/app/services/complete_moab_service/update_version.rb
@@ -47,7 +47,7 @@ module CompleteMoabService
       moab_validator.update_status(status) if status
       complete_moab.save!
 
-      preserved_object.current_version = incoming_version if primary_moab? # we only want to track highest seen version based on primary
+      preserved_object.current_version = incoming_version
       preserved_object.save!
     end
 


### PR DESCRIPTION
at least part of #1977

## Why was this change made? 🤔
Legacy


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

Unit

