### PR TITLE
Dashboard and dashboard code get some clarifications

### DIFF
--- a/app/components/dashboard/audit_information_component.rb
+++ b/app/components/dashboard/audit_information_component.rb
@@ -4,7 +4,7 @@ module Dashboard
   # methods for dashboard pertaining to AuditInformationComponent
   class AuditInformationComponent < ViewComponent::Base
     include Dashboard::AuditService
-    include Dashboard::CatalogService
+    include Dashboard::MoabOnStorageService
     include Dashboard::ReplicationService
   end
 end

--- a/app/components/dashboard/complete_moabs_component.rb
+++ b/app/components/dashboard/complete_moabs_component.rb
@@ -3,6 +3,6 @@
 module Dashboard
   # methods for dashboard pertaining to CompleteMoabsComponent
   class CompleteMoabsComponent < ViewComponent::Base
-    include Dashboard::CatalogService
+    include Dashboard::MoabOnStorageService
   end
 end

--- a/app/components/dashboard/moab_on_storage_status_component.rb
+++ b/app/components/dashboard/moab_on_storage_status_component.rb
@@ -3,6 +3,6 @@
 module Dashboard
   # methods for dashboard pertaining to MoabOnStorageStatusComponent
   class MoabOnStorageStatusComponent < ViewComponent::Base
-    include Dashboard::CatalogService
+    include Dashboard::MoabOnStorageService
   end
 end

--- a/app/components/dashboard/moab_storage_roots_component.rb
+++ b/app/components/dashboard/moab_storage_roots_component.rb
@@ -3,6 +3,6 @@
 module Dashboard
   # methods for dashboard pertaining to MoabStorageRootsComponent
   class MoabStorageRootsComponent < ViewComponent::Base
-    include Dashboard::CatalogService
+    include Dashboard::MoabOnStorageService
   end
 end

--- a/app/components/dashboard/object_versions_component.rb
+++ b/app/components/dashboard/object_versions_component.rb
@@ -3,6 +3,6 @@
 module Dashboard
   # methods for dashboard pertaining to ObjectVersionsComponent
   class ObjectVersionsComponent < ViewComponent::Base
-    include Dashboard::CatalogService
+    include Dashboard::MoabOnStorageService
   end
 end

--- a/app/components/dashboard/replication_endpoints_component.rb
+++ b/app/components/dashboard/replication_endpoints_component.rb
@@ -3,7 +3,7 @@
 module Dashboard
   # methods for dashboard pertaining to ReplicationEndpointsComponent
   class ReplicationEndpointsComponent < ViewComponent::Base
-    include Dashboard::CatalogService
+    include Dashboard::MoabOnStorageService
     include Dashboard::ReplicationService
   end
 end

--- a/app/components/dashboard/replication_status_component.rb
+++ b/app/components/dashboard/replication_status_component.rb
@@ -4,6 +4,6 @@ module Dashboard
   # methods for dashboard pertaining to ReplicationStatusComponent
   class ReplicationStatusComponent < ViewComponent::Base
     include Dashboard::ReplicationService
-    include Dashboard::CatalogService
+    include Dashboard::MoabOnStorageService
   end
 end

--- a/app/services/dashboard/audit_service.rb
+++ b/app/services/dashboard/audit_service.rb
@@ -4,7 +4,7 @@
 module Dashboard
   # methods pertaining to audit functionality for dashboard
   module AuditService
-    include CatalogService
+    include MoabOnStorageService
 
     # CompleteMoab.last_version_audit is the most recent of 3 separate audits:
     #   moab_to_catalog - all CompleteMoabs are queued for this on the 1st of the month

--- a/app/services/dashboard/catalog_service.rb
+++ b/app/services/dashboard/catalog_service.rb
@@ -4,7 +4,7 @@ require 'action_view' # for number_to_human_size
 
 # services for dashboard
 module Dashboard
-  # methods pertaining to catalog functionality for dashboard
+  # methods pertaining to catalog (on prem storage) functionality for dashboard
   module CatalogService
     include ActionView::Helpers::NumberHelper # for number_to_human_size
 

