### PR TITLE
dashboard service classes become modules

### DIFF
--- a/app/components/dashboard/audit_information_component.rb
+++ b/app/components/dashboard/audit_information_component.rb
@@ -3,28 +3,8 @@
 module Dashboard
   # methods for dashboard pertaining to AuditInformationComponent
   class AuditInformationComponent < ViewComponent::Base
-    attr_reader :dashboard_audit_service, :dashboard_catalog_service, :dashboard_replication_service
-
-    delegate :moab_audit_age_threshold,
-             :num_moab_audits_older_than_threshold,
-             :moab_audits_older_than_threshold?,
-             :replication_audit_age_threshold,
-             :num_replication_audits_older_than_threshold,
-             :replication_audits_older_than_threshold?,
-             to: :dashboard_audit_service
-
-    delegate :num_complete_moab_not_ok,
-             :any_complete_moab_errors?,
-             :num_expired_checksum_validation,
-             to: :dashboard_catalog_service
-
-    delegate :num_replication_errors, to: :dashboard_replication_service
-
-    def initialize
-      @dashboard_audit_service = Dashboard::AuditService.new
-      @dashboard_catalog_service = Dashboard::CatalogService.new
-      @dashboard_replication_service = Dashboard::ReplicationService.new
-      super
-    end
+    include Dashboard::AuditService
+    include Dashboard::CatalogService
+    include Dashboard::ReplicationService
   end
 end

--- a/app/components/dashboard/complete_moabs_component.rb
+++ b/app/components/dashboard/complete_moabs_component.rb
@@ -3,19 +3,6 @@
 module Dashboard
   # methods for dashboard pertaining to CompleteMoabsComponent
   class CompleteMoabsComponent < ViewComponent::Base
-    attr_reader :dashboard_catalog_service
-
-    delegate :status_labels,
-             :num_preserved_objects,
-             :complete_moab_total_size,
-             :complete_moab_average_size,
-             :complete_moab_status_counts,
-             :num_expired_checksum_validation,
-             to: :dashboard_catalog_service
-
-    def initialize
-      @dashboard_catalog_service = Dashboard::CatalogService.new
-      super
-    end
+    include Dashboard::CatalogService
   end
 end

--- a/app/components/dashboard/moab_storage_roots_component.rb
+++ b/app/components/dashboard/moab_storage_roots_component.rb
@@ -3,19 +3,6 @@
 module Dashboard
   # methods for dashboard pertaining to MoabStorageRootsComponent
   class MoabStorageRootsComponent < ViewComponent::Base
-    attr_reader :dashboard_catalog_service
-
-    delegate :status_labels,
-             :storage_root_info,
-             :storage_root_totals,
-             :storage_root_total_count,
-             :storage_root_total_ok_count,
-             :num_complete_moabs,
-             to: :dashboard_catalog_service
-
-    def initialize
-      @dashboard_catalog_service = Dashboard::CatalogService.new
-      super
-    end
+    include Dashboard::CatalogService
   end
 end

--- a/app/components/dashboard/object_versions_component.rb
+++ b/app/components/dashboard/object_versions_component.rb
@@ -3,21 +3,6 @@
 module Dashboard
   # methods for dashboard pertaining to ObjectVersionsComponent
   class ObjectVersionsComponent < ViewComponent::Base
-    attr_reader :dashboard_catalog_service
-
-    delegate :num_preserved_objects,
-             :num_object_versions_per_preserved_object,
-             :preserved_object_highest_version,
-             :average_version_per_preserved_object,
-             :num_complete_moabs,
-             :num_object_versions_per_complete_moab,
-             :complete_moab_highest_version,
-             :average_version_per_complete_moab,
-             to: :dashboard_catalog_service
-
-    def initialize
-      @dashboard_catalog_service = Dashboard::CatalogService.new
-      super
-    end
+    include Dashboard::CatalogService
   end
 end

