### PR TITLE
dashbaord audit information gets a couple of notes

### DIFF
--- a/app/components/dashboard/audit_information_component.html.erb
+++ b/app/components/dashboard/audit_information_component.html.erb
@@ -1,5 +1,13 @@
 <h3>Audit Information</h3>
 
+<p>See <a href="https://github.com/sul-dlss/preservation_catalog/wiki/Audits-(basic-info)">Audits (basic info)</a> wiki page for additional information about the different audits.</p>
+
+Note also:
+<ul>
+  <li>MoabRecord.last_moab_validation field indicates the last time catalog_to_moab or checksum_validation was run, NOT the last time the object was found to be valid.</li>
+  <li>If a checksum validation fails for a MoabRecord, other MoabRecord status checks won't run until the status is no longer invalid_checksum.</li>
+</ul>
+
 <table class="table table-bordered border-dark table-hover table-sm">
   <thead class="table-info">
     <tr>


### PR DESCRIPTION
## Why was this change made? 🤔

short answer:  because some things are non-obvious and the audit information part of the dashboard seems like a useful place for them.

longer answer:  I was looking to get rid of some github labels and encountered issue #490

### After

![image](https://user-images.githubusercontent.com/96775/208178156-03456e30-001f-4a50-9a30-aaac58cf8806.png)

### Before

![image](https://user-images.githubusercontent.com/96775/208159465-8f11b261-6603-4c1f-8c17-fc94aa17a867.png)


Closes #490 
Related to #2010

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



