### PR TITLE
fix rubocop after dashboard PR #1992 merge

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -48,7 +48,7 @@ module DashboardHelper # rubocop:disable Metrics/ModuleLength
     (ZipPart.count - ZipPart.ok.count).zero?
   end
 
-  def storage_root_info
+  def storage_root_info # rubocop:disable Metrics/AbcSize
     storage_root_info = {}
     MoabStorageRoot.all.each do |storage_root|
       storage_root_info[storage_root.name] =
@@ -68,7 +68,7 @@ module DashboardHelper # rubocop:disable Metrics/ModuleLength
   #   total of counts of each CompleteMoab status (ok, invalid_checksum, etc.)
   #   total of counts of fixity_check_expired
   #   total of complete_moab counts - this is last element in array due to index shift to skip storage_location and stored size
-  def storage_root_totals
+  def storage_root_totals # rubocop:disable Metrics/AbcSize
     return [0] if storage_root_info.values.size.zero?
 
     totals = Array.new(storage_root_info.values.first.size - 3, 0)

--- a/app/services/complete_moab_service/check_existence.rb
+++ b/app/services/complete_moab_service/check_existence.rb
@@ -34,7 +34,6 @@ module CompleteMoabService
       end
     end
 
-    # rubocop:disable Metrics/AbcSize
     def check_versions
       Rails.logger.debug "check_existence #{druid} called"
 
@@ -58,6 +57,5 @@ module CompleteMoabService
         complete_moab.save!
       end
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

after merging dashboard branch in PR #1992, we had rubocop violations

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