--- a/app/components/dashboard/replication_endpoints_component.rb
+++ b/app/components/dashboard/replication_endpoints_component.rb
@@ -3,16 +3,7 @@
 module Dashboard
   # methods for dashboard pertaining to ReplicationEndpointsComponent
   class ReplicationEndpointsComponent < ViewComponent::Base
-    attr_reader :dashboard_replication_service, :dashboard_catalog_service
-
-    delegate :endpoint_data, to: :dashboard_replication_service
-
-    delegate :num_object_versions_per_preserved_object, to: :dashboard_catalog_service
-
-    def initialize
-      @dashboard_replication_service = Dashboard::ReplicationService.new
-      @dashboard_catalog_service = Dashboard::CatalogService.new
-      super
-    end
+    include Dashboard::CatalogService
+    include Dashboard::ReplicationService
   end
 end

--- a/app/components/dashboard/replication_files_component.rb
+++ b/app/components/dashboard/replication_files_component.rb
@@ -3,13 +3,6 @@
 module Dashboard
   # methods for dashboard pertaining to ReplicationFilesComponent
   class ReplicationFilesComponent < ViewComponent::Base
-    attr_reader :dashboard_replication_service
-
-    delegate :zip_parts_total_size, to: :dashboard_replication_service
-
-    def initialize
-      @dashboard_replication_service = Dashboard::ReplicationService.new
-      super
-    end
+    include Dashboard::ReplicationService
   end
 end

--- a/app/components/dashboard/zip_parts_suffixes_component.rb
+++ b/app/components/dashboard/zip_parts_suffixes_component.rb
@@ -3,13 +3,6 @@
 module Dashboard
   # methods for dashboard pertaining to ZipPartsSuffixesComponent
   class ZipPartsSuffixesComponent < ViewComponent::Base
-    attr_reader :dashboard_replication_service
-
-    delegate :zip_part_suffixes, to: :dashboard_replication_service
-
-    def initialize
-      @dashboard_replication_service = Dashboard::ReplicationService.new
-      super
-    end
+    include Dashboard::ReplicationService
   end
 end

--- a/app/services/dashboard/audit_service.rb
+++ b/app/services/dashboard/audit_service.rb
@@ -3,7 +3,9 @@
 # services for dashboard
 module Dashboard
   # methods pertaining to audit functionality for dashboard
-  class AuditService
+  module AuditService
+    include CatalogService
+
     # CompleteMoab.last_version_audit is the most recent of 3 separate audits:
     #   moab_to_catalog - all CompleteMoabs are queued for this on the 1st of the month
     #   catalog_to_moab - all CompleteMoabs are queued for this on the 15th of the month
@@ -34,7 +36,7 @@ module Dashboard
     def moab_to_catalog_audit_ok?
       # NOTE: unsure if there needs to be more checking of CompleteMoab.status_details for more statuses to figure this out
       # I believe if there's a moab that's not in the catalog, it is added by this audit.
-      !CatalogService.new.any_complete_moab_errors?
+      !any_complete_moab_errors?
     end
 
     def checksum_validation_audit_ok?

--- a/app/services/dashboard/catalog_service.rb
+++ b/app/services/dashboard/catalog_service.rb
@@ -5,7 +5,7 @@ require 'action_view' # for number_to_human_size
 # services for dashboard
 module Dashboard
   # methods pertaining to catalog functionality for dashboard
-  class CatalogService
+  module CatalogService
     include ActionView::Helpers::NumberHelper # for number_to_human_size
 
     def catalog_ok?

--- a/app/services/dashboard/replication_service.rb
+++ b/app/services/dashboard/replication_service.rb
@@ -5,12 +5,13 @@ require 'action_view' # for number_to_human_size
 # services for dashboard
 module Dashboard
   # methods pertaining to replication functionality for dashboard
-  class ReplicationService
+  module ReplicationService
     include ActionView::Helpers::NumberHelper # for number_to_human_size
+    include CatalogService
 
     def replication_ok?
       endpoint_data.each do |_endpoint_name, info|
