### PR TITLE
Silence curl and simplify quoting

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,8 +11,8 @@ Config.load_and_set_settings(Config.setting_files('config', 'production'))
 
 # These define jobs that checkin with Honeybadger.
 # If changing the schedule of one of these jobs, also update at https://app.honeybadger.io/projects/54415/check_ins
-job_type :rake, "cd :path && :environment_variable=:environment bundle exec rake :task --silent :output && curl 'https://api.honeybadger.io/v1/check_in/:check_in'"
-job_type :runner_hb, "cd :path && bin/rails runner -e :environment ':task' && curl 'https://api.honeybadger.io/v1/check_in/:check_in' :output"
+job_type :rake, 'cd :path && :environment_variable=:environment bundle exec rake --silent ":task" :output && curl --silent https://api.honeybadger.io/v1/check_in/:check_in'
+job_type :runner_hb, 'cd :path && bin/rails runner -e :environment ":task" :output && curl --silent https://api.honeybadger.io/v1/check_in/:check_in'
 
 # 11 am on the 1st of every month
 # If changing schedule, also change for HB checkin


### PR DESCRIPTION
## Why was this change made? 🤔

cron on `preservation-catalog-prod-04` was sending email because curl's diagnostic output was being sent to stderr, which caused cron to think something was wrong. This change tells curl to be silent, and removes some of the unneeded quoting so that the cron entries are easier to read. The `:output` for runner_hb was also positioned earlier since curl will be quiet.

The two different styles of resulting cron entries now look like:

```
0 0 * * 3 /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20221207173228 && bin/rails runner -e production "PreservedObject.archive_check_expired.find_each(&:audit_moab_version_replication!)" >> /dev/null 2>> log/c2a-err.log && curl --silent https://api.honeybadger.io/v1/check_in/rkIdpB'

0 * * * * /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20221207173228 && RAILS_ENV=production bundle exec rake --silent "prescat:cache_cleaner:stale_files" >> /var/log/preservation_catalog/zip_cache_cleanup.log && curl --silent https://api.honeybadger.io/v1/check_in/2AIqEx'
```

Fixes #2102

## How was this change tested? 🤨

Tested crontab generation on QA.

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