--- a/app/services/dashboard/moab_on_storage_service.rb
+++ b/app/services/dashboard/moab_on_storage_service.rb
@@ -4,8 +4,8 @@ require 'action_view' # for number_to_human_size
 
 # services for dashboard
 module Dashboard
-  # methods pertaining to catalog (on prem storage) functionality for dashboard
-  module CatalogService
+  # methods pertaining to catalog functionality for MoabOnStorage for dashboard
+  module MoabOnStorageService
     include ActionView::Helpers::NumberHelper # for number_to_human_size
 
     def moabs_on_storage_ok?

--- a/app/services/dashboard/moab_on_storage_service.rb
+++ b/app/services/dashboard/moab_on_storage_service.rb
@@ -4,7 +4,7 @@ require 'action_view' # for number_to_human_size
 
 # services for dashboard
 module Dashboard
-  # methods pertaining to catalog functionality for MoabOnStorage for dashboard
+  # methods pertaining to PreservedObject and CompleteMoab database data for dashboard
   module MoabOnStorageService
     include ActionView::Helpers::NumberHelper # for number_to_human_size
 

--- a/app/services/dashboard/replication_service.rb
+++ b/app/services/dashboard/replication_service.rb
@@ -7,7 +7,7 @@ module Dashboard
   # methods pertaining to replication (cloud storage) tables in database for dashboard
   module ReplicationService
     include ActionView::Helpers::NumberHelper # for number_to_human_size
-    include CatalogService
+    include MoabOnStorageService
 
     def replication_and_zip_parts_ok?
       zip_parts_ok? && replication_ok?

--- a/app/services/dashboard/replication_service.rb
+++ b/app/services/dashboard/replication_service.rb
@@ -4,7 +4,7 @@ require 'action_view' # for number_to_human_size
 
 # services for dashboard
 module Dashboard
-  # methods pertaining to replication functionality for dashboard
+  # methods pertaining to replication (cloud storage) tables in database for dashboard
   module ReplicationService
     include ActionView::Helpers::NumberHelper # for number_to_human_size
     include CatalogService

--- a/app/views/dashboard/_replication_information.html.erb
+++ b/app/views/dashboard/_replication_information.html.erb
@@ -1,5 +1,11 @@
 <h2>Version Zips - Replication Status Information</h2>
-
+<div>
+  <p class="lead">Preservation Catalog replicates zipped versions of SDR objects (Moabs on storage) to multiple endpoints in cloud.</p>
+</div>
+<p><strong class="fs-4">PreservedObject</strong> records store the druid and links to db records about both the Moab on local storage and all the replicated instances in the cloud.</p>
+<p><strong class="fs-4">ZippedMoabVersion</strong> records are about a single version of the Moab that is archived as zip file(s) on a particular cloud endpoint.</p>
+<p><strong class="fs-4">ZipPart</strong> records represent the individual zip segments for a ZippedMoabVersion (zips larger than 10g are split into segments) that are replicated to the particular cloud endpoint.</p>
+<hr/>
 <div class="row row-cols-2">
   <div class="column col-8">
     <turbo-frame id="replication_endpoints">
@@ -12,9 +18,11 @@
     </turbo-frame>
   </div>
 </div>
+<hr/>
 <turbo-frame id="replication_flow">
   <%= render partial: 'replication_flow' %>
 </turbo-frame>
+<hr/>
 <turbo-frame id="zip_parts_suffix_counts">
   <%= render Dashboard::ZipPartsSuffixesComponent.new %>
 </turbo-frame>

--- a/spec/services/dashboard/moab_on_storage_service_spec.rb
+++ b/spec/services/dashboard/moab_on_storage_service_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe Dashboard::CatalogService do
+RSpec.describe Dashboard::MoabOnStorageService do
   let(:storage_root) { create(:moab_storage_root) }
   let(:outer_class) do
     Class.new do
-      include Dashboard::CatalogService
+      include Dashboard::MoabOnStorageService
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

from storytime 2022-11-28:   our code uses "catalog" in a misleading way, because it's more "on prem storage" vs. cloud (replicated) storage -- both are in the catalog.

I renamed the dashboard classes and partials that had "catalog" in the name and tweaked some comments and dashboard explanatory text with this in mind.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