-        return false if info[:replication_count] != CatalogService.new.num_object_versions_per_preserved_object
+        return false if info[:replication_count] != num_object_versions_per_preserved_object
       end
       true
     end

--- a/spec/services/dashboard/audit_service_spec.rb
+++ b/spec/services/dashboard/audit_service_spec.rb
@@ -4,6 +4,11 @@ require 'rails_helper'
 
 RSpec.describe Dashboard::AuditService do
   let(:storage_root) { create(:moab_storage_root) }
+  let(:outer_class) do
+    Class.new do
+      include Dashboard::AuditService
+    end
+  end
 
   describe '#validate_moab_audit_ok?' do
     context 'when there are CompleteMoabs with invalid_moab status' do
@@ -14,7 +19,7 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'returns false' do
-        expect(described_class.new.validate_moab_audit_ok?).to be false
+        expect(outer_class.new.validate_moab_audit_ok?).to be false
       end
     end
 
@@ -26,7 +31,7 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'returns false' do
-        expect(described_class.new.validate_moab_audit_ok?).to be false
+        expect(outer_class.new.validate_moab_audit_ok?).to be false
       end
     end
 
@@ -38,7 +43,7 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'returns true' do
-        expect(described_class.new.validate_moab_audit_ok?).to be true
+        expect(outer_class.new.validate_moab_audit_ok?).to be true
       end
     end
   end
@@ -52,7 +57,7 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'returns false' do
-        expect(described_class.new.catalog_to_moab_audit_ok?).to be false
+        expect(outer_class.new.catalog_to_moab_audit_ok?).to be false
       end
     end
 
@@ -64,7 +69,7 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'returns false' do
-        expect(described_class.new.catalog_to_moab_audit_ok?).to be false
+        expect(outer_class.new.catalog_to_moab_audit_ok?).to be false
       end
     end
 
@@ -76,7 +81,7 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'returns true' do
-        expect(described_class.new.catalog_to_moab_audit_ok?).to be true
+        expect(outer_class.new.catalog_to_moab_audit_ok?).to be true
       end
     end
   end
@@ -93,13 +98,13 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'returns false' do
-        expect(described_class.new.moab_to_catalog_audit_ok?).to be false
+        expect(outer_class.new.moab_to_catalog_audit_ok?).to be false
       end
     end
 
     context 'when all CompleteMoabs have status ok' do
       it 'returns true' do
-        expect(described_class.new.moab_to_catalog_audit_ok?).to be true
+        expect(outer_class.new.moab_to_catalog_audit_ok?).to be true
       end
     end
   end
@@ -113,7 +118,7 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'returns false' do
-        expect(described_class.new.checksum_validation_audit_ok?).to be false
+        expect(outer_class.new.checksum_validation_audit_ok?).to be false
       end
     end
 
@@ -125,7 +130,7 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'returns true' do
-        expect(described_class.new.checksum_validation_audit_ok?).to be true
+        expect(outer_class.new.checksum_validation_audit_ok?).to be true
       end
     end
   end
@@ -138,7 +143,7 @@ RSpec.describe Dashboard::AuditService do
 
     context 'when all ZipParts have ok status' do
       it 'is true' do
-        expect(described_class.new.catalog_to_archive_audit_ok?).to be true
+        expect(outer_class.new.catalog_to_archive_audit_ok?).to be true
       end
     end
 
@@ -148,15 +153,15 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'is false' do
-        expect(described_class.new.catalog_to_archive_audit_ok?).to be false
+        expect(outer_class.new.catalog_to_archive_audit_ok?).to be false
       end
     end
   end
 
   describe '#moab_audit_age_threshold' do
     it 'returns string version of MOAB_LAST_VERSION_AUDIT_THRESHOLD ago' do
-      expect(described_class.new.moab_audit_age_threshold).to be_a(String)
-      result = DateTime.parse(described_class.new.moab_audit_age_threshold)
+      expect(outer_class.new.moab_audit_age_threshold).to be_a(String)
+      result = DateTime.parse(outer_class.new.moab_audit_age_threshold)
       expect(result).to be <= DateTime.now - described_class::MOAB_LAST_VERSION_AUDIT_THRESHOLD
     end
   end
