### PR TITLE
dashboard view components: moving more logic to ruby

### DIFF
--- a/app/components/dashboard/audit_information_component.html.erb
+++ b/app/components/dashboard/audit_information_component.html.erb
@@ -46,7 +46,7 @@
       <td><strong>Weekly</strong>: 1am on Sunday<br/><em>for CompleteMoabs with expired checks</em></td>
       <td><strong>subset</strong>:<br/>expired checksums queued by associated MoabStorageRoot</td>
       <td class="text-end<%= ' table-warning' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
-      <td class="text-end<%= ' table-danger' if CompleteMoab.invalid_checksum.count != 0 %>"><%= CompleteMoab.invalid_checksum.count %></td>
+      <td class="text-end<%= ' table-danger' unless moab_checksum_validation_audit_ok? %>"><%= CompleteMoab.invalid_checksum.count %></td>
       <td class="text-center<%= ' table-warning' if num_expired_checksum_validation != 0 %>"><%= num_expired_checksum_validation %><br/><br/>(passing checks expire 90 days after they are run)</td>
     </tr>
     <tr>

--- a/app/components/dashboard/audit_status_component.html.erb
+++ b/app/components/dashboard/audit_status_component.html.erb
@@ -39,8 +39,8 @@
           <span class="text-secondary pe-2">Moabs</span>
           Checksum Validation
         </h6>
-        <span class="badge rounded-pill <%= checksum_validation_audit_ok? ? 'bg-success' : 'bg-danger' %>">
-          <%= checksum_validation_audit_ok? ? 'OK' : 'Error' %>
+        <span class="badge rounded-pill <%= moab_checksum_validation_audit_ok? ? 'bg-success' : 'bg-danger' %>">
+          <%= moab_checksum_validation_audit_ok? ? 'OK' : 'Error' %>
         </span>
       </li>
       <li class="list-group-item d-flex justify-content-between align-items-center">

--- a/app/components/dashboard/complete_moabs_component.html.erb
+++ b/app/components/dashboard/complete_moabs_component.html.erb
@@ -22,7 +22,7 @@
           <% complete_moab_status_counts[1..].map do |val| %>
             <td class="<%= 'table-danger' if val != 0 %>"><%= val %></td>
           <% end %>
-          <td class="<%= 'table-warning' if num_expired_checksum_validation != 0 %>"><%= num_expired_checksum_validation %></td>
+          <td class="<%= 'table-warning' if moabs_with_expired_checksum_validation? %>"><%= num_expired_checksum_validation %></td>
           </tr>
       </tbody>
     </table>

--- a/app/components/dashboard/moab_storage_roots_component.html.erb
+++ b/app/components/dashboard/moab_storage_roots_component.html.erb
@@ -28,10 +28,10 @@
             <td class="text-end"><%= info[3] %></td><%# moab count %>
             <td class="text-end"><%= info[4] %></td><%# ok status %>
             <% info[5..-2].map do |val| %>
-              <td class="text-end<%= ' table-danger' if val != 0 %>"><%= val %></td>
+              <td class="text-end<%= ' table-danger' if val.positive? %>"><%= val %></td>
             <% end %>
             <% num_expired_checksum = info[10] %>
-            <td class="text-end<%= ' table-warning' if num_expired_checksum != 0 %>"><%= num_expired_checksum %></td>
+            <td class="text-end<%= ' table-warning' if num_expired_checksum.positive? %>"><%= num_expired_checksum %></td>
           </tr>
         <% end %>
       </tbody>
@@ -44,10 +44,10 @@
           <td class="text-end<%= ' table-danger' if storage_root_total_count != num_complete_moabs %>"><%= storage_root_total_count %></td>
           <td class="text-end"><%= storage_root_total_ok_count %></td>
           <% storage_root_totals[2..-2]&.each do |count| %>
-            <td class="text-end<%= ' table-danger' if count != 0 %>"><%= count %></td>
+            <td class="text-end<%= ' table-danger' if count.positive? %>"><%= count %></td>
           <% end %>
           <% total_num_expired_checksum = storage_root_totals[7] %>
