### PR TITLE
Adjust table layout.

### DIFF
--- a/app/components/dashboard/audit_information_component.html.erb
+++ b/app/components/dashboard/audit_information_component.html.erb
@@ -8,63 +8,65 @@ Note also:
   <li>If a checksum validation fails for a MoabRecord, other MoabRecord status checks won't run until the status is no longer invalid_checksum.</li>
 </ul>
 
-<table class="table table-bordered border-dark table-hover table-sm">
-  <thead class="table-info">
-    <tr>
-      <th class="col-sm-2"/>
-      <th class="col-sm-1">redis queue name</th>
-      <th class="col-sm-3">expected frequency<br/>(from app/config/schedule.rb)</th>
-      <th class="col-sm-1">how many objects get queued</th>
-      <th class="col-sm-2">objects with audit timestamps older than threshold</th>
-      <th>objects with errors</th>
-      <th>expired checks</th>
-    </tr>
-  </thead>
-  <tbody class="table-group-divider">
-    <tr>
-      <td><strong>Validate Moab</strong><br/>moab-versioning gem validation for well-formedness (not checksums) run for locally stored Moabs.</td>
-      <td>validate_moab</td>
-      <td><strong>on demand</strong></td>
-      <td><strong>one</strong>:<br/>queued by preservation robot step after updating a Moab</td>
-      <td class="text-end<%= ' table-warning' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
-      <td class="text-end<%= ' table-danger' if any_moab_record_errors? %>"><%= num_moab_record_not_ok %></td>
-      <td class="table-secondary"/>
-    </tr>
-    <tr>
-      <td><strong>Moab to Catalog</strong><br/>moab-versioning gem validation for well-formedness (not checksums) run for locally stored Moabs and verified against database info.</td>
-      <td>m2c</td>
-      <td><strong>Monthly</strong>: 11 am on the 1st of every month</td>
-      <td><strong>all</strong>:<br/>queued by walking directories on MoabStorageRoot.storage_location</td>
-      <td class="text-end<%= ' table-warning' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
-      <td class="text-end<%= ' table-danger' if any_moab_record_errors? %>"><%= num_moab_record_not_ok %></td>
-      <td class="table-secondary"/>
-    </tr>
-    <tr>
-      <td><strong>Catalog to Moab</strong><br/>Database info verified against locally stored Moabs and moab-versioning integrity checks for Moabs.</td>
-      <td>c2m</td>
-      <td><strong>Monthly</strong>: 11 am on the 15th of every month</td>
-      <td><strong>all</strong>:<br/>queued by associated MoabStorageRoot</td>
-      <td class="text-end<%= ' table-warning' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
-      <td class="text-end<%= ' table-danger' if any_moab_record_errors? %>"><%= num_moab_record_not_ok %></td>
-      <td class="table-secondary"/>
-    </tr>
-    <tr>
-      <td><strong>Checksum Validation (CV)</strong><br/>Compare checksums in Moab metadata files on local storage with computed checksums for Moab metadata and content files.</td>
-      <td>checksum_validation</td>
-      <td><strong>Weekly</strong>: 1am on Sunday<br/><em>for MoabRecords with expired checks</em></td>
-      <td><strong>subset</strong>:<br/>expired checksums queued by associated MoabStorageRoot</td>
-      <td class="text-end<%= ' table-warning' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
-      <td class="text-end<%= ' table-danger' unless moab_checksum_validation_audit_ok? %>"><%= MoabRecord.invalid_checksum.count %></td>
-      <td class="text-center<%= ' table-warning' if moabs_with_expired_checksum_validation? %>"><%= num_moab_expired_checksum_validation %><br/><br/>(passing checks expire 90 days after they are run)</td>
-    </tr>
-    <tr>
-      <td><strong>Catalog to Archive</strong><br/>Confirm a PreservedObject has all versions/parts replicated for each of its target endpoints and attempts to backfill missing ones</td>
-      <td>moab_replication_audit<br/>part_audit_aws_s3_east_1<br/>part_audit_aws_s3_west_2<br/>part_audit_ibm_us_south</td>
-      <td><strong>Weekly</strong>: 12am on Wednesday<br/><em>for PreservedObjects with expired checks</em></td>
-      <td><strong>subset</strong>:<br/>expired archive checks for PreservedObjects and their associated ZipParts are queued</td>
-      <td class="text-end<%= ' table-warning' if replication_audits_older_than_threshold? %>">PreservedObject replication audits older than <%= replication_audit_age_threshold %>:<hr/><%= num_replication_audits_older_than_threshold %></td>
-      <td class="text-end<%= ' table-danger' unless zip_parts_ok? %>"><%= num_replication_errors %></td>
-      <td class="text-center"><%= PreservedObject.archive_check_expired.count %><br/><br/>(passing checks expire 90 days after they are run)</td>
-    </tr>
-  </tbody>
-</table>
+<div class="table-responsive">
+  <table class="table table-bordered border-dark table-hover table-sm">
+    <thead class="table-info">
+      <tr>
+        <th class="col-sm-2"/>
+        <th class="col-sm-1">redis queue name</th>
+        <th class="col-sm-3">expected frequency<br/>(from app/config/schedule.rb)</th>
+        <th class="col-sm-1">how many objects get queued</th>
+        <th class="col-sm-2">objects with audit timestamps older than threshold</th>
+        <th>objects with errors</th>
+        <th>expired checks</th>
+      </tr>
+    </thead>
+    <tbody class="table-group-divider">
+      <tr>
+        <td><strong>Validate Moab</strong><br/>moab-versioning gem validation for well-formedness (not checksums) run for locally stored Moabs.</td>
+        <td>validate_moab</td>
+        <td><strong>on demand</strong></td>
+        <td><strong>one</strong>:<br/>queued by preservation robot step after updating a Moab</td>
+        <td class="text-end<%= ' table-warning' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
+        <td class="text-end<%= ' table-danger' if any_moab_record_errors? %>"><%= num_moab_record_not_ok %></td>
+        <td class="table-secondary"/>
+      </tr>
+      <tr>
+        <td><strong>Moab to Catalog</strong><br/>moab-versioning gem validation for well-formedness (not checksums) run for locally stored Moabs and verified against database info.</td>
+        <td>m2c</td>
+        <td><strong>Monthly</strong>: 11 am on the 1st of every month</td>
+        <td><strong>all</strong>:<br/>queued by walking directories on MoabStorageRoot.storage_location</td>
+        <td class="text-end<%= ' table-warning' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
+        <td class="text-end<%= ' table-danger' if any_moab_record_errors? %>"><%= num_moab_record_not_ok %></td>
+        <td class="table-secondary"/>
+      </tr>
+      <tr>
+        <td><strong>Catalog to Moab</strong><br/>Database info verified against locally stored Moabs and moab-versioning integrity checks for Moabs.</td>
+        <td>c2m</td>
+        <td><strong>Monthly</strong>: 11 am on the 15th of every month</td>
+        <td><strong>all</strong>:<br/>queued by associated MoabStorageRoot</td>
+        <td class="text-end<%= ' table-warning' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
+        <td class="text-end<%= ' table-danger' if any_moab_record_errors? %>"><%= num_moab_record_not_ok %></td>
+        <td class="table-secondary"/>
+      </tr>
+      <tr>
+        <td><strong>Checksum Validation (CV)</strong><br/>Compare checksums in Moab metadata files on local storage with computed checksums for Moab metadata and content files.</td>
+        <td>checksum_validation</td>
+        <td><strong>Weekly</strong>: 1am on Sunday<br/><em>for MoabRecords with expired checks</em></td>
+        <td><strong>subset</strong>:<br/>expired checksums queued by associated MoabStorageRoot</td>
+        <td class="text-end<%= ' table-warning' if moab_audits_older_than_threshold? %>">Moab audits older than <%= moab_audit_age_threshold %>:<hr/><%= num_moab_audits_older_than_threshold %></td>
+        <td class="text-end<%= ' table-danger' unless moab_checksum_validation_audit_ok? %>"><%= MoabRecord.invalid_checksum.count %></td>
+        <td class="text-center<%= ' table-warning' if moabs_with_expired_checksum_validation? %>"><%= num_moab_expired_checksum_validation %><br/><br/>(passing checks expire 90 days after they are run)</td>
+      </tr>
+      <tr>
+        <td><strong>Catalog to Archive</strong><br/>Confirm a PreservedObject has all versions/parts replicated for each of its target endpoints and attempts to backfill missing ones</td>
+        <td>moab_replication_audit<br/>part_audit_aws_s3_east_1<br/>part_audit_aws_s3_west_2<br/>part_audit_ibm_us_south</td>
+        <td><strong>Weekly</strong>: 12am on Wednesday<br/><em>for PreservedObjects with expired checks</em></td>
+        <td><strong>subset</strong>:<br/>expired archive checks for PreservedObjects and their associated ZipParts are queued</td>
+        <td class="text-end<%= ' table-warning' if replication_audits_older_than_threshold? %>">PreservedObject replication audits older than <%= replication_audit_age_threshold %>:<hr/><%= num_replication_audits_older_than_threshold %></td>
+        <td class="text-end<%= ' table-danger' unless zip_parts_ok? %>"><%= num_replication_errors %></td>
+        <td class="text-center"><%= PreservedObject.archive_check_expired.count %><br/><br/>(passing checks expire 90 days after they are run)</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/components/dashboard/moab_storage_roots_component.html.erb
+++ b/app/components/dashboard/moab_storage_roots_component.html.erb
@@ -3,7 +3,7 @@
 
   <p><strong class="fs-5">MoabStorageRoot</strong> records represent an on premises storage location for a Moab.</p>
 
