### PR TITLE
Docs changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,31 +131,7 @@ _Please keep the database README up to date as the schema changes!_
 
 You may also wish to glance at the (much shorter) [Replication README](app/jobs/README.md).
 
-## Rake Tasks
-
-- Note: If the rake task takes multiple arguments, DO NOT put a space in between the commas.
-
-- Rake tasks will have the form:
-
-```sh
-RAILS_ENV=production bundle exec rake ...
-```
-
-## Rails Console
-
-The application's most powerful functionality is available via `rails console`.  To open it (for the appropriate environment):
-
-```sh
-bundle exec rails c -e p
-```
-
-(-e is the environment flag, p is for production)
-
-OR
-
-```sh
-RAILS_ENV=production bundle exec rails console
-```
+Making modifications to the database is usually done either using the Rails console or a Rake task. Some common operations are listed below.
 
 ## Moab to Catalog (M2C) existence/version check
 

--- a/README.md
+++ b/README.md
@@ -100,18 +100,6 @@ curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' http://lo
 }
 ```
 
-### Publish Image
-
-Build image:
-```
-docker build -t suldlss/preservation_catalog:latest .
-```
-
-Publish:
-```
-docker push suldlss/preservation_catalog:latest
-```
-
 ## General Info
 
 - The PostgreSQL database is the catalog of metadata about preserved SDR content, both on premises and in the cloud.  Integrity constraints are used heavily for keeping data clean and consistent.
@@ -132,7 +120,7 @@ docker push suldlss/preservation_catalog:latest
 
 - You can monitor the progress of most tasks by tailing `log/production.log` (or task specific log), checking the Resque dashboard, or by querying the database. The tasks for large storage roots can take a while -- check [the repo wiki for stats](https://github.com/sul-dlss/preservation_catalog/wiki) on the timing of past runs.
 
-- When executing long running queries, audits, remediations, etc from rails console, consider using a [screen session](http://thingsilearned.com/2009/05/26/gnu-screen-super-basic-tutorial/) in case you lose your connection. As an alternative to `screen`, you can also run tasks in the background using `nohup` so the invoked command is not killed when you exist your session. Output that would've gone to stdout is instead redirected to a file called `nohup.out`, or you can redirect the output explicitly.  For example:  `RAILS_ENV=production nohup bundle exec ...`
+- When executing long running queries, audits, remediations, etc from the Rails console, consider using a [screen session](http://thingsilearned.com/2009/05/26/gnu-screen-super-basic-tutorial/) or `nohup` so that the process isn't killed when you log out.
 
 If you are new to developing on this project, you should at least skim [the database README](db/README.md).
 It has a detailed explanation of the data model, some sample queries, and an ER diagram illustrating the


### PR DESCRIPTION
## Why was this change made? 🤔

This commit started with the intention of changing the docs to include
foreman instructions. But in the process I noticed that I ran into some
difficulty running tests when following the instructions, which led to a
wider set of changes.

The key changes are:

- Mention running with `bin/dev` for development since it will take care
  of (optionally) installing foreman and using it. The docs also now
  indicate that the webapp can be run via Docker if you prefer.
- Moving the testing section up into the beginning since that's what
  people most likely will be doing when they come to the app for the
  first time? Previously information on how to get up and running to
  develop was fragmented, and easy (for me) to miss.
- Removed the table of contents, mostly because not everything was
  linked up and GitHub  [supports](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/)  generating a table of contents 
  when you need one.

Closes #2031

## How was this change tested? 🤨

n/a

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