-          <td class="text-end<%= ' table-warning' if total_num_expired_checksum != 0 %>"><%= total_num_expired_checksum %></td>
+          <td class="text-end<%= ' table-warning' if total_num_expired_checksum.positive? %>"><%= total_num_expired_checksum %></td>
         </tr>
       </tfoot>
     </table>

--- a/app/components/dashboard/object_versions_component.html.erb
+++ b/app/components/dashboard/object_versions_component.html.erb
@@ -14,16 +14,16 @@
     <tbody class="table-group-divider">
       <tr>
         <td>PreservedObject</td>
-        <td class="text-end<%= ' table-danger' if num_preserved_objects != num_complete_moabs %>"><%= num_preserved_objects %></td>
-        <td class="text-end<%= ' table-danger' if num_object_versions_per_preserved_object != num_object_versions_per_complete_moab %>"><%= num_object_versions_per_preserved_object %></td>
-        <td class="text-end<%= ' table-danger' if preserved_object_highest_version != complete_moab_highest_version %>"><%= preserved_object_highest_version %></td>
+        <td class="text-end<%= ' table-danger' unless preserved_object_complete_moab_counts_match? %>"><%= num_preserved_objects %></td>
+        <td class="text-end<%= ' table-danger' unless num_object_versions_preserved_object_complete_moab_match? %>"><%= num_object_versions_per_preserved_object %></td>
+        <td class="text-end<%= ' table-danger' unless highest_version_preserved_object_complete_moab_match? %>"><%= preserved_object_highest_version %></td>
         <td class="text-end"><%= average_version_per_preserved_object %></td>
       </tr>
       <tr>
         <td>CompleteMoab</td>
-        <td class="text-end<%= ' table-danger' if num_preserved_objects != num_complete_moabs %>"><%= num_complete_moabs %></td>
-        <td class="text-end<%= ' table-danger' if num_object_versions_per_preserved_object != num_object_versions_per_complete_moab %>"><%= num_object_versions_per_complete_moab %></td>
-        <td class="text-end<%= ' table-danger' if preserved_object_highest_version != complete_moab_highest_version %>"><%= complete_moab_highest_version %></td>
+        <td class="text-end<%= ' table-danger' unless preserved_object_complete_moab_counts_match? %>"><%= num_complete_moabs %></td>
+        <td class="text-end<%= ' table-danger' unless num_object_versions_preserved_object_complete_moab_match? %>"><%= num_object_versions_per_complete_moab %></td>
+        <td class="text-end<%= ' table-danger' unless highest_version_preserved_object_complete_moab_match? %>"><%= complete_moab_highest_version %></td>
         <td class="text-end"><%= average_version_per_complete_moab %></td>
       </tr>
     </tbody>

--- a/app/components/dashboard/replication_endpoints_component.html.erb
+++ b/app/components/dashboard/replication_endpoints_component.html.erb
@@ -18,7 +18,7 @@
             <td><%= endpoint_name %></td>
             <td><%= info[:delivery_class] %></td>
             <% replication_count = info[:replication_count] %>
-            <td class="text-end<%= ' table-danger' if replication_count != num_object_versions_per_preserved_object%>"><%= replication_count %></td>
+            <td class="text-end<%= ' table-danger' unless endpoint_replication_count_ok?(replication_count) %>"><%= replication_count %></td>
             <td class="text-end"><%= num_object_versions_per_preserved_object %></td>
           </tr>
         <% end %>

--- a/app/components/dashboard/replication_files_component.html.erb
+++ b/app/components/dashboard/replication_files_component.html.erb
@@ -20,9 +20,9 @@
           <td><%= ZipPart.count %></td>
           <td><%= zip_parts_total_size %></td>
           <td class="text-end"><%= ZipPart.ok.count %></td>
