### PR TITLE
Misc touchups

### DIFF
--- a/app/jobs/ibm_south_delivery_job.rb
+++ b/app/jobs/ibm_south_delivery_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 # @see PreservationCatalog::Aws for how S3 credentials and bucket are configured
+# @note this class name appears in the configuration for the endpoints for which it delivers content.
+#   Please update the configs for the various environments if it's renamed or moved.
 class IbmSouthDeliveryJob < AbstractDeliveryJob
   queue_as :ibm_us_south_delivery
 

--- a/app/jobs/s3_east_delivery_job.rb
+++ b/app/jobs/s3_east_delivery_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 # @see PreservationCatalog::Aws for how S3 credentials and bucket are configured
+# @note this class name appears in the configuration for the endpoints for which it delivers content.
+#   Please update the configs for the various environments if it's renamed or moved.
 # @note This name is slightly misleading, as this class solely deals with AWS US East 1 endpoint
 class S3EastDeliveryJob < AbstractDeliveryJob
   queue_as :s3_us_east_1_delivery

--- a/app/jobs/s3_west_delivery_job.rb
+++ b/app/jobs/s3_west_delivery_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 # @see S3::Aws for how S3 credentials and bucket are configured
+# @note this class name appears in the configuration for the endpoints for which it delivers content.
+#   Please update the configs for the various environments if it's renamed or moved.
 # @note This name is slightly misleading, as this class solely deals with AWS US West 2 endpoint
 class S3WestDeliveryJob < AbstractDeliveryJob
   queue_as :s3_us_west_2_delivery

--- a/app/services/s3/aws/audit.rb
+++ b/app/services/s3/aws/audit.rb
@@ -3,6 +3,8 @@
 module S3
   module Aws
     # Methods for auditing the state of a ZippedMoabVersion on an AWS S3 endpoint.
+    # @note this class name appears in the configuration for the endpoints for which it audits content.
+    #   Please update the configs for the various environments if it's renamed or moved.
     class Audit < S3::S3Audit
       def s3_provider_class
         ::S3::AwsProvider

--- a/app/services/s3/ibm/audit.rb
+++ b/app/services/s3/ibm/audit.rb
@@ -3,6 +3,8 @@
 module S3
   module Ibm
     # Methods for auditing the state of a ZippedMoabVersion on an IBM S3 compatible endpoint.
+    # @note this class name appears in the configuration for the endpoints for which it audits content.
+    #   Please update the configs for the various environments if it's renamed or moved.
     class Audit < S3::S3Audit
       def s3_provider_class
         ::S3::IbmProvider

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - db
       - redis
   db:
-    image: postgres
+    image: postgres:12
     ports:
       - 5432:5432
     environment:

--- a/spec/services/audit/moab_to_catalog_spec.rb
+++ b/spec/services/audit/moab_to_catalog_spec.rb
@@ -184,6 +184,8 @@ RSpec.describe Audit::MoabToCatalog do
                             'The record failed to save after its foreign key was set to nil.>'
       expect(storage_dir_a_seed_result_lists.first).to eq([{ db_update_failed: expected_result_msg }])
       expect(CompleteMoab.by_druid(druid).count).to eq 1
+      # the Moab's original location should remain the location of record in the DB
+      expect(CompleteMoab.by_druid(druid).take.moab_storage_root.storage_location).to eq(storage_dir)
       expect(CompleteMoab.count).to eq 3
       expect(PreservedObject.count).to eq 3
     end

--- a/spec/services/complete_moab_service/check_existence_spec.rb
+++ b/spec/services/complete_moab_service/check_existence_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CompleteMoabService::CheckExistence do
   let(:incoming_size) { 9876 }
   let(:preserved_object) { PreservedObject.find_by!(druid: druid) }
   let(:moab_storage_root) { MoabStorageRoot.find_by!(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
-  let(:complete_moab) { CompleteMoab.find_by!(moab_storage_root: moab_storage_root) }
+  let(:complete_moab) { CompleteMoab.by_druid(druid).take }
   let(:db_update_failed_prefix) { 'db update failed' }
   let(:complete_moab_service) do
     described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: incoming_size, moab_storage_root: moab_storage_root)


### PR DESCRIPTION
## Why was this change made? 🤔

mostly misc small follow on from comments on https://github.com/sul-dlss/preservation_catalog/pull/1953 and #1983, and a couple similarly small unrelated things.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