@@ -171,14 +176,14 @@ RSpec.describe Dashboard::AuditService do
 
     describe '#num_moab_audits_older_than_threshold' do
       it 'returns a number greater than 0' do
-        expect(described_class.new.num_moab_audits_older_than_threshold).to be > 0
-        expect(described_class.new.num_moab_audits_older_than_threshold).to eq 2
+        expect(outer_class.new.num_moab_audits_older_than_threshold).to be > 0
+        expect(outer_class.new.num_moab_audits_older_than_threshold).to eq 2
       end
     end
 
     describe '#moab_audits_older_than_threshold?' do
       it 'is true' do
-        expect(described_class.new.moab_audits_older_than_threshold?).to be true
+        expect(outer_class.new.moab_audits_older_than_threshold?).to be true
       end
     end
   end
@@ -190,21 +195,21 @@ RSpec.describe Dashboard::AuditService do
 
     describe '#num_moab_audits_older_than_threshold' do
       it 'returns 0' do
-        expect(described_class.new.num_moab_audits_older_than_threshold).to eq 0
+        expect(outer_class.new.num_moab_audits_older_than_threshold).to eq 0
       end
     end
 
     describe '#moab_audits_older_than_threshold?' do
       it 'is false' do
-        expect(described_class.new.moab_audits_older_than_threshold?).to be false
+        expect(outer_class.new.moab_audits_older_than_threshold?).to be false
       end
     end
   end
 
   describe '#replication_audit_age_threshold' do
     it 'returns string version of REPLICATION_AUDIT_THRESHOLD ago' do
-      expect(described_class.new.replication_audit_age_threshold).to be_a(String)
-      result = DateTime.parse(described_class.new.replication_audit_age_threshold)
+      expect(outer_class.new.replication_audit_age_threshold).to be_a(String)
+      result = DateTime.parse(outer_class.new.replication_audit_age_threshold)
       expect(result).to be <= DateTime.now - described_class::REPLICATION_AUDIT_THRESHOLD
     end
   end
@@ -219,14 +224,14 @@ RSpec.describe Dashboard::AuditService do
 
     describe '#num_replication_audits_older_than_threshold' do
       it 'returns a number greater than 0' do
-        expect(described_class.new.num_replication_audits_older_than_threshold).to be > 0
-        expect(described_class.new.num_replication_audits_older_than_threshold).to eq 3
+        expect(outer_class.new.num_replication_audits_older_than_threshold).to be > 0
+        expect(outer_class.new.num_replication_audits_older_than_threshold).to eq 3
       end
     end
 
     describe '#replication_audits_older_than_threshold?' do
       it 'is true' do
-        expect(described_class.new.replication_audits_older_than_threshold?).to be true
+        expect(outer_class.new.replication_audits_older_than_threshold?).to be true
       end
     end
   end
@@ -239,13 +244,13 @@ RSpec.describe Dashboard::AuditService do
 
     describe '#num_replication_audits_older_than_threshold' do
       it 'returns 0' do
-        expect(described_class.new.num_replication_audits_older_than_threshold).to eq 0
+        expect(outer_class.new.num_replication_audits_older_than_threshold).to eq 0
       end
     end
 
     describe '#replication_audits_older_than_threshold?' do
       it 'is false' do
-        expect(described_class.new.replication_audits_older_than_threshold?).to be false
+        expect(outer_class.new.replication_audits_older_than_threshold?).to be false
       end
     end
   end

--- a/spec/services/dashboard/catalog_service_spec.rb
+++ b/spec/services/dashboard/catalog_service_spec.rb
@@ -4,6 +4,11 @@ require 'rails_helper'
 
 RSpec.describe Dashboard::CatalogService do
   let(:storage_root) { create(:moab_storage_root) }
+  let(:outer_class) do
+    Class.new do
+      include Dashboard::CatalogService
+    end
+  end
 
   describe '#catalog_ok?' do
     context 'when PreservedObject and CompleteMoab counts are different' do
