### PR TITLE
Close quote for HB URL

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,7 +11,7 @@ Config.load_and_set_settings(Config.setting_files('config', 'production'))
 
 # These define jobs that checkin with Honeybadger.
 # If changing the schedule of one of these jobs, also update at https://app.honeybadger.io/projects/54415/check_ins
-job_type :rake, "cd :path && :environment_variable=:environment bundle exec rake :task --silent :output && curl 'https://api.honeybadger.io/v1/check_in/:check_in"
+job_type :rake, "cd :path && :environment_variable=:environment bundle exec rake :task --silent :output && curl 'https://api.honeybadger.io/v1/check_in/:check_in'"
 job_type :runner_hb, "cd :path && bin/rails runner -e :environment ':task' && curl 'https://api.honeybadger.io/v1/check_in/:check_in' :output"
 
 # 11 am on the 1st of every month


### PR DESCRIPTION
## Why was this change made? 🤔

The HB URL needed a close quote to run. Fixes #2099

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



