### PR TITLE
Refactor catalog to moab

### DIFF
--- a/app/services/audit/catalog_to_moab.rb
+++ b/app/services/audit/catalog_to_moab.rb
@@ -1,45 +1,33 @@
 # frozen_string_literal: true
 
 module Audit
-  # Catalog to Moab existence check code
+  # Service for checking versions, validating moab on storage, and updating catalog.
   class CatalogToMoab
-    attr_reader :complete_moab, :druid, :logger
+    attr_reader :complete_moab, :logger
 
     def initialize(complete_moab)
       @complete_moab = complete_moab
-      @druid = complete_moab.preserved_object.druid
       @logger = Logger.new(Rails.root.join('log', 'c2m.log'))
     end
 
-    # shameless green implementation
+    # Check the catalog version (complete moab version) against versions of the preserved object and the moab on storage,
+    # possibly validate the moab on storage, and possibly update the complete moab.
     def check_catalog_version
-      unless complete_moab.matches_po_current_version?
-        results.add_result(AuditResults::CM_PO_VERSION_MISMATCH,
-                           cm_version: complete_moab.version,
-                           po_version: complete_moab.preserved_object.current_version)
-        return report_results!
-      end
+      return report_results! unless check_preserved_object_and_complete_moab_versions_match
 
-      if moab_on_storage.nil?
-        transaction_ok = ActiveRecordUtils.with_transaction_and_rescue(results) do
-          status_handler.update_status('online_moab_not_found')
-          complete_moab.save!
-        end
-        results.remove_db_updated_results unless transaction_ok
+      return report_results! unless check_for_moab_on_storage
 
-        results.add_result(AuditResults::MOAB_NOT_FOUND,
-                           db_created_at: complete_moab.created_at.iso8601,
-                           db_updated_at: complete_moab.updated_at.iso8601)
-        return report_results!
-      end
-
+      # Complete moab status is not currently 'invalid_checksum'
       return report_results! unless moab_on_storage_validator.can_validate_current_comp_moab_status?(complete_moab: complete_moab)
 
-      compare_version_and_take_action
-    end
+      # An expected outcome if nothing changes on storage.
+      return report_versions_match if complete_moab.version == moab_on_storage_version
 
-    def moab_on_storage
-      @moab_on_storage ||= MoabOnStorage.moab(druid: druid, storage_location: storage_location)
+      # An expected outcome if new version added to storage. Validate and update the complete moab version.
+      return validate_moab_on_storage_and_report_results if complete_moab.version < moab_on_storage_version
+
+      # An error when complete_moab.version > moab_on_storage_version
+      report_complete_moab_greater_than_moab_on_storage_version
     end
 
     def results
@@ -48,6 +36,36 @@ module Audit
     end
 
     private
+
+    def druid
+      @druid ||= complete_moab.preserved_object.druid
+    end
+
+    def check_preserved_object_and_complete_moab_versions_match
+      return true if complete_moab.matches_po_current_version?
+
+      results.add_result(AuditResults::CM_PO_VERSION_MISMATCH,
+                         cm_version: complete_moab.version,
+                         po_version: complete_moab.preserved_object.current_version)
+      false
+    end
+
+    def check_for_moab_on_storage
+      return true if moab_on_storage.present?
+
+      persist_db_transaction!(update_audit_timestamps: false) do
+        status_handler.update_complete_moab_status('online_moab_not_found')
+      end
+
+      results.add_result(AuditResults::MOAB_NOT_FOUND,
+                         db_created_at: complete_moab.created_at.iso8601,
+                         db_updated_at: complete_moab.updated_at.iso8601)
+      false
+    end
+
+    def moab_on_storage
+      @moab_on_storage ||= MoabOnStorage.moab(druid: druid, storage_location: storage_location)
+    end
 
     def report_results!
       AuditResultsReporter.report_results(audit_results: results, logger: @logger)
@@ -65,32 +83,46 @@ module Audit
       complete_moab.moab_storage_root.storage_location
     end
 
