### PR TITLE
Remove replicatable_status.

### DIFF
--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -62,11 +62,6 @@ class CompleteMoab < ApplicationRecord
     ChecksumValidationJob.perform_later(self)
   end
 
-  # TODO: may become obsolete
-  def replicatable_status?
-    ok?
-  end
-
   def update_audit_timestamps(moab_validated, version_audited)
     t = Time.current
     self.last_moab_validation = t if moab_validated

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -51,17 +51,6 @@ RSpec.describe CompleteMoab do
     end
   end
 
-  describe '#replicatable_status?' do
-    it 'reponds true IFF status should allow replication' do
-      # validity_unknown initial status implicitly tested (otherwise assignment wouldn't change the reponse)
-      expect { cm.status = 'ok'                            }.to change(cm, :replicatable_status?).to(true)
-      expect { cm.status = 'invalid_checksum'              }.to change(cm, :replicatable_status?).to(false)
-      expect { cm.status = 'invalid_moab'                  }.not_to change(cm, :replicatable_status?).from(false)
-      expect { cm.status = 'online_moab_not_found'         }.not_to change(cm, :replicatable_status?).from(false)
-      expect { cm.status = 'unexpected_version_on_storage' }.not_to change(cm, :replicatable_status?).from(false)
-    end
-  end
-
   it { is_expected.to belong_to(:moab_storage_root) }
   it { is_expected.to belong_to(:preserved_object) }
   it { is_expected.to have_db_index(:last_version_audit) }


### PR DESCRIPTION
## Why was this change made? 🤔
Unused.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