@@ -14,7 +19,7 @@ RSpec.describe Dashboard::CatalogService do
       end
 
       it 'returns false' do
-        expect(described_class.new.catalog_ok?).to be false
+        expect(outer_class.new.catalog_ok?).to be false
       end
     end
 
@@ -27,7 +32,7 @@ RSpec.describe Dashboard::CatalogService do
       end
 
       it 'returns false' do
-        expect(described_class.new.catalog_ok?).to be false
+        expect(outer_class.new.catalog_ok?).to be false
       end
     end
 
@@ -40,7 +45,7 @@ RSpec.describe Dashboard::CatalogService do
       end
 
       it 'returns true' do
-        expect(described_class.new.catalog_ok?).to be true
+        expect(outer_class.new.catalog_ok?).to be true
       end
     end
   end
@@ -87,7 +92,7 @@ RSpec.describe Dashboard::CatalogService do
     end
 
     it 'returns total number of Moabs on all storage roots' do
-      expect(described_class.new.storage_root_total_count).to eq 3
+      expect(outer_class.new.storage_root_total_count).to eq 3
     end
   end
 
@@ -99,7 +104,7 @@ RSpec.describe Dashboard::CatalogService do
     end
 
     it 'returns total number of Moabs with status ok on all storage roots' do
-      expect(described_class.new.storage_root_total_ok_count).to eq 2
+      expect(outer_class.new.storage_root_total_ok_count).to eq 2
     end
   end
 
@@ -111,7 +116,7 @@ RSpec.describe Dashboard::CatalogService do
     end
 
     it 'returns the total size of CompleteMoabs in Terabytes as a string' do
-      expect(described_class.new.complete_moab_total_size).to eq '6.49 TB'
+      expect(outer_class.new.complete_moab_total_size).to eq '6.49 TB'
     end
   end
 
@@ -125,18 +130,18 @@ RSpec.describe Dashboard::CatalogService do
       # "#{(CompleteMoab.average(:size) / Numeric::MEGABYTE).to_f.round(2)} Mb" unless num_complete_moabs.zero?
 
       it 'returns the average size of CompleteMoabs in Megabytes as a string' do
-        expect(described_class.new.complete_moab_average_size).to eq '1.33 MB'
+        expect(outer_class.new.complete_moab_average_size).to eq '1.33 MB'
       end
     end
 
     context 'when num_complete_moabs is 0' do
       # this avoids a divide by zero error when running locally
       before do
-        allow(described_class.new).to receive(:num_complete_moabs).and_return(0)
+        allow(outer_class.new).to receive(:num_complete_moabs).and_return(0)
       end
 
       it 'returns nil' do
-        expect(described_class.new.complete_moab_average_size).to be_nil
+        expect(outer_class.new.complete_moab_average_size).to be_nil
       end
     end
   end
@@ -156,18 +161,18 @@ RSpec.describe Dashboard::CatalogService do
     end
 
     it 'returns array of counts for each CompleteMoab status' do
-      expect(described_class.new.complete_moab_status_counts).to eq [2, 1, 3, 1, 1, 2]
+      expect(outer_class.new.complete_moab_status_counts).to eq [2, 1, 3, 1, 1, 2]
     end
   end
 
   describe '#status_labels' do
     it 'returns CompleteMoab.statuses.keys with blanks instead of underscores' do
-      expect(described_class.new.status_labels).to eq ['ok',
-                                                       'invalid moab',
-                                                       'invalid checksum',
-                                                       'online moab not found',
-                                                       'unexpected version on storage',
-                                                       'validity unknown']
+      expect(outer_class.new.status_labels).to eq ['ok',
+                                                   'invalid moab',
+                                                   'invalid checksum',
+                                                   'online moab not found',
+                                                   'unexpected version on storage',
+                                                   'validity unknown']
     end
   end
 
@@ -179,7 +184,7 @@ RSpec.describe Dashboard::CatalogService do
 
     context 'when there are no errors' do
       it 'returns false' do
