### PR TITLE
dashboard: Replication information display tweak

### DIFF
--- a/app/views/dashboard/_replicated_files.html.erb
+++ b/app/views/dashboard/_replicated_files.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h4>Replication Files</h4>
 
-  <p>Zipped files for an object are split into parts of no more than 10G.</p>
+  <p>ZippedMoabVersion are turned into one or more zip files (ZipParts), each no more than 10G.</p>
 
   <div class="col-sm-6">
     <table class="table table-bordered table-hover">

--- a/app/views/dashboard/_replication_information.html.erb
+++ b/app/views/dashboard/_replication_information.html.erb
@@ -1,19 +1,20 @@
 <h3>S3 Replication Information</h3>
 
-<%= render partial: 'replication_endpoint_data' %>
 <div class="row row-cols-2">
-  <div class="column">
+  <div class="column col-8">
+    <turbo-frame id="replication_endpoint_data">
+      <%= render partial: 'replication_endpoint_data' %>
+    </turbo-frame>
+  </div>
+  <div class="column col-4">
     <turbo-frame id="replicated_files">
       <%= render partial: 'replicated_files' %>
     </turbo-frame>
   </div>
-  <div class="column">
-    <turbo-frame id="zip_parts_suffix_counts">
-      <%= render partial: 'zip_parts_suffix_counts' %>
-    </turbo-frame>
-  </div>
 </div>
-
 <turbo-frame id="replication_flow">
   <%= render partial: 'replication_flow' %>
+</turbo-frame>
+<turbo-frame id="zip_parts_suffix_counts">
+  <%= render partial: 'zip_parts_suffix_counts' %>
 </turbo-frame>


### PR DESCRIPTION
## Why was this change made? 🤔

After looking at prod, this will make a better layout

### After

![image](https://user-images.githubusercontent.com/96775/200764808-da69c83b-1675-4723-aa70-35d15e446993.png)

(zip parts are after Replication Flow table)

### Before

![image](https://user-images.githubusercontent.com/96775/200764760-cbcb3ece-17e8-4797-8d09-872b0bf7f827.png)


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



