### PR TITLE
Fix to Audit::MoabToCatalog module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ MoabStorageRoot.find_each { |msr| msr.m2c_check! }
 #### Single Druid
 To M2C a single druid synchronously, in console:
 ```ruby
-Audit::MoabToCatalog.check_existence_for_druid('jj925bx9565')
+CatalogUtils.check_existence_for_druid('jj925bx9565')
 ```
 
 #### Druid List
@@ -175,7 +175,7 @@ For a predetermined list of druids, a convenience wrapper for the above command 
   - File should not contain headers.
 
 ```ruby
-Audit::MoabToCatalog.check_existence_for_druid_list('/file/path/to/your/csv/druid_list.csv')
+CatalogUtils.check_existence_for_druid_list('/file/path/to/your/csv/druid_list.csv')
 ```
 
 Note: it should not typically be necessary to serialize a list of druids to CSV.  Just iterate over them and use the "Single Druid" approach.


### PR DESCRIPTION
## Why was this change made? 🤔
Naming was incorrect.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



