### PR TITLE
Adds query performance instrumentation.

### DIFF
--- a/app/services/instrumentation_support.rb
+++ b/app/services/instrumentation_support.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Methods to support instrumentation
+module InstrumentationSupport
+  # Provides a source annotation for logging queries.
+  # Example: storage_root.moab_records.annotate(source_annotation).sum(:size)
+  # See lib/slow_query_logger.rb
+  def caller
+    # No-op if slow queries are not enabled
+    return unless Settings.slow_queries.enable
+
+    location = Kernel.caller_locations(2, 1).first
+    path = location.path.delete_prefix("#{Rails.root}/")
+
+    "source=#{path}:#{location.lineno} in #{location.base_label}"
+  end
+end

--- a/config/initializers/slow_queries.rb
+++ b/config/initializers/slow_queries.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# See lib/slow_query_logger.rb
+if Settings.slow_queries.enable
+  require 'slow_query_logger'
+
+  # Setup the logger
+  output = Rails.root.join('log/slow_queries.log')
+  logger = SlowQueryLogger.new(output: output, threshold: Settings.slow_queries.threshold)
+
+  # Subscribe to notifications
+  ActiveSupport::Notifications.subscribe('sql.active_record', logger)
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -65,3 +65,7 @@ honeybadger_checkins:
   catalog_to_moab: xyzzy
   checksum_validation: xyzzy
   audit_replication: xyzzy
+
+slow_queries:
+  enable: false
+  threshold: 500

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -23,3 +23,7 @@ zip_endpoints:
     access_key_id: 'foo'
     secret_access_key: 'bar'
 workflow_services_url: 'https://sul-lyberservices-test.stanford.edu/workflow/'
+
+slow_queries:
+  enable: true
+  threshold: 1

--- a/lib/slow_query_logger.rb
+++ b/lib/slow_query_logger.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'digest'
+require 'logger'
+
+# Logs slow queries to a file as reported by ActiveSupport::Notifications
+# Only queries annotated with a source will be logged.
+# For example, PreservedObject.annotate('source=MoabOnStorageService.num_preserved_objects').count
+# Adapted from https://sosedoff.com/2020/02/18/rails-log-slow-queries.html
+class SlowQueryLogger
+  def initialize(threshold:, output: $stdout)
+    @threshold = threshold
+
+    @logger = Logger.new(output)
+    @logger.formatter = method(:formatter)
+  end
+
+  def call(_name, start, finish, _id, payload)
+    sql, source = parse_sql(payload[:sql])
+    return unless source
+    # Skip transaction start/end statements
+    return if sql.match?(/BEGIN|COMMIT|SET|SHOW/)
+
+    duration = duration_for(start, finish)
+    return unless duration >= threshold
+
+    data = {
+      time: start.iso8601,
+      duration_ms: duration,
+      source: source,
+      query: clean_sql(sql),
+      bindings: payload[:type_casted_binds].presence
+    }.compact
+
+    logger.info(data)
+  end
+
+  private
+
+  attr_reader :logger, :threshold
+
+  def duration_for(start, finish)
+    ((finish - start) * 1000).round(0)
+  end
+
+  def formatter(_severity, _time, _progname, data)
+    "#{JSON.dump(data)}\n"
+  end
+
+  def clean_sql(sql)
+    sql.strip.gsub(/(^(\s+)?$\n)/, '').gsub('"', "'")
+  end
+
+  def parse_sql(sql)
+    return unless (matcher = sql.match(%r{(.+) /\* source=(.+) \*/}))
+
+    [matcher[1], matcher[2]]
+  end
+end

--- a/spec/services/dashboard/moab_on_storage_service_spec.rb
+++ b/spec/services/dashboard/moab_on_storage_service_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Dashboard::MoabOnStorageService do
 
       context 'when storage_roots_moab_count does not match MoabRecord.count' do
         before do
-          allow(MoabRecord).to receive(:count).and_return(4)
+          allow_any_instance_of(outer_class).to receive(:num_moab_records).and_return(4) # rubocop:disable RSpec/AnyInstance
         end
 
         it 'false' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'webmock/rspec'
 SimpleCov.start :rails do
   add_filter '/spec/'
   add_filter '/vendor/'
+  add_filter '/lib/'
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
refs #2084

## Why was this change made? 🤔
Support targeted performance instrumentation (in particular, for the dashboard).


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

Tested on stage.

