### PR TITLE
Refactors MoabValidator.

### DIFF
--- a/app/models/audit_results.rb
+++ b/app/models/audit_results.rb
@@ -85,8 +85,7 @@ class AuditResults
     CM_STATUS_CHANGED
   ].freeze
 
-  attr_accessor :actual_version
-  attr_reader :druid, :moab_storage_root, :check_name
+  attr_reader :druid, :moab_storage_root, :check_name, :actual_version
 
   def initialize(druid:, moab_storage_root:, actual_version: nil, check_name: nil)
     @druid = druid

--- a/app/services/complete_moab_service/check_existence.rb
+++ b/app/services/complete_moab_service/check_existence.rb
@@ -26,7 +26,7 @@ module CompleteMoabService
 
     def update_complete_moab_preserved_object_or_set_status
       if validation_errors?
-        moab_validator.update_status('invalid_moab')
+        status_handler.update_status('invalid_moab')
       else
         complete_moab.upd_audstamps_version_size(moab_validator.ran_moab_validation?, incoming_version, incoming_size)
         preserved_object.current_version = incoming_version if primary_moab? # we only want to track highest seen version based on primary
@@ -40,17 +40,17 @@ module CompleteMoabService
       with_active_record_transaction_and_rescue do
         raise_rollback_if_version_mismatch
 
-        return report_results! unless moab_validator.can_validate_current_comp_moab_status?
+        return report_results! unless moab_validator.can_validate_current_comp_moab_status?(complete_moab: complete_moab)
 
         if incoming_version == complete_moab.version
-          moab_validator.set_status_as_seen_on_disk(true) unless complete_moab.status == 'ok'
+          status_handler.set_status_as_seen_on_disk(found_expected_version: true, moab_validator: moab_validator) unless complete_moab.status == 'ok'
           results.add_result(AuditResults::VERSION_MATCHES, 'CompleteMoab')
         elsif incoming_version > complete_moab.version
-          moab_validator.set_status_as_seen_on_disk(true) unless complete_moab.status == 'ok'
+          status_handler.set_status_as_seen_on_disk(found_expected_version: true, moab_validator: moab_validator) unless complete_moab.status == 'ok'
           results.add_result(AuditResults::ACTUAL_VERS_GT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
           update_complete_moab_preserved_object_or_set_status
         else # incoming_version < complete_moab.version
-          moab_validator.set_status_as_seen_on_disk(false)
+          status_handler.set_status_as_seen_on_disk(found_expected_version: false, moab_validator: moab_validator)
           results.add_result(AuditResults::ACTUAL_VERS_LT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
         end
         complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, true)

--- a/app/services/complete_moab_service/update_version.rb
+++ b/app/services/complete_moab_service/update_version.rb
@@ -44,7 +44,7 @@ module CompleteMoabService
 
       complete_moab.upd_audstamps_version_size(moab_validator.ran_moab_validation?, incoming_version, incoming_size)
       complete_moab.last_checksum_validation = Time.current if checksums_validated && complete_moab.last_checksum_validation
-      moab_validator.update_status(status) if status
+      status_handler.update_status(status) if status
       complete_moab.save!
 
       preserved_object.current_version = incoming_version if primary_moab? # we only want to track highest seen version based on primary
@@ -55,7 +55,7 @@ module CompleteMoabService
       results.add_result(AuditResults::UNEXPECTED_VERSION, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
       version_comparison_results
 
-      moab_validator.update_status(status) if status
+      status_handler.update_status(status) if status
       complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, true)
       complete_moab.save!
     end

--- a/app/services/complete_moab_service/update_version_after_validation.rb
+++ b/app/services/complete_moab_service/update_version_after_validation.rb
@@ -54,7 +54,7 @@ module CompleteMoabService
 
     def update_complete_moab_to_validity_unknown
       with_active_record_transaction_and_rescue do
-        moab_validator.update_status('validity_unknown')
+        status_handler.update_status('validity_unknown')
         complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, false)
         complete_moab.save!
       end
@@ -62,7 +62,7 @@ module CompleteMoabService
 
     def update_complete_moab_to_invalid_moab
       with_active_record_transaction_and_rescue do
-        moab_validator.update_status('invalid_moab')
+        status_handler.update_status('invalid_moab')
         complete_moab.update_audit_timestamps(moab_validator.ran_moab_validation?, false)
         complete_moab.save!
       end