-          <td class="text-end<%= ' table-danger' if ZipPart.replicated_checksum_mismatch.count != 0 %>"><%= ZipPart.replicated_checksum_mismatch.count %></td>
-          <td class="text-end<%= ' table-warning' if ZipPart.unreplicated.count != 0 %>"><%= ZipPart.unreplicated.count %></td>
-          <td class="text-end<%= ' table-danger' if ZipPart.not_found.count != 0 %>"><%= ZipPart.not_found.count %></td>
+          <td class="text-end<%= ' table-danger' if zip_parts_replicated_checksum_mismatch? %>"><%= ZipPart.replicated_checksum_mismatch.count %></td>
+          <td class="text-end<%= ' table-warning' if zip_parts_unreplicated? %>"><%= ZipPart.unreplicated.count %></td>
+          <td class="text-end<%= ' table-danger' if zip_parts_not_found? %>"><%= ZipPart.not_found.count %></td>
         </tr>
       </tbody>
     </table>

--- a/app/services/dashboard/audit_service.rb
+++ b/app/services/dashboard/audit_service.rb
@@ -19,7 +19,7 @@ module Dashboard
       validate_moab_audit_ok? &&
         catalog_to_moab_audit_ok? &&
         moab_to_catalog_audit_ok? &&
-        checksum_validation_audit_ok? &&
+        moab_checksum_validation_audit_ok? &&
         catalog_to_archive_audit_ok?
     end
 
@@ -39,7 +39,7 @@ module Dashboard
       !any_complete_moab_errors?
     end
 
-    def checksum_validation_audit_ok?
+    def moab_checksum_validation_audit_ok?
       # NOTE: unsure if there needs to be more checking of CompleteMoab.status_details for more statuses to figure this out
       CompleteMoab.invalid_checksum.count.zero?
     end

--- a/app/services/dashboard/moab_on_storage_service.rb
+++ b/app/services/dashboard/moab_on_storage_service.rb
@@ -5,7 +5,7 @@ require 'action_view' # for number_to_human_size
 # services for dashboard
 module Dashboard
   # methods pertaining to PreservedObject and CompleteMoab database data for dashboard
-  module MoabOnStorageService
+  module MoabOnStorageService # rubocop:disable Metrics/ModuleLength
     include ActionView::Helpers::NumberHelper # for number_to_human_size
 
     def moabs_on_storage_ok?
@@ -13,8 +13,8 @@ module Dashboard
     end
 
     def moab_on_storage_counts_ok?
-      num_preserved_objects == num_complete_moabs &&
-        num_object_versions_per_preserved_object == num_object_versions_per_complete_moab
+      preserved_object_complete_moab_counts_match? &&
+        num_object_versions_preserved_object_complete_moab_match?
     end
 
     def storage_root_info # rubocop:disable Metrics/AbcSize
@@ -77,6 +77,10 @@ module Dashboard
       CompleteMoab.fixity_check_expired.count
     end
 
+    def moabs_with_expired_checksum_validation?
+      num_expired_checksum_validation.positive?
+    end
+
     def any_complete_moab_errors?
       num_complete_moab_not_ok.positive?
     end
@@ -119,6 +123,18 @@ module Dashboard
       # note, no user input to sanitize here, so ok to use Arel.sql
       # see https://api.rubyonrails.org/v7.0.4/classes/ActiveRecord/UnknownAttributeReference.html
       CompleteMoab.pick(Arel.sql('SUM(version)::numeric/COUNT(id)')).round(2) unless num_complete_moabs.zero?
+    end
+
+    def preserved_object_complete_moab_counts_match?
+      num_preserved_objects == num_complete_moabs
+    end
+
+    def num_object_versions_preserved_object_complete_moab_match?
+      num_object_versions_per_preserved_object == num_object_versions_per_complete_moab
+    end
+
+    def highest_version_preserved_object_complete_moab_match?
+      preserved_object_highest_version == complete_moab_highest_version
     end
 
     private

--- a/app/services/dashboard/replication_service.rb
+++ b/app/services/dashboard/replication_service.rb
@@ -15,9 +15,13 @@ module Dashboard
 
     def replication_ok?
       endpoint_data.each do |_endpoint_name, info|
