### PR TITLE
Renames CompleteMoab.least_recent_version_audit.

### DIFF
--- a/app/helpers/dashboard_audit_helper.rb
+++ b/app/helpers/dashboard_audit_helper.rb
@@ -41,7 +41,7 @@ module DashboardAuditHelper
   end
 
   def num_moab_audits_older_than_threshold
-    CompleteMoab.least_recent_version_audit(moab_audit_age_threshold).count
+    CompleteMoab.version_audit_expired(moab_audit_age_threshold).count
   end
 
   def moab_audits_older_than_threshold?

--- a/app/models/complete_moab.rb
+++ b/app/models/complete_moab.rb
@@ -40,8 +40,8 @@ class CompleteMoab < ApplicationRecord
     joins(:moab_storage_root).where(moab_storage_root: moab_storage_root)
   }
 
-  scope :least_recent_version_audit, lambda { |last_checked_b4_date|
-    where('last_version_audit IS NULL or last_version_audit < ?', normalize_date(last_checked_b4_date))
+  scope :version_audit_expired, lambda { |expired_date|
+    where('last_version_audit IS NULL or last_version_audit < ?', normalize_date(expired_date))
   }
 
   scope :fixity_check_expired, lambda {

--- a/app/models/moab_storage_root.rb
+++ b/app/models/moab_storage_root.rb
@@ -24,7 +24,7 @@ class MoabStorageRoot < ApplicationRecord
 
   # Use a queue to check all associated CompleteMoab objects for C2M
   def c2m_check!(last_checked_b4_date = Time.current)
-    complete_moabs.least_recent_version_audit(last_checked_b4_date).find_each do |cm|
+    complete_moabs.version_audit_expired(last_checked_b4_date).find_each do |cm|
       CatalogToMoabJob.perform_later(cm)
     end
   end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -135,7 +135,7 @@ end
 # check CompleteMoab#last_version_audit to ensure it isn't too old
 class VersionAuditWindowCheck < OkComputer::Check
   def check
-    if CompleteMoab.least_recent_version_audit(clause).first
+    if CompleteMoab.version_audit_expired(clause).first
       mark_message "CompleteMoab#last_version_audit older than #{clause}. "
       mark_failure
     else

--- a/spec/config/okcomputer_spec.rb
+++ b/spec/config/okcomputer_spec.rb
@@ -19,7 +19,7 @@ describe 'OkComputer custom checks' do # rubocop:disable RSpec/DescribeClass
     it { is_expected.to be_successful }
 
     context 'with old data' do
-      before { allow(CompleteMoab).to receive(:least_recent_version_audit).with(any_args).and_return([double]) }
+      before { allow(CompleteMoab).to receive(:version_audit_expired).with(any_args).and_return([double]) }
 
       it { is_expected.not_to be_successful }
     end

--- a/spec/models/complete_moab_spec.rb
+++ b/spec/models/complete_moab_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe CompleteMoab do
     end
   end
 
-  context 'ordered (by last version_audited) and unordered least_recent_version_audit' do
+  context 'ordered (by last version_audited) and unordered version_audit_expired' do
     let!(:newer_timestamp_cm) do
       create(:complete_moab, args.merge(version: 6, last_version_audit: (now - 1.day), preserved_object: create(:preserved_object)))
     end
@@ -183,26 +183,26 @@ RSpec.describe CompleteMoab do
       create(:complete_moab, args.merge(version: 8, last_version_audit: (now + 1.day), preserved_object: create(:preserved_object)))
     end
 
-    describe '.least_recent_version_audit' do
+    describe '.version_audit_expired' do
       it 'returns CompleteMoabs with nils and CompleteMoabs < given date (not orded by last_version_audit)' do
-        expect(described_class.least_recent_version_audit(now).sort).to eq [cm, newer_timestamp_cm, older_timestamp_cm]
+        expect(described_class.version_audit_expired(now).sort).to eq [cm, newer_timestamp_cm, older_timestamp_cm]
       end
 
       it 'returns no CompleteMoabs with future timestamps' do
-        expect(described_class.least_recent_version_audit(now)).not_to include future_timestamp_cm
+        expect(described_class.version_audit_expired(now)).not_to include future_timestamp_cm
       end
     end
 
     describe '.order_last_version_audit' do
-      let(:least_recent_version) { described_class.least_recent_version_audit(now) }
+      let(:version_audit_expired) { described_class.version_audit_expired(now) }
 
       it 'returns CompleteMoabs with nils first, then old to new timestamps' do
-        expect(described_class.order_last_version_audit(least_recent_version))
+        expect(described_class.order_last_version_audit(version_audit_expired))
           .to eq [cm, older_timestamp_cm, newer_timestamp_cm]
       end
 
       it 'returns no CompleteMoabs with future timestamps' do
-        expect(described_class.order_last_version_audit(least_recent_version))
+        expect(described_class.order_last_version_audit(version_audit_expired))
           .not_to include future_timestamp_cm
       end
     end


### PR DESCRIPTION
closes #2067

## Why was this change made? 🤔
To make things not confusing.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



