### PR TITLE
dashboard audit_info_component: fix table styling error

### DIFF
--- a/app/components/dashboard/audit_information_component.html.erb
+++ b/app/components/dashboard/audit_information_component.html.erb
@@ -55,7 +55,7 @@
       <td><strong>Weekly</strong>: 12am on Wednesday<br/><em>for PreservedObjects with expired checks</em></td>
       <td><strong>subset</strong>:<br/>expired archive checks for PreservedObjects and their associated ZipParts are queued</td>
       <td class="text-end<%= ' table-warning' if replication_audits_older_than_threshold? %>">PreservedObject replication audits older than <%= replication_audit_age_threshold %>:<hr/><%= num_replication_audits_older_than_threshold %></td>
-      <td class="text-end<%= ' table-danger' if zip_parts_ok? %>"><%= num_replication_errors %></td>
+      <td class="text-end<%= ' table-danger' unless zip_parts_ok? %>"><%= num_replication_errors %></td>
       <td class="text-center"><%= PreservedObject.archive_check_expired.count %><br/><br/>(passing checks expire 90 days after they are run)</td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Why was this change made? 🤔

I noticed the styling was incorrect.  Whoopsie!

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



