### PR TITLE
resque references become sidekiq references

### DIFF
--- a/.github/ISSUE_TEMPLATE/storage-migration-checklist-short.md
+++ b/.github/ISSUE_TEMPLATE/storage-migration-checklist-short.md
@@ -16,7 +16,7 @@ assignees: ''
 - More info is available here _(please read before proceeding)_: https://github.com/sul-dlss/preservation_catalog/wiki/Storage-Migration---Additional-Information
 
 - Keep an eye out for Honeybadger errors from preservation_catalog and from preservation_robots.
-- Keep an eye out for failed prescat resque worker jobs.
+- Keep an eye out for failed prescat sidekiq (redis) worker jobs.
 
 ## Audit Reports Before Cutover Weekend
 
@@ -24,7 +24,7 @@ Run all validation checks on Moabs and generate reports.  Note that error detail
 
 ### M2C (moab to catalog -- ensure everything on the disk is currently in the catalog)
 - [ ] run on storage root: ```RAILS_ENV=production bundle exec rake prescat:audit:m2c[stor_root_name]```
-  - [ ] requeue failed jobs / ensure no jobs failed via resque GUI https://preservation-catalog-prod-01.stanford.edu/resque/overview
+  - [ ] requeue failed jobs / ensure no jobs failed via sidekiq GUI https://preservation-catalog-prod-01.stanford.edu/queues
   - [ ] the run should be finished when all jobs in the `m2c` queue have been worked (queue is back down to 0)
 - [ ] after M2C finishes, generate report for objects with error status ```RAILS_ENV=production bundle exec rake prescat:reports:msr_moab_audit_errors[stor_root_name,m2c_b4]```
 - [ ] note druids for each existing M2C error (from report in /opt/app/pres/preservation_catalog/current/log/reports)
@@ -32,7 +32,7 @@ Run all validation checks on Moabs and generate reports.  Note that error detail
 
 ### C2M (catalog to moab -- ensure everything in the catalog for that disk actually exists on the disk)
 - [ ] run on storage root ```RAILS_ENV=production bundle exec rake prescat:audit:c2m[stor_root_name]```
-  - [ ] requeue failed jobs / ensure no jobs failed via resque GUI https://preservation-catalog-prod-01.stanford.edu/resque/overview
+  - [ ] requeue failed jobs / ensure no jobs failed via sidekiq GUI https://preservation-catalog-prod-01.stanford.edu/queues
   - [ ] the run should be finished when all jobs in the `c2m` queue have been worked (queue is back down to 0)
 - [ ] after C2M finishes, generate report for objects with error status ```RAILS_ENV=production bundle exec rake prescat:reports:msr_moab_audit_errors[stor_root_name,c2m_b4]```
 - [ ] note druids for each existing C2M error (from report in /opt/app/pres/preservation_catalog/current/log/reports)

--- a/app/components/dashboard/audit_status_component.html.erb
+++ b/app/components/dashboard/audit_status_component.html.erb
@@ -53,7 +53,7 @@
         </span>
       </li>
       <li class="list-group-item d-flex justify-content-between align-items-center">
-        <h6><a href="resque">Redis queues</a></h6>
+        <h6><a href="queues">Redis queues</a></h6>
       </li>
     </ul>
   </div>

--- a/app/components/dashboard/replication_status_component.html.erb
+++ b/app/components/dashboard/replication_status_component.html.erb
@@ -27,7 +27,7 @@
         </li>
       <% end %>
       <li class="list-group-item d-flex justify-content-between align-items-center">
-        <h6><a href="resque">Redis queues</a></h6>
+        <h6><a href="queues">Redis queues</a></h6>
       </li>
     </ul>
   </div>

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -18,7 +18,7 @@ class ApiController < ActionController::API
   # appropritaly small workgroup.
   def non_api_route?
     # no need to list /status (okcomputer) URLs here, because those aren't handled by ApplicationController
-    request.fullpath.match(%r{^/(resque)|(dashboard)(/.*)?$})
+    request.fullpath.match(%r{^/(queues)|(dashboard)(/.*)?$})
   end
 
   def check_auth_token!

--- a/spec/components/dashboard/audit_status_component_spec.rb
+++ b/spec/components/dashboard/audit_status_component_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe Dashboard::AuditStatusComponent, type: :component do
     expect(rendered).to match(/Moab to Catalog/) # sub status
     expect(rendered).to match(/Catalog to Archive/) # sub status
     expect(rendered_html).to match('OK') # actual status data
-    expect(rendered_html).to match(%r{<a href="resque">Redis queues</a>}) # link to redis
+    expect(rendered_html).to match(%r{<a href="queues">Redis queues</a>}) # link to redis
   end
 end

--- a/spec/components/dashboard/replication_status_component_spec.rb
+++ b/spec/components/dashboard/replication_status_component_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe Dashboard::ReplicationStatusComponent, type: :component do
     expect(rendered).to match(/ZipPart Statuses/) # sub status
     expect(rendered).to match(/Endpoint:/) # sub status
     expect(rendered_html).to match('OK') # actual status data
-    expect(rendered_html).to match(%r{<a href="resque">Redis queues</a>}) # link to redis
+    expect(rendered_html).to match(%r{<a href="queues">Redis queues</a>}) # link to redis
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

because we switched to sidekiq.

Fixes #2090 

## How was this change tested? 🤨

CI

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