-        expect(described_class.new.any_complete_moab_errors?).to be false
+        expect(outer_class.new.any_complete_moab_errors?).to be false
       end
     end
 
@@ -189,7 +194,7 @@ RSpec.describe Dashboard::CatalogService do
       end
 
       it 'returns true' do
-        expect(described_class.new.any_complete_moab_errors?).to be true
+        expect(outer_class.new.any_complete_moab_errors?).to be true
       end
     end
   end
@@ -202,7 +207,7 @@ RSpec.describe Dashboard::CatalogService do
 
     context 'when all CompleteMoabs are status ok' do
       it 'is 0' do
-        expect(described_class.new.num_complete_moab_not_ok).to eq 0
+        expect(outer_class.new.num_complete_moab_not_ok).to eq 0
       end
     end
 
@@ -218,7 +223,7 @@ RSpec.describe Dashboard::CatalogService do
       end
 
       it 'is not 0' do
-        expect(described_class.new.num_complete_moab_not_ok).to eq 5
+        expect(outer_class.new.num_complete_moab_not_ok).to eq 5
       end
     end
   end
@@ -229,8 +234,8 @@ RSpec.describe Dashboard::CatalogService do
     end
 
     it 'returns PreservedObject.count' do
-      expect(described_class.new.num_preserved_objects).to eq(PreservedObject.count)
-      expect(described_class.new.num_preserved_objects).to eq 2
+      expect(outer_class.new.num_preserved_objects).to eq(PreservedObject.count)
+      expect(outer_class.new.num_preserved_objects).to eq 2
     end
   end
 
@@ -242,7 +247,7 @@ RSpec.describe Dashboard::CatalogService do
     end
 
     it 'returns the highest current_version value of any PreservedObject' do
-      expect(described_class.new.preserved_object_highest_version).to eq 67
+      expect(outer_class.new.preserved_object_highest_version).to eq 67
     end
   end
 
@@ -254,7 +259,7 @@ RSpec.describe Dashboard::CatalogService do
     end
 
     it 'returns the total number of object versions according to PreservedObject table' do
-      expect(described_class.new.num_object_versions_per_preserved_object).to eq 71
+      expect(outer_class.new.num_object_versions_per_preserved_object).to eq 71
     end
   end
 
@@ -267,14 +272,14 @@ RSpec.describe Dashboard::CatalogService do
       end
 
       it 'returns the average number of versions per object according to the PreservedObject table' do
-        expect(described_class.new.average_version_per_preserved_object).to eq 23.67
+        expect(outer_class.new.average_version_per_preserved_object).to eq 23.67
       end
     end
 
     context 'when there are no PreservedObjects' do
       # this avoids a divide by zero error when running locally
       it 'returns nil' do
-        expect(described_class.new.average_version_per_preserved_object).to be_nil
+        expect(outer_class.new.average_version_per_preserved_object).to be_nil
       end
     end
   end
@@ -285,8 +290,8 @@ RSpec.describe Dashboard::CatalogService do
     end
 
     it 'returns CompleteMoab.count' do
-      expect(described_class.new.num_complete_moabs).to eq(CompleteMoab.count)
-      expect(described_class.new.num_complete_moabs).to eq 2
+      expect(outer_class.new.num_complete_moabs).to eq(CompleteMoab.count)
+      expect(outer_class.new.num_complete_moabs).to eq 2
     end
   end
 
@@ -298,7 +303,7 @@ RSpec.describe Dashboard::CatalogService do
     end
 
     it 'returns the highest version value of any CompleteMoab' do
-      expect(described_class.new.complete_moab_highest_version).to eq 67
+      expect(outer_class.new.complete_moab_highest_version).to eq 67
     end
   end
 
@@ -310,7 +315,7 @@ RSpec.describe Dashboard::CatalogService do
     end
 
     it 'returns the total number of object versions according to CompleteMoab table' do