--- a/app/services/moab_utils.rb
+++ b/app/services/moab_utils.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+##
+# Utility methods for Moab::StorageObject and Druid
+class MoabUtils
+  # @param druid [String]
+  # @param storage_location [String] the root directory holding the druid tree (the storage root path)
+  def self.object_dir(druid:, storage_location:)
+    DruidTools::Druid.new(druid, storage_location).path
+  end
+
+  # @param druid [String]
+  # @param storage_location [String] the root directory holding the druid tree (the storage root path)
+  def self.moab(druid:, storage_location:)
+    Moab::StorageObject.new(druid, object_dir(druid: druid, storage_location: storage_location))
+  end
+end

--- a/app/services/moab_validator.rb
+++ b/app/services/moab_validator.rb
@@ -3,46 +3,16 @@
 ##
 # service class with methods for running StorageObjectValidator
 class MoabValidator
-  attr_reader :druid, :storage_location, :results, :caller_validates_checksums
-
-  # @param druid [String] the druid for the moab being audited
-  # @param storage_location [String] the root directory holding the druid tree (the storage root path)
+  # @param moab [Moab::StorageObject] the moab to be validated
   # @param results [AuditResults] the instance the including class is using to track findings of interest
-  # @param complete_moab [CompleteMoab, nil] instance of the complete moab being validated, if already available from the caller.  if nil, will query
-  #   as needed (and memoize result).
-  # @caller_validates_checksums [Boolean] defaults to false.  was this called by code that re-computes checksums to confirm that they match the
-  #   values listed in the manifests?
-  def initialize(druid:, storage_location:, results:, complete_moab: nil, caller_validates_checksums: false)
-    @druid = druid
-    @storage_location = storage_location
-    @results = results
-    @complete_moab = complete_moab
-    @caller_validates_checksums = caller_validates_checksums
+  def initialize(moab:, audit_results:)
+    @moab = moab
+    @audit_results = audit_results
   end
 
-  def object_dir
-    @object_dir ||= DruidTools::Druid.new(druid, storage_location).path
-  end
-
-  def complete_moab
-    # There should be at most one CompleteMoab for a given druid on a given storage location:
-    # * At the DB level, there's a unique index on druid for preserved_objects, a unique index on storage_location
-    # for moab_storage_roots, and a unique index on the combo of preserved_object_id and moab_storage_root_id for
-    # complete_moabs.
-    # * A moab always lives in the druid tree path of the storage_location, so there is only one
-    # possible moab path for any given druid in a given storage root.
-    @complete_moab ||= CompleteMoab.joins(:preserved_object, :moab_storage_root).find_by!(
-      preserved_objects: { druid: druid }, moab_storage_roots: { storage_location: storage_location }
-    )
-  end
-
-  def moab
-    @moab ||= Moab::StorageObject.new(druid, object_dir)
-  end
-
-  def can_validate_current_comp_moab_status?
+  def can_validate_current_comp_moab_status?(complete_moab:, caller_validates_checksums: false)
     can_do = caller_validates_checksums || complete_moab.status != 'invalid_checksum'
-    results.add_result(AuditResults::UNABLE_TO_CHECK_STATUS, current_status: complete_moab.status) unless can_do
+    audit_results.add_result(AuditResults::UNABLE_TO_CHECK_STATUS, current_status: complete_moab.status) unless can_do
     can_do
   end
 
@@ -57,63 +27,21 @@ class MoabValidator
           moab_errors.each do |error_hash|
             moab_error_msgs += error_hash.values
           end
-          results.add_result(AuditResults::INVALID_MOAB, moab_error_msgs)
+          audit_results.add_result(AuditResults::INVALID_MOAB, moab_error_msgs)
         end
         moab_errors
       end
-  end
-
-  def ran_moab_validation!
-    @ran_moab_validation = true
   end
 
   def ran_moab_validation?
     @ran_moab_validation ||= false
   end
 
-  def update_status(new_status)
-    complete_moab.status = new_status
-
-    if complete_moab.status_changed?
-      results.add_result(
-        AuditResults::CM_STATUS_CHANGED, old_status: complete_moab.status_was, new_status: complete_moab.status
-      )
-    end
-
-    complete_moab.status_details = results.results_as_string
+  def ran_moab_validation!
+    @ran_moab_validation = true
   end
 
