### PR TITLE
Increase zip cache expiration to 2 weeks.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,7 +22,7 @@ workflow_services_url: 'https://workflows.example.org/workflow/'
 
 checksum_algos: ['md5'] # 'sha1' 'sha256'
 
-zip_cache_expiry_time: '+10080' # this is UNIX `find` speak for "greater than seven days"
+zip_cache_expiry_time: '+20160' # this is UNIX `find` speak for "greater than 14 days"
 zip_storage: '/tmp' # override in #{RAILS_ENV}.yml
 
 resque_dashboard_hostnames: # tells the router where to mount the resque dashboard


### PR DESCRIPTION
closes #2020

## Why was this change made? 🤔
Make replication retries easier.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



