### PR TITLE
QA: update cap deploy config to use load balanced web hosts

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-server 'preservation-catalog-qa-01.stanford.edu', user: 'pres', roles: %w[app db web]
-server 'preservation-catalog-qa-02.stanford.edu', user: 'pres', roles: %w[app resque queue_populator cache_cleaner]
+server 'preservation-catalog-web-qa-01.stanford.edu', user: 'pres', roles: %w[app web]
+server 'preservation-catalog-web-qa-02.stanford.edu', user: 'pres', roles: %w[app web]
+server 'preservation-catalog-qa-02.stanford.edu', user: 'pres', roles: %w[app db resque queue_populator cache_cleaner]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'


### PR DESCRIPTION
## Why was this change made? 🤔

finish off dropped part of OS migration and load balancing from this summer

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_preassembly_image_spec.rb) on stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