-        return false if info[:replication_count] != num_object_versions_per_preserved_object
+        return false unless endpoint_replication_count_ok?(info[:replication_count])
       end
       true
+    end
+
+    def endpoint_replication_count_ok?(endpoint_replication_count)
+      endpoint_replication_count == num_object_versions_per_preserved_object
     end
 
     def endpoint_data
@@ -46,6 +50,18 @@ module Dashboard
 
     def zip_parts_ok?
       num_replication_errors.zero?
+    end
+
+    def zip_parts_unreplicated?
+      ZipPart.unreplicated.count.positive?
+    end
+
+    def zip_parts_not_found?
+      ZipPart.not_found.count.positive?
+    end
+
+    def zip_parts_replicated_checksum_mismatch?
+      ZipPart.replicated_checksum_mismatch.count.positive?
     end
   end
 end

--- a/spec/services/dashboard/audit_service_spec.rb
+++ b/spec/services/dashboard/audit_service_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Dashboard::AuditService do
     end
   end
 
-  describe '#checksum_validation_audit_ok?' do
+  describe '#moab_checksum_validation_audit_ok?' do
     context 'when there are CompleteMoabs with online_moab_not_found status' do
       before do
         create(:complete_moab, status: 'ok')
@@ -118,7 +118,7 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'returns false' do
-        expect(outer_class.new.checksum_validation_audit_ok?).to be false
+        expect(outer_class.new.moab_checksum_validation_audit_ok?).to be false
       end
     end
 
@@ -130,7 +130,7 @@ RSpec.describe Dashboard::AuditService do
       end
 
       it 'returns true' do
-        expect(outer_class.new.checksum_validation_audit_ok?).to be true
+        expect(outer_class.new.moab_checksum_validation_audit_ok?).to be true
       end
     end
   end

--- a/spec/services/dashboard/moab_on_storage_service_spec.rb
+++ b/spec/services/dashboard/moab_on_storage_service_spec.rb
@@ -383,4 +383,98 @@ RSpec.describe Dashboard::MoabOnStorageService do
       expect(outer_class.new.num_expired_checksum_validation).to eq(2)
     end
   end
+
+  describe '#moabs_with_expired_checksum_validation?' do
+    context 'when there are no expired checksum validations' do
+      before do
+        create(:complete_moab, moab_storage_root: storage_root, last_checksum_validation: Time.zone.now)
+      end
+
+      it 'returns false' do
+        expect(outer_class.new.moabs_with_expired_checksum_validation?).to be false
+      end
+    end
+
+    context 'when there are expired checksum validations' do
+      before do
+        create(:complete_moab, moab_storage_root: storage_root, last_checksum_validation: 4.months.ago)
+      end
+
+      it 'returns true' do
+        expect(outer_class.new.moabs_with_expired_checksum_validation?).to be true
+      end
+    end
+  end
+
+  describe 'preserved_object_complete_moab_counts_match?' do
+    before do
+      storage_root.complete_moabs = build_list(:complete_moab, 2)
+    end
+
+    context 'when the counts match' do
+      it 'returns true' do
+        expect(outer_class.new.preserved_object_complete_moab_counts_match?).to be true
+      end
+    end
+
+    context 'when the counts do not match' do
+      before do
+        create(:preserved_object, current_version: 1)
+      end
+
+      it 'returns false' do
+        expect(outer_class.new.preserved_object_complete_moab_counts_match?).to be false
+      end
+    end
+  end
+
+  describe '#num_object_versions_preserved_object_complete_moab_match?' do
+    let!(:preserved_object) { create(:preserved_object, current_version: 2) }
+
+    before do
+      create(:complete_moab, preserved_object: preserved_object, version: 2)
+    end
+
+    context 'when the number of object versions match' do
+      it 'returns true' do
+        expect(outer_class.new.num_object_versions_preserved_object_complete_moab_match?).to be true
+      end
+    end
+
+    context 'when the number of object versions do not match' do
+      before do
+        preserved_object.current_version = 1 # pretend it wasn't updated to version 2
+        preserved_object.save!
+      end
+
+      it 'returns false' do
+        expect(outer_class.new.num_object_versions_preserved_object_complete_moab_match?).to be false
+      end
+    end
+  end
+
+  describe '#highest_version_preserved_object_complete_moab_match?' do
+    let!(:preserved_object) { create(:preserved_object, current_version: 2) }
+
+    before do
+      create(:complete_moab, preserved_object: preserved_object, version: 2)
+    end
+
+    context 'when the highest versions match' do
+      it 'returns true' do
+        expect(outer_class.new.highest_version_preserved_object_complete_moab_match?).to be true
+      end
+    end
+
+    context 'when the highest versions do not match' do
+      before do
+        preserved_object.current_version = 1 # pretend it wasn't updated to version 2
+        preserved_object.save!
+      end
+
+      it 'returns false' do
+        expect(outer_class.new.highest_version_preserved_object_complete_moab_match?).to be false
+      end
+    end
+  end
 end