-      expect(described_class.new.num_object_versions_per_complete_moab).to eq 71
+      expect(outer_class.new.num_object_versions_per_complete_moab).to eq 71
     end
   end
 
@@ -323,14 +328,14 @@ RSpec.describe Dashboard::CatalogService do
       end
 
       it 'returns the average number of versions per object accrding to the CompleteMoab table' do
-        expect(described_class.new.average_version_per_complete_moab).to eq 23.67
+        expect(outer_class.new.average_version_per_complete_moab).to eq 23.67
       end
     end
 
     context 'when there are no CompleteMoabs' do
       # this avoids a divide by zero error when running locally
       it 'returns nil' do
-        expect(described_class.new.average_version_per_complete_moab).to be_nil
+        expect(outer_class.new.average_version_per_complete_moab).to be_nil
       end
     end
   end
@@ -343,7 +348,7 @@ RSpec.describe Dashboard::CatalogService do
     end
 
     it 'returns CompleteMoab.fixity_check_expired.count and includes nil in the count' do
-      expect(described_class.new.num_expired_checksum_validation).to eq(2)
+      expect(outer_class.new.num_expired_checksum_validation).to eq(2)
     end
   end
 end

--- a/spec/services/dashboard/replication_service_spec.rb
+++ b/spec/services/dashboard/replication_service_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard::ReplicationService do
+  let(:outer_class) do
+    Class.new do
+      include Dashboard::ReplicationService
+    end
+  end
+
   describe '#replication_ok?' do
     let(:po1) { create(:preserved_object, current_version: 2) }
     let(:po2) { create(:preserved_object, current_version: 1) }
@@ -17,7 +23,7 @@ RSpec.describe Dashboard::ReplicationService do
 
     context 'when a ZipEndpoint count does not match num_object_versions_per_preserved_object' do
       it 'returns false' do
-        expect(described_class.new.replication_ok?).to be false
+        expect(outer_class.new.replication_ok?).to be false
       end
     end
 
@@ -29,7 +35,7 @@ RSpec.describe Dashboard::ReplicationService do
       end
 
       it 'returns true' do
-        expect(described_class.new.replication_ok?).to be true
+        expect(outer_class.new.replication_ok?).to be true
       end
     end
   end
@@ -48,7 +54,7 @@ RSpec.describe Dashboard::ReplicationService do
     end
 
     it 'returns a hash with endpoint_name keys and values of Hash with delivery_class and replication_count' do
-      endpoint_data = described_class.new.endpoint_data
+      endpoint_data = outer_class.new.endpoint_data
       expect(endpoint_data[endpoint1.endpoint_name]).to eq({ delivery_class: endpoint1.delivery_class, replication_count: 5 })
       expect(endpoint_data[endpoint2.endpoint_name]).to eq({ delivery_class: endpoint2.delivery_class, replication_count: 2 })
     end
@@ -62,7 +68,7 @@ RSpec.describe Dashboard::ReplicationService do
     end
 
     it 'returns a hash of suffies as keys and values as counts' do
-      expect(described_class.new.zip_part_suffixes).to eq('.zip' => 3)
+      expect(outer_class.new.zip_part_suffixes).to eq('.zip' => 3)
     end
   end
 
@@ -74,7 +80,7 @@ RSpec.describe Dashboard::ReplicationService do
     end
 
     it 'returns the total size of ZipParts in Terabytes as a string' do
-      expect(described_class.new.zip_parts_total_size).to eq '6.49 TB'
+      expect(outer_class.new.zip_parts_total_size).to eq '6.49 TB'
     end
   end
 
@@ -89,7 +95,7 @@ RSpec.describe Dashboard::ReplicationService do
 
     it 'returns ZipPart.count - ZipPart.ok.count' do
       expect(ZipPart.count).to eq 5
-      expect(described_class.new.num_replication_errors).to eq 3
+      expect(outer_class.new.num_replication_errors).to eq 3
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

This was an excellet suggestion by @justinlittman in PR #2076.   Check out the giant simplification of the ViewComponent classes.

Fixes #2078.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



