### PR TITLE
Rename MoabStorageRootReporter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,7 +46,7 @@ Metrics/AbcSize:
     - 'app/services/checksum_validator.rb'
     - 'app/services/complete_moab_service/check_existence.rb'
     - 'app/services/complete_moab_service/update_version.rb'
-    - 'app/services/moab_storage_root_reporter.rb'
+    - 'app/services/moab_storage_root_report_service.rb'
     - 'app/services/s3/s3_audit.rb'
     - 'config/initializers/okcomputer.rb'
 
@@ -68,7 +68,7 @@ Metrics/MethodLength:
 # AllowedIdentifiers: capture3, iso8601, rfc1123_date, rfc822, rfc2822, rfc3339
 Naming/VariableNumber:
   Exclude:
-    - 'spec/services/moab_storage_root_reporter_spec.rb'
+    - 'spec/services/moab_storage_root_report_service_spec.rb'
 
 # Offense count: 1
 RSpec/BeforeAfterAll:

--- a/app/services/moab_storage_root_report_service.rb
+++ b/app/services/moab_storage_root_report_service.rb
@@ -5,11 +5,10 @@ require 'csv'
 ##
 # run queries and produce reports from the results, for consumption
 # by preservation catalog maintainers
-class MoabStorageRootReporter
+class MoabStorageRootReportService
   attr_reader :storage_root
 
-  # @params [Hash] params used to initialize the MoabStorageRootReporter service
-  # @return [MoabStorageRootReporter] the reporter
+  # @params [Hash] params used to initialize the MoabStorageRootReport service
   def initialize(params)
     @storage_root = MoabStorageRoot.find_by!(name: params[:storage_root_name])
     @msr_names = {}

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -48,14 +48,14 @@ namespace :prescat do
   namespace :reports do
     desc 'query for druids on storage root & dump to CSV (2nd & 3rd arg optional)'
     task :msr_druids, [:storage_root_name, :report_tag, :csv_filename] => [:environment] do |_task, args|
-      reporter = MoabStorageRootReporter.new(storage_root_name: args[:storage_root_name])
+      reporter = MoabStorageRootReportService.new(storage_root_name: args[:storage_root_name])
       csv_loc = reporter.write_to_csv(reporter.druid_csv_list, report_type: 'druids', report_tag: args[:report_tag], filename: args[:csv_filename])
       puts "druids for #{args[:storage_root_name]} written to #{csv_loc}"
     end
 
     desc 'query for druids on storage root & dump details to CSV (2nd & 3rd arg optional)'
     task :msr_moab_status_details, [:storage_root_name, :report_tag, :csv_filename] => [:environment] do |_task, args|
-      reporter = MoabStorageRootReporter.new(storage_root_name: args[:storage_root_name])
+      reporter = MoabStorageRootReportService.new(storage_root_name: args[:storage_root_name])
       data = reporter.moab_detail_csv_list
       csv_loc = reporter.write_to_csv(data, report_type: 'moab_status_details', report_tag: args[:report_tag], filename: args[:csv_filename])
       puts "druid details for #{args[:storage_root_name]} written to #{csv_loc}"
@@ -63,7 +63,7 @@ namespace :prescat do
 
     desc 'query for druids on storage root & dump audit error details to CSV (2nd & 3rd arg optional)'
     task :msr_moab_audit_errors, [:storage_root_name, :report_tag, :csv_filename] => [:environment] do |_task, args|
-      reporter = MoabStorageRootReporter.new(storage_root_name: args[:storage_root_name])
+      reporter = MoabStorageRootReportService.new(storage_root_name: args[:storage_root_name])
       data = reporter.moab_detail_csv_list(errors_only: true)
       csv_loc = reporter.write_to_csv(data, report_type: 'moab_audit_errors', report_tag: args[:report_tag], filename: args[:csv_filename])
       puts "druids with errors details for #{args[:storage_root_name]} written to #{csv_loc}"

--- a/spec/services/moab_storage_root_report_service_spec.rb
+++ b/spec/services/moab_storage_root_report_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe MoabStorageRootReporter do
+RSpec.describe MoabStorageRootReportService do
   let!(:test_start_time) { DateTime.now.utc.iso8601 } # useful for both output cleanup and CSV filename testing
 
   let!(:msr_a) { create(:moab_storage_root) }


### PR DESCRIPTION
## Why was this change made? 🤔
Reduce confusion by only using "reporters" in one way -- see the reporters module.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