-  def mark_moab_not_found
-    results.add_result(AuditResults::MOAB_NOT_FOUND,
-                       db_created_at: complete_moab.created_at.iso8601,
-                       db_updated_at: complete_moab.updated_at.iso8601)
-    update_status('online_moab_not_found')
-  end
+  private
 
-  # found_expected_version is a boolean indicating whether the latest version of the moab
-  # on disk is the expected version according to the catalog.  NOTE: in the case of an update
-  # this might mean the on disk version is one higher than the catalog version, if the
-  # catalog hasn't been updated yet.
-  # @param [Boolean] found_expected_version
-  # @return [void]
-  def set_status_as_seen_on_disk(found_expected_version) # rubocop:disable Naming/AccessorMethodName
-    begin
-      return update_status('invalid_moab') if moab_validation_errors.any?
-    rescue Errno::ENOENT
-      return mark_moab_not_found
-    end
-
-    return update_status('unexpected_version_on_storage') unless found_expected_version
-
-    # NOTE: subclasses which override this method should NOT perform checksum validation inside of this method!
-    # CV is expensive, and can run a while, and this method should likely be called from within a DB transaction,
-    # but CV definitely shouldn't happen inside a DB transaction.
-    if results.contains_result_code?(AuditResults::MOAB_CHECKSUM_VALID)
-      update_status('ok')
-    elsif caller_validates_checksums
-      update_status('invalid_checksum')
-    else
-      update_status('validity_unknown')
-    end
-  end
+  attr_reader :moab, :audit_results
 end

--- a/app/services/status_handler.rb
+++ b/app/services/status_handler.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+##
+# service class for updating status in AuditResults and CompleteMoab
+class StatusHandler
+  delegate :add_result, to: :audit_results
+
+  # @param results [AuditResults] the instance the including class is using to track findings of interest
+  # @param complete_moab [CompleteMoab] instance of the complete moab being validated
+  def initialize(audit_results:, complete_moab:)
+    @audit_results = audit_results
+    @complete_moab = complete_moab
+  end
+
+  def update_status(new_status)
+    complete_moab.status = new_status
+
+    if complete_moab.status_changed?
+      add_result(
+        AuditResults::CM_STATUS_CHANGED, old_status: complete_moab.status_was, new_status: complete_moab.status
+      )
+    end
+
+    complete_moab.status_details = audit_results.results_as_string
+  end
+
+  def mark_moab_not_found
+    add_result(AuditResults::MOAB_NOT_FOUND,
+               db_created_at: complete_moab.created_at.iso8601,
+               db_updated_at: complete_moab.updated_at.iso8601)
+    update_status('online_moab_not_found')
+  end
+
+  # found_expected_version is a boolean indicating whether the latest version of the moab
+  # on disk is the expected version according to the catalog.  NOTE: in the case of an update
+  # this might mean the on disk version is one higher than the catalog version, if the
+  # catalog hasn't been updated yet.
+  # @param [Boolean] found_expected_version
+  # @params [MoabValidator] moab_validator
+  # @caller_validates_checksums [Boolean] defaults to false.  was this called by code that re-computes checksums to confirm that they match the
+  #   values listed in the manifests?
+  # @return [void]
+  def set_status_as_seen_on_disk(found_expected_version:, moab_validator:, caller_validates_checksums: false)
+    begin
+      return update_status('invalid_moab') if moab_validator.moab_validation_errors.any?
+    rescue Errno::ENOENT
+      return mark_moab_not_found
+    end
+
+    return update_status('unexpected_version_on_storage') unless found_expected_version
+
+    # NOTE: subclasses which override this method should NOT perform checksum validation inside of this method!
+    # CV is expensive, and can run a while, and this method should likely be called from within a DB transaction,
+    # but CV definitely shouldn't happen inside a DB transaction.
+    if audit_results.contains_result_code?(AuditResults::MOAB_CHECKSUM_VALID)
+      update_status('ok')
+    elsif caller_validates_checksums
+      update_status('invalid_checksum')
+    else
+      update_status('validity_unknown')
+    end
+  end
+
+  private
+
+  attr_reader :complete_moab, :audit_results
+end

--- a/spec/services/audit/catalog_to_moab_spec.rb
+++ b/spec/services/audit/catalog_to_moab_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Audit::CatalogToMoab do
   let(:results_double) do
     instance_double(AuditResults,
                     add_result: nil,
-                    :actual_version= => nil,
                     results: [],
                     results_as_string: nil)
   end