--- a/spec/services/dashboard/replication_service_spec.rb
+++ b/spec/services/dashboard/replication_service_spec.rb
@@ -75,6 +75,25 @@ RSpec.describe Dashboard::ReplicationService do
     end
   end
 
+  describe '#endpoint_replication_count_ok?' do
+    before do
+      create(:preserved_object, current_version: 2)
+      create(:preserved_object, current_version: 3)
+    end
+
+    context 'when parameter matches num_object_versions_per_preserved_object' do
+      it 'returns true' do
+        expect(outer_class.new.endpoint_replication_count_ok?(5)).to be true
+      end
+    end
+
+    context 'when parameter does not match num_object_versions_per_preserved_object' do
+      it 'returns false' do
+        expect(outer_class.new.endpoint_replication_count_ok?(4)).to be false
+      end
+    end
+  end
+
   describe '#endpoint_data' do
     let(:endpoint1) { ZipEndpoint.first }
     let(:endpoint2) { ZipEndpoint.last }
@@ -152,6 +171,60 @@ RSpec.describe Dashboard::ReplicationService do
 
       it 'returns false' do
         expect(outer_class.new.zip_parts_ok?).to be false
+      end
+    end
+  end
+
+  describe '#zip_parts_unreplicated?' do
+    context 'when no ZipPart with status unreplicated' do
+      it 'returns false' do
+        expect(outer_class.new.zip_parts_unreplicated?).to be false
+      end
+    end
+
+    context 'when at least one ZipPart has status unreplicated' do
+      before do
+        create(:zip_part, status: :unreplicated)
+      end
+
+      it 'returns true' do
+        expect(outer_class.new.zip_parts_unreplicated?).to be true
+      end
+    end
+  end
+
+  describe '#zip_parts_not_found?' do
+    context 'when no ZipPart with status not_found' do
+      it 'returns false' do
+        expect(outer_class.new.zip_parts_not_found?).to be false
+      end
+    end
+
+    context 'when at least one ZipPart has status not_found' do
+      before do
+        create(:zip_part, status: :not_found)
+      end
+
+      it 'returns true' do
+        expect(outer_class.new.zip_parts_not_found?).to be true
+      end
+    end
+  end
+
+  describe '#zip_parts_replicated_checksum_mismatch?' do
+    context 'when no ZipPart with status replicated_checksum_mismatch' do
+      it 'returns false' do
+        expect(outer_class.new.zip_parts_replicated_checksum_mismatch?).to be false
+      end
+    end
+
+    context 'when at least one ZipPart has status replicated_checksum_mismatch' do
+      before do
+        create(:zip_part, status: :replicated_checksum_mismatch)
+      end
+
+      it 'returns true' do
+        expect(outer_class.new.zip_parts_replicated_checksum_mismatch?).to be true
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

The goal here is to make the erb files more straightforward.

Fixes #2079

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



