### PR TITLE
fix rubocop failure

### DIFF
--- a/app/services/complete_moab_service/check_existence.rb
+++ b/app/services/complete_moab_service/check_existence.rb
@@ -34,6 +34,7 @@ module CompleteMoabService
       end
     end
 
+    # rubocop:disable Metrics/AbcSize
     def check_versions
       Rails.logger.debug "check_existence #{druid} called"
 
@@ -57,5 +58,6 @@ module CompleteMoabService
         complete_moab.save!
       end
     end
+    # rubocop:enable Metrics/AbcSize
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

'cause the build was failing and it wasn't my branch's fault.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