@@ -54,7 +53,7 @@ RSpec.describe Audit::CatalogToMoab do
     it 'gets the current version on disk from the Moab::StorageObject' do
       moab = instance_double(Moab::StorageObject, object_pathname: object_dir)
       allow(Moab::StorageObject).to receive(:new).with(druid, String).and_return(moab)
-      expect(moab).to receive(:current_version_id).and_return(3)
+      expect(moab).to receive(:current_version_id).twice.and_return(3)
       c2m.check_catalog_version
     end
 
@@ -447,7 +446,6 @@ RSpec.describe Audit::CatalogToMoab do
           allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
           my_results_double = instance_double(AuditResults,
                                               add_result: nil,
-                                              :actual_version= => nil,
                                               results: [],
                                               results_as_string: 'mock results as string')
           c2m.instance_variable_set(:@results, my_results_double)
@@ -474,7 +472,6 @@ RSpec.describe Audit::CatalogToMoab do
           allow(Stanford::StorageObjectValidator).to receive(:new).and_return(mock_sov)
           my_results_double = instance_double(AuditResults,
                                               add_result: nil,
-                                              :actual_version= => nil,
                                               results: [],
                                               results_as_string: 'mock results as string')
           c2m.instance_variable_set(:@results, my_results_double)

--- a/spec/services/checksum_validator_spec.rb
+++ b/spec/services/checksum_validator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ChecksumValidator do
   let(:complete_moab) { create(:preserved_object_fixture, druid: druid).complete_moab }
   let(:checksum_validator) { described_class.new(complete_moab) }
   let(:moab_validator) { checksum_validator.send(:moab_validator) }
-  let(:results) { instance_double(AuditResults, check_name: nil, :actual_version= => nil) }
+  let(:results) { instance_double(AuditResults) }
   let(:logger_double) { instance_double(ActiveSupport::Logger, info: nil, error: nil, add: nil) }
   let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
   let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
@@ -73,7 +73,7 @@ RSpec.describe ChecksumValidator do
       end
 
       it 'sets status to online_moab_not_found and adds corresponding audit result' do
-        expect(moab_validator.moab.object_pathname.exist?).to be true
+        expect(checksum_validator.moab.object_pathname.exist?).to be true
         expect { checksum_validator.validate_checksums }.to change(complete_moab, :status).to 'online_moab_not_found'
         expect(complete_moab.reload.status).to eq 'online_moab_not_found'
         expect(checksum_validator.results.results.first).to have_key(:moab_not_found)

--- a/spec/services/complete_moab_service/check_existence_spec.rb
+++ b/spec/services/complete_moab_service/check_existence_spec.rb
@@ -369,12 +369,13 @@ RSpec.describe CompleteMoabService::CheckExistence do
           let(:incoming_version) { 2 }
 
           before do
-            allow(moab_validator.complete_moab).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
+            allow(complete_moab_service).to receive(:complete_moab).and_return(complete_moab)
+            allow(complete_moab).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'foo')
           end
 
           context 'transaction is rolled back' do
             it 'CompleteMoab is not updated' do
-              expect { complete_moab_service.execute }.not_to change { complete_moab_service.complete_moab.reload.updated_at }
+              expect { complete_moab_service.execute }.not_to change { complete_moab.reload.updated_at }
             end
 
             it 'PreservedObject is not updated' do

--- a/spec/services/complete_moab_service/create_after_validation_spec.rb
+++ b/spec/services/complete_moab_service/create_after_validation_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe CompleteMoabService::CreateAfterValidation do
   let(:incoming_size) { 9876 }
   let(:storage_dir) { 'spec/fixtures/storage_root01/sdr2objects' }
   let(:moab_storage_root) { MoabStorageRoot.find_by(storage_location: storage_dir) }
-  let(:complete_moab_service) { described_class.new(druid, incoming_version, incoming_size, moab_storage_root) }
   let(:expected_msg) { 'added object to db as it did not exist' }
   let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
   let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil) }


### PR DESCRIPTION
refs https://github.com/sul-dlss/preservation_catalog/issues/1951

## Why was this change made? 🤔
MoabValidator had 3 different uses:
* Validation
* Updating status
* Acting as a convenience container for some objects.

This PR refactors so that: (1) MoabValidator only does validation; (2) StatusHandler updates status; and (3) the need for a convenience container is factored out.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

Unit, QA

