### PR TITLE
refactor dashboard helper method for endpoint data and tweak the view slightly

### DIFF
--- a/app/helpers/dashboard_replication_helper.rb
+++ b/app/helpers/dashboard_replication_helper.rb
@@ -3,22 +3,22 @@
 # helper methods for dashboard pertaining to replication functionality
 module DashboardReplicationHelper
   def replication_ok?
-    replication_info.each_value do |info|
-      return false if info[1] != num_object_versions_per_preserved_object
+    endpoint_data.each do |_endpoint_name, info|
+      return false if info[:replication_count] != num_object_versions_per_preserved_object
     end
     true
   end
 
-  def replication_info
-    replication_info = {}
+  def endpoint_data
+    endpoint_data = {}
     ZipEndpoint.all.each do |zip_endpoint|
-      replication_info[zip_endpoint.endpoint_name] =
-        [
-          zip_endpoint.delivery_class,
-          ZippedMoabVersion.where(zip_endpoint_id: zip_endpoint.id).count
-        ].flatten
+      endpoint_data[zip_endpoint.endpoint_name] =
+        {
+          delivery_class: zip_endpoint.delivery_class,
+          replication_count: ZippedMoabVersion.where(zip_endpoint_id: zip_endpoint.id).count
+        }
     end
-    replication_info
+    endpoint_data
   end
 
   def zip_part_suffixes

--- a/app/views/dashboard/_replication_endpoint_data.html.erb
+++ b/app/views/dashboard/_replication_endpoint_data.html.erb
@@ -1,6 +1,7 @@
 <div>
   <h4>Endpoint Data</h4>
   <p>The database uses ZippedMoabVersion to track which versions of which Moabs have been replicated to which replication endpoints.</p>
+  <p>The ZippedMoabVersion replicated count for each endpoint should match the number of object versions according to PreservedObject data.</p>
   <div class="col-sm-4">
     <table class="table table-bordered table-hover">
       <thead class="table-info">
@@ -12,13 +13,12 @@
         </tr>
       </thead>
       <tbody class="table-group-divider">
-        <% replication_info.each do |endpoint_name, info| %>
+        <% endpoint_data.each do |endpoint_name, info| %>
           <tr>
             <td><%= endpoint_name %></td>
-            <td><%= info[0] %></td>
-            <% info[1..].map do |val| %>
-              <td class="text-end<%= ' table-danger' if val != num_object_versions_per_preserved_object%>"><%= val %></td>
-            <% end %>
+            <td><%= info[:delivery_class] %></td>
+            <% replication_count = info[:replication_count] %>
+            <td class="text-end<%= ' table-danger' if replication_count != num_object_versions_per_preserved_object%>"><%= replication_count %></td>
             <td class="text-end"><%= num_object_versions_per_preserved_object %></td>
           </tr>
         <% end %>

--- a/spec/helpers/dashboard_replication_helper_spec.rb
+++ b/spec/helpers/dashboard_replication_helper_spec.rb
@@ -34,17 +34,24 @@ RSpec.describe DashboardReplicationHelper do
     end
   end
 
-  describe '#replication_info' do
-    skip('FIXME: intend to change this internal structure soon; not testing yet')
-    # replication_info = {}
-    # ZipEndpoint.all.each do |zip_endpoint|
-    #   replication_info[zip_endpoint.endpoint_name] =
-    #     [
-    #       zip_endpoint.delivery_class,
-    #       ZippedMoabVersion.where(zip_endpoint_id: zip_endpoint.id).count
-    #     ].flatten
-    # end
-    # replication_info
+  describe '#endpoint_data' do
+    let(:endpoint1) { ZipEndpoint.first }
+    let(:endpoint2) { ZipEndpoint.last }
+
+    before do
+      zmv_rel1 = ZippedMoabVersion.where(zip_endpoint_id: endpoint1.id)
+      zmv_rel2 = ZippedMoabVersion.where(zip_endpoint_id: endpoint2.id)
+      allow(zmv_rel1).to receive(:count).and_return(5)
+      allow(zmv_rel2).to receive(:count).and_return(2)
+      allow(ZippedMoabVersion).to receive(:where).with(zip_endpoint_id: endpoint1.id).and_return(zmv_rel1)
+      allow(ZippedMoabVersion).to receive(:where).with(zip_endpoint_id: endpoint2.id).and_return(zmv_rel2)
+    end
+
+    it 'returns a hash with endpoint_name keys and values of Hash with delivery_class and replication_count' do
+      endpoint_data = helper.endpoint_data
+      expect(endpoint_data[endpoint1.endpoint_name]).to eq({ delivery_class: endpoint1.delivery_class, replication_count: 5 })
+      expect(endpoint_data[endpoint2.endpoint_name]).to eq({ delivery_class: endpoint2.delivery_class, replication_count: 2 })
+    end
   end
 
   describe '#zip_part_suffixes' do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Dashboard Nav Bar' do
         expect(response.body).to match(/S3 Replication Information/)
       end
 
-      it 'renders _endpoint_data template' do
+      it 'renders _replication_endpoint_data template' do
         expect(response).to render_template('dashboard/_replication_endpoint_data')
         expect(response.body).to match(/Endpoint Data/)
         expect(response.body).to match(/ActiveJob class for replication/) # table header


### PR DESCRIPTION
## Why was this change made? 🤔

Lower cognitive load - make the data structure more transparent by giving it a better name and using a hash instead of an array to keep the information, so it is defactor labeled.

Also added a little more explanation to the view:

### After

![image](https://user-images.githubusercontent.com/96775/200443914-2324d68b-02ff-49cf-8762-d962f810f2dd.png)

### Before

![image](https://user-images.githubusercontent.com/96775/200443978-4dc9bbcb-56a9-4d87-9f8c-4aca3f030383.png)

Fixes #2014

## How was this change tested? 🤨

locally and with new spec.

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



