### PR TITLE
ZipDeliveryService notifies Honeybadger if s3 part exists already

### DIFF
--- a/app/services/zip_delivery_service.rb
+++ b/app/services/zip_delivery_service.rb
@@ -15,8 +15,22 @@ class ZipDeliveryService
     @metadata = stringify_values(metadata)
   end
 
-  def deliver
-    return if s3_part.exists?
+  def deliver # rubocop:disable Metrics/AbcSize
+    if s3_part.exists?
+      msg = 'WARNING: S3 location already has content. ' \
+            'Perhaps a failed replication was pruned from the database, but was not removed from the cloud. ' \
+            "If so, prune this content from the database again (there's a rake task), ask ops to delete the bad replicated content, and try again."
+      hb_context = {
+        druid: dvz_part.druid.druid, # dvz_part.dvz.druid is a DruidTools::Druid object
+        version: dvz_part.dvz.version,
+        endpoint: s3_part.bucket_name
+      }
+      Honeybadger.notify(msg, context: hb_context)
+      Rails.logger.warn("msg: #{msg}, context: #{hb_context}")
+
+      # retries will fail and as nothing was delivered, we do NOT want to proceed with replication job sequence.
+      return
+    end
 
     raise "#{s3_part.key} MD5 mismatch: passed #{given_md5}, computed #{fresh_md5}" if fresh_md5 != given_md5
 


### PR DESCRIPTION
## Why was this change made? 🤔

These errors must be surfaced so we can address them.  Automatic retries won't fix them, and allowing the `CatalogToArchive` audit to backfill missing parts ... will never address this either.   So let's report the error.

Fixes #2041 

## How was this change tested? 🤨

new unit test

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