-    # compare the catalog version to the actual Moab on storage;  update the catalog version if the Moab is newer
-    #   report results (and return them)
-    def compare_version_and_take_action
-      moab_version = moab_on_storage.current_version_id
-      catalog_version = complete_moab.version
-      transaction_ok = ActiveRecordUtils.with_transaction_and_rescue(results) do
-        if catalog_version == moab_version
-          unless complete_moab.ok?
-            status_handler.set_status_as_seen_on_disk(found_expected_version: true,
-                                                      moab_on_storage_validator: moab_on_storage_validator)
-          end
-          results.add_result(AuditResults::VERSION_MATCHES, 'CompleteMoab')
-          report_results!
-        elsif catalog_version < moab_version
-          status_handler.set_status_as_seen_on_disk(found_expected_version: true, moab_on_storage_validator: moab_on_storage_validator)
-          CompleteMoabService::UpdateVersionAfterValidation.execute(druid: druid, incoming_version: moab_version, incoming_size: moab_on_storage.size,
-                                                                    moab_storage_root: complete_moab.moab_storage_root)
-        else # catalog_version > moab_version
-          status_handler.set_status_as_seen_on_disk(found_expected_version: false, moab_on_storage_validator: moab_on_storage_validator)
-          results.add_result(
-            AuditResults::UNEXPECTED_VERSION, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version
-          )
-          report_results!
-        end
+    def moab_on_storage_version
+      moab_on_storage.current_version_id
+    end
 
-        complete_moab.update_audit_timestamps(moab_on_storage_validator.ran_moab_validation?, true)
+    def report_versions_match
+      persist_db_transaction! do
+        unless complete_moab.ok? # if status != 'ok'
+          status_handler.validate_moab_on_storage_and_set_status(found_expected_version: true,
+                                                                 moab_on_storage_validator: moab_on_storage_validator)
+        end
+        results.add_result(AuditResults::VERSION_MATCHES, 'CompleteMoab')
+        report_results!
+      end
+    end
+
+    def validate_moab_on_storage_and_report_results
+      persist_db_transaction! do
+        status_handler.validate_moab_on_storage_and_set_status(found_expected_version: true, moab_on_storage_validator: moab_on_storage_validator)
+        # Update the complete moab's version to match the version on storage.
+        CompleteMoabService::UpdateVersionAfterValidation.execute(druid: druid, incoming_version: moab_on_storage_version,
+                                                                  incoming_size: moab_on_storage.size,
+                                                                  moab_storage_root: complete_moab.moab_storage_root)
+      end
+    end
+
+    def report_complete_moab_greater_than_moab_on_storage_version
+      persist_db_transaction! do
+        status_handler.validate_moab_on_storage_and_set_status(found_expected_version: false, moab_on_storage_validator: moab_on_storage_validator)
+        results.add_result(
+          AuditResults::UNEXPECTED_VERSION, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version
+        )
+        report_results!
+      end
+    end
+
+    def persist_db_transaction!(update_audit_timestamps: true)
+      transaction_ok = ActiveRecordUtils.with_transaction_and_rescue(results) do
+        yield if block_given?
+
+        complete_moab.update_audit_timestamps(moab_on_storage_validator.ran_moab_validation?, true) if update_audit_timestamps
         complete_moab.save!
       end
       results.remove_db_updated_results unless transaction_ok

--- a/app/services/complete_moab_service/check_existence.rb
+++ b/app/services/complete_moab_service/check_existence.rb
@@ -26,7 +26,7 @@ module CompleteMoabService
 
     def update_complete_moab_preserved_object_or_set_status
       if validation_errors?
-        status_handler.update_status('invalid_moab')
+        status_handler.update_complete_moab_status('invalid_moab')
       else
         complete_moab.upd_audstamps_version_size(moab_on_storage_validator.ran_moab_validation?, incoming_version, incoming_size)
         preserved_object.current_version = incoming_version
@@ -44,19 +44,19 @@ module CompleteMoabService
 
         if incoming_version == complete_moab.version
           unless complete_moab.status == 'ok'
