### PR TITLE
Update docker compose syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Rails application to track, audit and replicate archival artifacts associated wi
 
 ### Installing dependencies
 
-Use `docker-compose` to start supporting services (PostgreSQL and Redis)
+Use `docker compose` to start supporting services (PostgreSQL and Redis)
 ```sh
-docker-compose up -d db redis
+docker compose up -d db redis
 ```
 
 ### Configuring The database (ensure all defined storage roots, cloud endpoints, etc have the necessary DB records)
@@ -345,19 +345,19 @@ A Dockerfile is provided in order to interact with the application in developmen
 Build the docker image:
 
 ```sh
-docker-compose build app
+docker compose build app
 ```
 
 Bring up the docker container and its dependencies:
 
 ```sh
-docker-compose up -d
+docker compose up -d
 ```
 
 Initialize the database:
 
 ```sh
-docker-compose run app bundle exec rails db:reset db:seed
+docker compose run app bundle exec rails db:reset db:seed
 ```
 
 Interact with the application via localhost:

--- a/db/README.md
+++ b/db/README.md
@@ -9,7 +9,7 @@ _Please keep this up to date as the schema changes!_
 To generate the updated ER diagram
 
 - Make sure the `db` container is running, and that the `development` database has all migrations applied (`bin/rails db:create db:migrate`).
-- Run `docker-compose run --rm gen_er_diagram` from the project root.
+- Run `docker compose run --rm gen_er_diagram` from the project root.
 - Commit the updated copy of `db/schema_er_diagram.svg`.
 
 ###### Key:


### PR DESCRIPTION
## Why was this change made? 🤔

One of my tiny PRs to changes `docker-compose` to `docker compose` as I find them...

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



