### PR TITLE
Refactor: CatalogRemediator slight refactors, ditto S3Audit

### DIFF
--- a/app/services/s3/s3_audit.rb
+++ b/app/services/s3/s3_audit.rb
@@ -3,6 +3,10 @@
 module S3
   # Base class for AWS and IBM audit classes
   class S3Audit
+    def self.check_replicated_zipped_moab_version(zmv, results, check_unreplicated_parts = false)
+      new(zmv, results, check_unreplicated_parts).check_replicated_zipped_moab_version
+    end
+
     delegate :bucket, :bucket_name, to: :s3_provider
 
     attr_reader :zmv, :results, :check_unreplicated_parts
@@ -14,11 +18,6 @@ module S3
       @zmv = zmv
       @results = results
       @check_unreplicated_parts = check_unreplicated_parts
-    end
-
-    # convenience method for instantiating the audit class and running the check in one call
-    def self.check_replicated_zipped_moab_version(zmv, results, check_unreplicated_parts = false)
-      new(zmv, results, check_unreplicated_parts).check_replicated_zipped_moab_version
     end
 
     def check_replicated_zipped_moab_version

--- a/spec/services/catalog_remediator_spec.rb
+++ b/spec/services/catalog_remediator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CatalogRemediator do
       end
 
       before do
-        allow(instance).to receive(:audit_results_for).with(zipped_moab_version_new).and_return(fake_audit_results_no_errors)
+        allow(instance).to receive(:empty_audit_results).with(zipped_moab_version_new).and_return(fake_audit_results_no_errors)
       end
 
       it 'ignores' do
@@ -61,7 +61,7 @@ RSpec.describe CatalogRemediator do
       end
 
       before do
-        allow(instance).to receive(:audit_results_for).with(zipped_moab_version_no_errors).and_return(fake_audit_results_no_errors)
+        allow(instance).to receive(:empty_audit_results).with(zipped_moab_version_no_errors).and_return(fake_audit_results_no_errors)
       end
 
       it 'ignores' do
@@ -75,7 +75,7 @@ RSpec.describe CatalogRemediator do
       end
 
       before do
-        allow(instance).to receive(:audit_results_for).with(zipped_moab_version_no_parts).and_return(fake_audit_results_no_errors)
+        allow(instance).to receive(:empty_audit_results).with(zipped_moab_version_no_parts).and_return(fake_audit_results_no_errors)
       end
 
       it 'includes in audit results' do
@@ -91,7 +91,7 @@ RSpec.describe CatalogRemediator do
       end
 
       before do
-        allow(instance).to receive(:audit_results_for).with(zipped_moab_version_with_errors).and_return(fake_audit_results_with_errors)
+        allow(instance).to receive(:empty_audit_results).with(zipped_moab_version_with_errors).and_return(fake_audit_results_with_errors)
       end
 
       it 'includes in audit results' do


### PR DESCRIPTION
## Why was this change made? 🤔

I was having trouble grokking the code; I believe these changes, largely comments, make it easier.  

CodeClimate is out of its gourd.

Wingnut approves this PR.

![image](https://user-images.githubusercontent.com/96775/201209601-7154716c-e8fc-49a6-ae47-81f6e5d4ac2b.png)


## How was this change tested? 🤨

specs

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



