### PR TITLE
UniqueJob: update comment about borrowed code to reduce confusion

### DIFF
--- a/app/jobs/concerns/unique_job.rb
+++ b/app/jobs/concerns/unique_job.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# Q: Why copy the logic out of resque-lock instead of using the gem?
-# A: It's a small amount of (MIT licensed) code, the gem is and unmaintained (last updated in 2012),
-# and the lock cleanup hook wasn't getting invoked automatically in our jobs.  Inlining the code
-# reduces indirection and dependency (on both resque-lock and on Resque itself, since we use ActiveJob
-# hooks here instead of Resque hooks).
+# Q: Why copy the logic out of resque-lock instead of using the gem?  This app doesn't even use Resque anymore!
+# A: It's a small amount of (MIT licensed) code, it uses a general Redis pattern that still works with Sidekiq,
+# resque-lock is unmaintained (last updated in 2012), and even before switching to Sidekiq, resque-lock's cleanup
+# hook wasn't getting invoked in our jobs.  Inlining the code fixed that bug, reduced indirection, and removed
+# dependency on both resque-lock and Resque itself (as the inlined code uses ActiveJob hooks instead of Resque hooks).
 
 # @note logic for `before_enqueue` `around_perform`/`clear_lock`, `queue_lock_key`, `before_enqueue_lock`, and
 #   `lock_timeout` from resque-lock.


### PR DESCRIPTION
## Why was this change made? 🤔

acknowledge that it's confusing that we continue to use borrowed old resque-lock code for enforcing job uniqueness with Sidekiq.

(thanks to @ndushay for the suggestion)


## How was this change tested? 🤨

PR review, documentation only

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



