### PR TITLE
dashboard services get memoization for perf improvement

### DIFF
--- a/spec/services/dashboard/replication_service_spec.rb
+++ b/spec/services/dashboard/replication_service_spec.rb
@@ -45,15 +45,17 @@ RSpec.describe Dashboard::ReplicationService do
   end
 
   describe '#replication_ok?' do
+    let(:endpoint1) { ZipEndpoint.first }
+    let(:endpoint2) { ZipEndpoint.last }
     let(:po1) { create(:preserved_object, current_version: 2) }
     let(:po2) { create(:preserved_object, current_version: 1) }
 
     before do
       # test seeds have 2 ZipEndpoints
-      create(:zipped_moab_version, preserved_object: po1, zip_endpoint: ZipEndpoint.first)
-      create(:zipped_moab_version, preserved_object: po1, zip_endpoint: ZipEndpoint.last)
-      create(:zipped_moab_version, preserved_object: po2, zip_endpoint: ZipEndpoint.first)
-      create(:zipped_moab_version, preserved_object: po2, zip_endpoint: ZipEndpoint.last)
+      create(:zipped_moab_version, preserved_object: po1, zip_endpoint: endpoint1)
+      create(:zipped_moab_version, preserved_object: po1, zip_endpoint: endpoint2)
+      create(:zipped_moab_version, preserved_object: po2, zip_endpoint: endpoint1)
+      create(:zipped_moab_version, preserved_object: po2, zip_endpoint: endpoint2)
     end
 
     context 'when a ZipEndpoint count does not match num_object_versions_per_preserved_object' do


### PR DESCRIPTION
## Why was this change made? 🤔

I started a PR for dashboard performance improvemets a while back.  These are simple memoizations that may help performance a bit.  It seemed better to do this than throw away the work.

Part of #2084.

## How was this change tested? 🤨

CI

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



