### PR TITLE
removing use of PreservedObjectsPrimaryMoab table

### DIFF
--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -27,9 +27,7 @@ class CompleteMoab < ApplicationRecord
   belongs_to :moab_storage_root, inverse_of: :complete_moabs
   belongs_to :from_moab_storage_root, class_name: 'MoabStorageRoot', optional: true
 
-  # NOTE: we'd like to check if there is a different complete_moab for the preserved_object and
-  #  assign the other complete_moab to preserved_objects_primary_moab
-  has_one :preserved_objects_primary_moab, dependent: :destroy
+  has_one :preserved_objects_primary_moab, dependent: :destroy # to be removed
 
   validates :status, :version, presence: true
   validates :preserved_object_id, uniqueness: true

--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -16,7 +16,7 @@ class PreservedObject < ApplicationRecord
   belongs_to :preservation_policy
   has_one :complete_moab, dependent: :restrict_with_exception, autosave: true
   has_many :zipped_moab_versions, dependent: :restrict_with_exception, inverse_of: :preserved_object
-  has_one :preserved_objects_primary_moab, dependent: :restrict_with_exception
+  has_one :preserved_objects_primary_moab, dependent: :restrict_with_exception # to be removed
 
   validates :druid,
             presence: true,

--- a/app/services/complete_moab_service/base.rb
+++ b/app/services/complete_moab_service/base.rb
@@ -76,11 +76,7 @@ module CompleteMoabService
     def create_db_objects(status, checksums_validated: false)
       transaction_ok = with_active_record_transaction_and_rescue do
         preserved_object = create_preserved_object
-        complete_moab = preserved_object.create_complete_moab!(complete_moab_attrs(status, checksums_validated))
-        # add to join table unless there is already a primary moab
-        PreservedObjectsPrimaryMoab.find_or_create_by!(preserved_object: preserved_object) do |preserved_objects_primary_moab|
-          preserved_objects_primary_moab.complete_moab = complete_moab
-        end
+        preserved_object.create_complete_moab!(complete_moab_attrs(status, checksums_validated))
       end
       results.add_result(AuditResults::CREATED_NEW_OBJECT) if transaction_ok
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -144,11 +144,6 @@ RSpec.describe CatalogController do
       create(:preserved_object_fixture, druid: bare_druid)
     end
     let(:comp_moab) { pres_obj.complete_moab }
-    let(:primary_moab) { comp_moab }
-
-    before do
-      PreservedObjectsPrimaryMoab.create!(preserved_object: pres_obj, complete_moab: primary_moab)
-    end
 
     context 'with valid params' do
       before do

--- a/spec/jobs/integration_spec.rb
+++ b/spec/jobs/integration_spec.rb
@@ -73,9 +73,7 @@ describe 'the whole replication pipeline' do
 
     it 'gets from zipmaker queue to replication result message for the new version when the moab is updated' do
       # pretend catalog is on version 2 before update call from robots
-      create(:complete_moab, preserved_object: preserved_object, version: version, moab_storage_root: moab_storage_root) do |cm|
-        PreservedObjectsPrimaryMoab.create!(preserved_object: preserved_object, complete_moab: cm)
-      end
+      create(:complete_moab, preserved_object: preserved_object, version: version, moab_storage_root: moab_storage_root)
 
       expect(ZipmakerJob).to receive(:perform_later).with(druid, next_version, moab_storage_root.storage_location).and_call_original
       expect(PlexerJob).to receive(:perform_later).with(druid, next_version, s3_key, Hash).and_call_original

--- a/spec/services/complete_moab_service/check_existence_spec.rb
+++ b/spec/services/complete_moab_service/check_existence_spec.rb
@@ -41,9 +41,7 @@ RSpec.describe CompleteMoabService::CheckExistence do
           size: 1,
           moab_storage_root: moab_storage_root,
           status: 'ok' # NOTE: we are pretending we checked for moab validation errs
-        ) do |primary_complete_moab|
-          PreservedObjectsPrimaryMoab.create!(preserved_object: preserved_object, complete_moab: primary_complete_moab)
-        end
+        )
       end
 
       context 'incoming and db versions match' do

--- a/spec/services/complete_moab_service/create_after_validation_spec.rb
+++ b/spec/services/complete_moab_service/create_after_validation_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe CompleteMoabService::CreateAfterValidation do
       end
     end
 
-    it 'creates PreservedObject and CompleteMoab and PreservedObjectsPrimaryMoab in database when there are no validation errors' do
+    it 'creates PreservedObject and CompleteMoab and in database when there are no validation errors' do
       complete_moab_service = described_class.new(druid: valid_druid, incoming_version: incoming_version, incoming_size: incoming_size,
                                                   moab_storage_root: moab_storage_root)
       complete_moab_service.execute