-  <div class="col-sm-11">
+  <div class="col-sm-11 table-responsive">
     <table class="table table-bordered table-hover table-sm">
       <thead class="table-info">
         <tr>

--- a/app/components/dashboard/replication_flow_component.html.erb
+++ b/app/components/dashboard/replication_flow_component.html.erb
@@ -3,7 +3,7 @@
 <p>See also <a href="https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md">app/jobs/README.md</a>
 for a diagram and a few words about replication queues/job flow.</p>
 
-<div>
+<div class="table-responsive">
   <table class="table table-bordered border-dark table-hover">
     <thead class="table-info">
       <tr>

--- a/app/views/dashboard/_moab_information.html.erb
+++ b/app/views/dashboard/_moab_information.html.erb
@@ -2,20 +2,14 @@
 <p><strong class="fs-4">PreservedObject</strong> records store the druid and links to db records about both the Moab on local storage and all the replicated instances in the cloud.</p>
 <p><strong class="fs-4">MoabRecord</strong> records are about the Moab on storage.</p>
 <hr/>
-<div class="row row-cols-2">
-  <div class="column col-5">
-    <turbo-frame id="moab-record-versions" src="<%= dashboard_moab_record_versions_path %>" loading="lazy">
-      <%= render Spinner.new %>
-    </turbo-frame>
-  </div>
-  <div class="column col-7">
-    <turbo-frame id="moab-record-info" src="<%= dashboard_moab_record_info_path %>" loading="lazy">
-      <%= render Spinner.new %>
-    </turbo-frame>
-  </div>
-</div>
+<turbo-frame id="moab-record-versions" src="<%= dashboard_moab_record_versions_path %>" loading="lazy">
+  <%= render Spinner.new %>
+</turbo-frame>
 <hr/>
