### PR TITLE
refer to a constant in its specific helper class

### DIFF
--- a/spec/helpers/dashboard_audit_helper_spec.rb
+++ b/spec/helpers/dashboard_audit_helper_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe DashboardAuditHelper do
     it 'returns string version of MOAB_LAST_VERSION_AUDIT_THRESHOLD ago' do
       expect(helper.moab_audit_age_threshold).to be_a(String)
       result = DateTime.parse(helper.moab_audit_age_threshold)
-      expect(result).to be <= DateTime.now - DashboardHelper::MOAB_LAST_VERSION_AUDIT_THRESHOLD
+      expect(result).to be <= DateTime.now - DashboardAuditHelper::MOAB_LAST_VERSION_AUDIT_THRESHOLD
     end
   end
 
@@ -217,7 +217,7 @@ RSpec.describe DashboardAuditHelper do
     it 'returns string version of REPLICATION_AUDIT_THRESHOLD ago' do
       expect(helper.replication_audit_age_threshold).to be_a(String)
       result = DateTime.parse(helper.replication_audit_age_threshold)
-      expect(result).to be <= DateTime.now - DashboardHelper::REPLICATION_AUDIT_THRESHOLD
+      expect(result).to be <= DateTime.now - DashboardAuditHelper::REPLICATION_AUDIT_THRESHOLD
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

I bumped into this experimenting with something else.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