@@ -59,7 +59,6 @@ RSpec.describe CompleteMoabService::CreateAfterValidation do
       new_complete_moab = new_preserved_object.complete_moab
       expect(new_complete_moab).not_to be_nil
       expect(new_complete_moab.status).to eq 'validity_unknown'
-      expect(new_preserved_object.preserved_objects_primary_moab.complete_moab_id).to eq new_complete_moab.id
     end
 
     it 'creates CompleteMoab with "ok" status and validation timestamps if no validation errors and caller ran CV' do
@@ -99,7 +98,7 @@ RSpec.describe CompleteMoabService::CreateAfterValidation do
         end
       end
 
-      it 'creates PreservedObject, and CompleteMoab with "invalid_moab" status, and PreservedObjectsPrimaryMoab in database' do
+      it 'creates PreservedObject, and CompleteMoab with "invalid_moab" status in database' do
         complete_moab_service.execute
         new_preserved_object = PreservedObject.find_by(druid: invalid_druid, current_version: incoming_version)
         expect(new_preserved_object).not_to be_nil
@@ -108,7 +107,6 @@ RSpec.describe CompleteMoabService::CreateAfterValidation do
         expect(new_complete_moab.status).to eq 'invalid_moab'
         expect(new_complete_moab.last_moab_validation).to be_a ActiveSupport::TimeWithZone
         expect(new_complete_moab.last_version_audit).to be_a ActiveSupport::TimeWithZone
-        expect(new_preserved_object.preserved_objects_primary_moab.complete_moab_id).to eq new_complete_moab.id
       end
 
       it 'creates CompleteMoab with "invalid_moab" status in database even if caller ran CV' do

--- a/spec/services/complete_moab_service/create_spec.rb
+++ b/spec/services/complete_moab_service/create_spec.rb
@@ -26,14 +26,13 @@ RSpec.describe CompleteMoabService::Create do
   end
 
   describe '#execute' do
-    it 'creates PreservedObject and CompleteMoab and PreservedObjectsPrimaryMoab in database' do
+    it 'creates PreservedObject and CompleteMoab in database' do
       complete_moab_service.execute
       new_preserved_object = PreservedObject.find_by(druid: druid)
       new_complete_moab = new_preserved_object.complete_moab
       expect(new_preserved_object.current_version).to eq incoming_version
       expect(new_complete_moab.moab_storage_root).to eq moab_storage_root
       expect(new_complete_moab.size).to eq incoming_size
-      expect(new_preserved_object.preserved_objects_primary_moab.complete_moab_id).to eq new_complete_moab.id
     end
 
     it 'creates the CompleteMoab with "ok" status and validation timestamps if caller ran CV' do

--- a/spec/services/complete_moab_service/update_version_after_validation_spec.rb
+++ b/spec/services/complete_moab_service/update_version_after_validation_spec.rb
@@ -51,9 +51,7 @@ RSpec.describe CompleteMoabService::UpdateVersionAfterValidation do
             status: 'ok', # NOTE: pretending we checked for moab validation errs at create time
             last_version_audit: time,
             last_moab_validation: time
-          ) do |primary_complete_moab|
-            PreservedObjectsPrimaryMoab.create!(preserved_object: preserved_object, complete_moab: primary_complete_moab)
-          end
+          )
         end
 
         let(:preserved_object) { PreservedObject.create!(druid: druid, current_version: 2, preservation_policy: default_preservation_policy) }
@@ -200,9 +198,7 @@ RSpec.describe CompleteMoabService::UpdateVersionAfterValidation do
             status: 'ok', # pretending we checked for moab validation errs at create time
             last_version_audit: time,
             last_moab_validation: time
-          ) do |primary_complete_moab|
-            PreservedObjectsPrimaryMoab.create!(preserved_object: preserved_object, complete_moab: primary_complete_moab)
-          end
+          )
         end
 
         context 'checksums_validated = false' do

--- a/spec/services/complete_moab_service/update_version_spec.rb
+++ b/spec/services/complete_moab_service/update_version_spec.rb
@@ -40,9 +40,7 @@ RSpec.describe CompleteMoabService::UpdateVersion do
           status: 'ok', # pretending we checked for moab validation errs at create time
           last_version_audit: Time.current,
           last_moab_validation: Time.current
-        ) do |primary_complete_moab|
-          PreservedObjectsPrimaryMoab.create!(preserved_object: preserved_object, complete_moab: primary_complete_moab)
-        end
+        )
       end
 
       context 'incoming version newer than catalog versions (both) (happy path)' do


### PR DESCRIPTION
## Why was this change made? 🤔

closes #1977

This is the last of the primary moab code to remove before removing the db table and associations for primary moab concept.

## How was this change tested? 🤨

rspec tests

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