-
+<turbo-frame id="moab-record-info" src="<%= dashboard_moab_record_info_path %>" loading="lazy">
+  <%= render Spinner.new %>
+</turbo-frame>
+<hr/>
 <turbo-frame id="storage-root-data" src="<%= dashboard_storage_root_data_path %>" loading="lazy">
   <%= render Spinner.new %>
 </turbo-frame>

--- a/app/views/dashboard/_replication_information.html.erb
+++ b/app/views/dashboard/_replication_information.html.erb
@@ -6,18 +6,13 @@
 <p><strong class="fs-4">ZippedMoabVersion</strong> records are about a single version of the Moab that is archived as zip file(s) on a particular cloud endpoint.</p>
 <p><strong class="fs-4">ZipPart</strong> records represent the individual zip segments for a ZippedMoabVersion (zips larger than <%= Replication::DruidVersionZip::ZIP_SPLIT_SIZE %> are split into segments) that are replicated to the particular cloud endpoint.</p>
 <hr/>
-<div class="row row-cols-2">
-  <div class="column col-8">
-    <turbo-frame id="replication-endpoints" src="<%= dashboard_replication_endpoints_path %>" loading="lazy">
-      <%= render Spinner.new %>
-    </turbo-frame>
-  </div>
-  <div class="column col-4">
-    <turbo-frame id="replicated-files" src="<%= dashboard_replicated_files_path %>" loading="lazy">
-      <%= render Spinner.new %>
-    </turbo-frame>
-  </div>
-</div>
+<turbo-frame id="replication-endpoints" src="<%= dashboard_replication_endpoints_path %>" loading="lazy">
+  <%= render Spinner.new %>
+</turbo-frame>
+<hr/>
+<turbo-frame id="replicated-files" src="<%= dashboard_replicated_files_path %>" loading="lazy">
+  <%= render Spinner.new %>
+</turbo-frame>
 <hr/>
 <turbo-frame id="replication-flow" src="<%= dashboard_replication_flow_path %>" loading="lazy">
   <%= render Spinner.new %>


### PR DESCRIPTION
closes #2124

## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

Local.

Tables with side-by-side layout changed to vertical layout since tables don't play well in columns.
![image](https://user-images.githubusercontent.com/588335/208193382-6aaa5368-3203-458d-ba43-63a940891928.png)

Wide tables made responsive so they get scroll bars when exceed viewport width.
![image](https://user-images.githubusercontent.com/588335/208193640-f08e6e2c-c303-4176-bf65-28d98f9a10da.png)



