### PR TITLE
update documentation around the word 'integrity'

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ curl -H 'Authorization: Bearer eyJhbGcxxxxx.eyJzdWIxxxxx.lWMJ66Wxx-xx' http://lo
 
 ## General Info
 
-- The PostgreSQL database is the catalog of metadata about preserved SDR content, both on premises and in the cloud.  Integrity constraints are used heavily for keeping data clean and consistent.
+- The PostgreSQL database is the catalog of metadata about preserved SDR content, both on premises and in the cloud.  Database-level constraints are used heavily for keeping data clean and consistent.
 
 - Background jobs (using ActiveJob/Resque/Redis) perform the audit and replication work.
 

--- a/app/components/dashboard/audit_information_component.html.erb
+++ b/app/components/dashboard/audit_information_component.html.erb
@@ -14,7 +14,7 @@
   </thead>
   <tbody class="table-group-divider">
     <tr>
-      <td><strong>Validate Moab</strong><br/>moab-versioning integrity checks run for locally stored Moabs.</td>
+      <td><strong>Validate Moab</strong><br/>moab-versioning gem validation for well-formedness (not checksums) run for locally stored Moabs.</td>
       <td>validate_moab</td>
       <td><strong>on demand</strong></td>
       <td><strong>one</strong>:<br/>queued by preservation robot step after updating a Moab</td>
@@ -23,7 +23,7 @@
       <td class="table-secondary"/>
     </tr>
     <tr>
-      <td><strong>Moab to Catalog</strong><br/>moab-versioning integrity checks run for locally stored Moabs and verified against database info.</td>
+      <td><strong>Moab to Catalog</strong><br/>moab-versioning gem validation for well-formedness (not checksums) run for locally stored Moabs and verified against database info.</td>
       <td>m2c</td>
       <td><strong>Monthly</strong>: 11 am on the 1st of every month</td>
       <td><strong>all</strong>:<br/>queued by walking directories on MoabStorageRoot.storage_location</td>

--- a/db/README.md
+++ b/db/README.md
@@ -65,7 +65,7 @@ To generate the updated ER diagram
 
 ### Basic database advice / pres cat specific guidelines
 
-Preservation Catalog uses PostgreSQL to store metadata about the last known state of all known copies of preserved SDR objects. It relies heavily on DB-level integrity constraints for keeping data consistent.
+Preservation Catalog uses PostgreSQL to store metadata about the last known state of all known copies of preserved SDR objects. It relies heavily on DB-level constraints for keeping data consistent.
 
 The Rails API docs: http://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html
 


### PR DESCRIPTION
## Why was this change made? 🤔

Andrew mentioned recently that "integrity" was being used in a way that he found troubling:

> My suggestion was to use “completeness” to refer to a Moab that has all the manifests and all the files in the right places in the manifests (including size checks). I think of integrity including all of that plus checksums.

This PR attemtps to address that.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



