### PR TITLE
refactor: clearer method name in Dashboard::MoabOnStorageService

### DIFF
--- a/app/components/dashboard/audit_information_component.html.erb
+++ b/app/components/dashboard/audit_information_component.html.erb
@@ -47,7 +47,7 @@
       <td><strong>subset</strong>:<br/>expired checksums queued by associated MoabStorageRoot</td>
       <td class="text-end<%= ' table-warning' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
       <td class="text-end<%= ' table-danger' unless moab_checksum_validation_audit_ok? %>"><%= CompleteMoab.invalid_checksum.count %></td>
-      <td class="text-center<%= ' table-warning' if num_expired_checksum_validation != 0 %>"><%= num_expired_checksum_validation %><br/><br/>(passing checks expire 90 days after they are run)</td>
+      <td class="text-center<%= ' table-warning' if num_moab_expired_checksum_validation != 0 %>"><%= num_moab_expired_checksum_validation %><br/><br/>(passing checks expire 90 days after they are run)</td>
     </tr>
     <tr>
       <td><strong>Catalog to Archive</strong><br/>Confirm a PreservedObject has all versions/parts replicated for each of its target endpoints and attempts to backfill missing ones</td>

--- a/app/components/dashboard/audit_information_component.html.erb
+++ b/app/components/dashboard/audit_information_component.html.erb
@@ -47,7 +47,7 @@
       <td><strong>subset</strong>:<br/>expired checksums queued by associated MoabStorageRoot</td>
       <td class="text-end<%= ' table-warning' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
       <td class="text-end<%= ' table-danger' unless moab_checksum_validation_audit_ok? %>"><%= CompleteMoab.invalid_checksum.count %></td>
-      <td class="text-center<%= ' table-warning' if num_moab_expired_checksum_validation != 0 %>"><%= num_moab_expired_checksum_validation %><br/><br/>(passing checks expire 90 days after they are run)</td>
+      <td class="text-center<%= ' table-warning' if moabs_with_expired_checksum_validation? %>"><%= num_moab_expired_checksum_validation %><br/><br/>(passing checks expire 90 days after they are run)</td>
     </tr>
     <tr>
       <td><strong>Catalog to Archive</strong><br/>Confirm a PreservedObject has all versions/parts replicated for each of its target endpoints and attempts to backfill missing ones</td>
@@ -55,7 +55,7 @@
       <td><strong>Weekly</strong>: 12am on Wednesday<br/><em>for PreservedObjects with expired checks</em></td>
       <td><strong>subset</strong>:<br/>expired archive checks for PreservedObjects and their associated ZipParts are queued</td>
       <td class="text-end<%= ' table-warning' if replication_audits_older_than_threshold? %>">PreservedObject replication audits older than <%= replication_audit_age_threshold %>:<hr/><%= num_replication_audits_older_than_threshold %></td>
-      <td class="text-end<%= ' table-danger' if num_replication_errors != 0 %>"><%= num_replication_errors %></td>
+      <td class="text-end<%= ' table-danger' if zip_parts_ok? %>"><%= num_replication_errors %></td>
       <td class="text-center"><%= PreservedObject.archive_check_expired.count %><br/><br/>(passing checks expire 90 days after they are run)</td>
     </tr>
   </tbody>

--- a/app/components/dashboard/complete_moabs_component.html.erb
+++ b/app/components/dashboard/complete_moabs_component.html.erb
@@ -22,7 +22,7 @@
           <% complete_moab_status_counts[1..].map do |val| %>
             <td class="<%= 'table-danger' if val != 0 %>"><%= val %></td>
           <% end %>
-          <td class="<%= 'table-warning' if moabs_with_expired_checksum_validation? %>"><%= num_expired_checksum_validation %></td>
+          <td class="<%= 'table-warning' if moabs_with_expired_checksum_validation? %>"><%= num_moab_expired_checksum_validation %></td>
           </tr>
       </tbody>
     </table>

--- a/app/services/dashboard/moab_on_storage_service.rb
+++ b/app/services/dashboard/moab_on_storage_service.rb
@@ -73,12 +73,12 @@ module Dashboard
       CompleteMoab.statuses.keys.map { |status| status.tr('_', ' ') }
     end
 
-    def num_expired_checksum_validation
-      CompleteMoab.fixity_check_expired.count
+    def num_moab_expired_checksum_validation
+      @num_moab_expired_checksum_validation ||= CompleteMoab.fixity_check_expired.count
     end
 
     def moabs_with_expired_checksum_validation?
-      num_expired_checksum_validation.positive?
+      num_moab_expired_checksum_validation.positive?
     end
 
     def any_complete_moab_errors?

--- a/spec/services/dashboard/moab_on_storage_service_spec.rb
+++ b/spec/services/dashboard/moab_on_storage_service_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe Dashboard::MoabOnStorageService do
     end
   end
 
-  describe '#num_expired_checksum_validation' do
+  describe '#num_moab_expired_checksum_validation' do
     before do
       create(:complete_moab, moab_storage_root: storage_root, last_checksum_validation: Time.zone.now)
       create(:complete_moab, preserved_object: create(:preserved_object), last_checksum_validation: 4.months.ago)
@@ -380,7 +380,7 @@ RSpec.describe Dashboard::MoabOnStorageService do
     end
 
     it 'returns CompleteMoab.fixity_check_expired.count and includes nil in the count' do
-      expect(outer_class.new.num_expired_checksum_validation).to eq(2)
+      expect(outer_class.new.num_moab_expired_checksum_validation).to eq(2)
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

1.  we get expired checksums for replicated ZipPart and for CompleteMoab so ... let's distinguish better.

2.  get a little more logic out of erb files.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



