### PR TITLE
Replication::DruidVersionZip gets ZIP_SPLIT_SIZE constant instead of zip_split_size method

### DIFF
--- a/app/components/dashboard/zip_parts_suffixes_component.html.erb
+++ b/app/components/dashboard/zip_parts_suffixes_component.html.erb
@@ -1,6 +1,6 @@
 <div>
   <h4>ZipPart suffix counts</h4>
-  <p>The first ZipPart suffix will always be .zip. If a zip is over 10g, the suffixes of the parts will be .zip, .z01, .z02, etc.</p>
+  <p>The first ZipPart suffix will always be .zip. If a zip is over <%= Replication::DruidVersionZip::ZIP_SPLIT_SIZE %>, the suffixes of the parts will be .zip, .z01, .z02, etc.</p>
   <div class="col-sm-2">
     <table class="table table-bordered table-hover table-sm">
       <thead class="table-info">

--- a/app/models/replication/druid_version_zip.rb
+++ b/app/models/replication/druid_version_zip.rb
@@ -13,6 +13,9 @@ module Replication
 
     delegate :base64digest, :hexdigest, to: :md5
 
+    # the size used with "zip -s" to break up the zip into parts
+    ZIP_SPLIT_SIZE = '10g'
+
     # @param [String] druid
     # @param [Integer] version
     # @param [String] storage_location The path of storage_root/storage_trunk with the druid tree from which the zipped version should be
@@ -146,7 +149,7 @@ module Replication
     # @see #work_dir
     # @return [String] shell command to create this zip
     def zip_command
-      "zip -r0X -s #{zip_split_size} #{file_path} #{druid.id}/#{v_version}"
+      "zip -r0X -s #{ZIP_SPLIT_SIZE} #{file_path} #{druid.id}/#{v_version}"
     end
 
     def zip_version
@@ -160,11 +163,6 @@ module Replication
 
     def zip_size_ok?
       total_part_size > moab_version_size
-    end
-
-    # @return [String] the option included with "zip -s"
-    def zip_split_size
-      '10g'
     end
 
     def moab_version_size

--- a/app/views/dashboard/_replication_information.html.erb
+++ b/app/views/dashboard/_replication_information.html.erb
@@ -4,7 +4,7 @@
 </div>
 <p><strong class="fs-4">PreservedObject</strong> records store the druid and links to db records about both the Moab on local storage and all the replicated instances in the cloud.</p>
 <p><strong class="fs-4">ZippedMoabVersion</strong> records are about a single version of the Moab that is archived as zip file(s) on a particular cloud endpoint.</p>
-<p><strong class="fs-4">ZipPart</strong> records represent the individual zip segments for a ZippedMoabVersion (zips larger than 10g are split into segments) that are replicated to the particular cloud endpoint.</p>
+<p><strong class="fs-4">ZipPart</strong> records represent the individual zip segments for a ZippedMoabVersion (zips larger than <%= Replication::DruidVersionZip::ZIP_SPLIT_SIZE %> are split into segments) that are replicated to the particular cloud endpoint.</p>
 <hr/>
 <div class="row row-cols-2">
   <div class="column col-8">

--- a/spec/components/dashboard/zip_parts_suffixes_component_spec.rb
+++ b/spec/components/dashboard/zip_parts_suffixes_component_spec.rb
@@ -10,5 +10,6 @@ RSpec.describe Dashboard::ZipPartsSuffixesComponent, type: :component do
     expect(rendered).to match(/ZipPart/)
     expect(rendered).to match(/suffix/) # table header
     expect(rendered_html).to match(/\.zip/) # table data
+    expect(rendered_html).to match(/10g/) # reference to Replication::DruidVersionZipPart::ZIP_PART_SIZE
   end
 end

--- a/spec/jobs/zipmaker_job_spec.rb
+++ b/spec/jobs/zipmaker_job_spec.rb
@@ -35,7 +35,7 @@ describe ZipmakerJob do
     let(:druid) { 'bz514sm9647' }
     let(:version) { 1 }
 
-    before { allow(druid_version_zip).to receive(:zip_split_size).and_return('64k') }
+    before { stub_const('Replication::DruidVersionZip::ZIP_SPLIT_SIZE', '64k') }
 
     after { FileUtils.rm_rf(File.join(Settings.zip_storage, 'bz/514/sm/9647')) }
 

--- a/spec/models/replication/druid_version_zip_spec.rb
+++ b/spec/models/replication/druid_version_zip_spec.rb
@@ -181,7 +181,7 @@ describe Replication::DruidVersionZip do
 
     context 'for every part' do
       before do
-        allow(dvz).to receive(:zip_split_size).and_return('1m')
+        stub_const('ZIP_SPLIT_SIZE', '1m')
         allow(dvz).to receive(:zip_size_ok?).and_return(true)
       end
 
@@ -200,7 +200,7 @@ describe Replication::DruidVersionZip do
       before { allow(dvz).to receive(:zip_command).and_return(zip_command) }
 
       context 'when inpath is incorrect' do
-        let(:zip_command) { "zip -r0X -s 10g #{zip_path} /wrong/path" }
+        let(:zip_command) { "zip -r0X -s #{Replication::DruidVersionZip::ZIP_SPLIT_SIZE} #{zip_path} /wrong/path" }
 
         it 'raises error' do
           expect { dvz.create_zip! }.to raise_error(RuntimeError, %r{zipmaker failure.*/wrong/path}m)
@@ -216,7 +216,7 @@ describe Replication::DruidVersionZip do
       end
 
       context 'if the utility "moved"' do
-        let(:zip_command) { "zap -r0X -s 10g #{zip_path} #{druid}/v0003" }
+        let(:zip_command) { "zap -r0X -s #{Replication::DruidVersionZip::ZIP_SPLIT_SIZE} #{zip_path} #{druid}/v0003" }
 
         it 'raises error' do
           expect { dvz.create_zip! }.to raise_error(Errno::ENOENT, /No such file/)
@@ -305,7 +305,7 @@ describe Replication::DruidVersionZip do
     let(:dvz) { described_class.new(druid, version, 'spec/fixtures/storage_root02/sdr2objects') }
 
     before do
-      allow(dvz).to receive(:zip_split_size).and_return('1m')
+      stub_const('Replication::DruidVersionZip::ZIP_SPLIT_SIZE', '1m')
       FileUtils.rm_rf('/tmp/dc') # prep clean dir
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2037

Since it IS a hardcoded constant, and since it was hard for me to find when writing the dashboard views, this was warranted.

CodeClimate is out of it's little mind.


## How was this change tested? 🤨

specs and CI

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



