### PR TITLE
dashboard: sort zip part suffixes numerically

### DIFF
--- a/app/components/dashboard/zip_parts_suffixes_component.html.erb
+++ b/app/components/dashboard/zip_parts_suffixes_component.html.erb
@@ -1,6 +1,7 @@
 <div>
   <h4>ZipPart suffix counts</h4>
   <p>The first ZipPart suffix will always be .zip. If a zip is over <%= Replication::DruidVersionZip::ZIP_SPLIT_SIZE %>, the suffixes of the parts will be .zip, .z01, .z02, etc.</p>
+  <p>The count column should be descending.</p>
   <div class="col-sm-2">
     <table class="table table-bordered table-hover table-sm">
       <thead class="table-info">

--- a/app/components/dashboard/zip_parts_suffixes_component.rb
+++ b/app/components/dashboard/zip_parts_suffixes_component.rb
@@ -4,5 +4,9 @@ module Dashboard
   # methods for dashboard pertaining to ZipPartsSuffixesComponent
   class ZipPartsSuffixesComponent < ViewComponent::Base
     include Dashboard::ReplicationService
+
+    def sorted_zip_parts_suffixes
+      zip_part_suffixes.keys.sort_by { |s| s == '.zip' ? 0 : s.scan(/\d+/).first.to_i }
+    end
   end
 end

--- a/spec/components/dashboard/zip_parts_suffixes_component_spec.rb
+++ b/spec/components/dashboard/zip_parts_suffixes_component_spec.rb
@@ -12,4 +12,26 @@ RSpec.describe Dashboard::ZipPartsSuffixesComponent, type: :component do
     expect(rendered_html).to match(/\.zip/) # table data
     expect(rendered_html).to match(/10g/) # reference to Replication::DruidVersionZipPart::ZIP_PART_SIZE
   end
+
+  describe '#sorted_zip_parts_suffixes' do
+    let(:unsorted) do
+      {
+        '.z01' => 12,
+        '.z05' => 10,
+        '.zip' => 25,
+        '.z10' => 5,
+        '.z100' => 1
+      }
+    end
+    let(:class_instance) { described_class.new }
+
+    before do
+      # this is from Dashboard::ReplicationService
+      allow(class_instance).to receive(:zip_part_suffixes).and_return(unsorted)
+    end
+
+    it 'returns .zip first and rest in numerical order' do
+      expect(class_instance.sorted_zip_parts_suffixes).to eq(%w[.zip .z01 .z05 .z10 .z100])
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2027

To put `.z100` after `.z99`, for example:

### Before

![image](https://user-images.githubusercontent.com/96775/200700770-188d0038-30fb-44fe-8b50-d788e34af17a.png)

### After

(no image because need to deploy to prod for zips that are split into 100 parts)


## How was this change tested? 🤨

unit test, runnning locally and on stage

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