-            status_handler.set_status_as_seen_on_disk(found_expected_version: true,
-                                                      moab_on_storage_validator: moab_on_storage_validator)
+            status_handler.validate_moab_on_storage_and_set_status(found_expected_version: true,
+                                                                   moab_on_storage_validator: moab_on_storage_validator)
           end
           results.add_result(AuditResults::VERSION_MATCHES, 'CompleteMoab')
         elsif incoming_version > complete_moab.version
           unless complete_moab.status == 'ok'
-            status_handler.set_status_as_seen_on_disk(found_expected_version: true,
-                                                      moab_on_storage_validator: moab_on_storage_validator)
+            status_handler.validate_moab_on_storage_and_set_status(found_expected_version: true,
+                                                                   moab_on_storage_validator: moab_on_storage_validator)
           end
           results.add_result(AuditResults::ACTUAL_VERS_GT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
           update_complete_moab_preserved_object_or_set_status
         else # incoming_version < complete_moab.version
-          status_handler.set_status_as_seen_on_disk(found_expected_version: false, moab_on_storage_validator: moab_on_storage_validator)
+          status_handler.validate_moab_on_storage_and_set_status(found_expected_version: false, moab_on_storage_validator: moab_on_storage_validator)
           results.add_result(AuditResults::ACTUAL_VERS_LT_DB_OBJ, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
         end
         complete_moab.update_audit_timestamps(moab_on_storage_validator.ran_moab_validation?, true)

--- a/app/services/complete_moab_service/update_version.rb
+++ b/app/services/complete_moab_service/update_version.rb
@@ -44,7 +44,7 @@ module CompleteMoabService
 
       complete_moab.upd_audstamps_version_size(moab_on_storage_validator.ran_moab_validation?, incoming_version, incoming_size)
       complete_moab.last_checksum_validation = Time.current if checksums_validated && complete_moab.last_checksum_validation
-      status_handler.update_status(status) if status
+      status_handler.update_complete_moab_status(status) if status
       complete_moab.save!
 
       preserved_object.current_version = incoming_version
@@ -55,7 +55,7 @@ module CompleteMoabService
       results.add_result(AuditResults::UNEXPECTED_VERSION, db_obj_name: 'CompleteMoab', db_obj_version: complete_moab.version)
       version_comparison_results
 
-      status_handler.update_status(status) if status
+      status_handler.update_complete_moab_status(status) if status
       complete_moab.update_audit_timestamps(moab_on_storage_validator.ran_moab_validation?, true)
       complete_moab.save!
     end

--- a/app/services/complete_moab_service/update_version_after_validation.rb
+++ b/app/services/complete_moab_service/update_version_after_validation.rb
@@ -54,7 +54,7 @@ module CompleteMoabService
 
     def update_complete_moab_to_validity_unknown
       with_active_record_transaction_and_rescue do
-        status_handler.update_status('validity_unknown')
+        status_handler.update_complete_moab_status('validity_unknown')
         complete_moab.update_audit_timestamps(moab_on_storage_validator.ran_moab_validation?, false)
         complete_moab.save!
       end
@@ -62,7 +62,7 @@ module CompleteMoabService
 
     def update_complete_moab_to_invalid_moab
       with_active_record_transaction_and_rescue do
-        status_handler.update_status('invalid_moab')
+        status_handler.update_complete_moab_status('invalid_moab')
         complete_moab.update_audit_timestamps(moab_on_storage_validator.ran_moab_validation?, false)
         complete_moab.save!
       end

--- a/spec/services/audit/catalog_to_moab_spec.rb
+++ b/spec/services/audit/catalog_to_moab_spec.rb
@@ -588,7 +588,7 @@ RSpec.describe Audit::CatalogToMoab do
 
     context 'moab found on disk' do
       # use the same setup as 'catalog version > moab version', since we know that should
-      # lead to an update_status('unexpected_version_on_storage') call
+      # lead to an update_complete_moab_status('unexpected_version_on_storage') call
       before do
         moab = instance_double(Moab::StorageObject, size: 666, object_pathname: object_dir)
         allow(Moab::StorageObject).to receive(:new).with(druid, instance_of(String)).and_return(moab)


### PR DESCRIPTION
## Why was this change made? 🤔
Readability


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



