### PR TITLE
Update filesystem_delay_seconds comments.

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -22,11 +22,7 @@ class ApplicationJob < ActiveJob::Base
     end
   end
 
-  # sleep for a configured amount of time.
-  #
-  # BUT WHY? to prevent duplication and possible explanation drift, see Robots::SdrRepo::PreservationIngest::UpdateCatalog#wait_as_needed
-  # for more detailed explanation.  the short version is, this helps alleviate Ceph MDS write/read sync and/or contention issues that
-  # we don't yet fully understand.
+  # sleep to allow for file system sync latency.
   def wait_as_needed
     sleep(Settings.filesystem_delay_seconds)
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,8 +45,7 @@ minimum_subfolder_count: 1 # for okcomputer pres-cat mount check, verifies the s
 api_jwt:
   hmac_secret: 'my$ecretK3y'
 
-# we expect/hope that this will not stay around forever.  see usage for further explanation.
-filesystem_delay_seconds: 0.05 # the default value is artificially low to keep test suite fast -- should override to be many seconds in prod
+filesystem_delay_seconds: 0.05 # the default value is artificially low to keep test suite fast
 
 rabbitmq:
   hostname: localhost


### PR DESCRIPTION
closes #2047

## Why was this change made? 🤔
Keep comments useful.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



