### PR TITLE
Tweaks slow query.

### DIFF
--- a/app/models/moab_record.rb
+++ b/app/models/moab_record.rb
@@ -45,11 +45,7 @@ class MoabRecord < ApplicationRecord
   }
 
   scope :fixity_check_expired, lambda {
-    joins(:preserved_object)
-      .where(
-        '(last_checksum_validation + (? * INTERVAL \'1 SECOND\')) < CURRENT_TIMESTAMP OR last_checksum_validation IS NULL',
-        Settings.preservation_policy.fixity_ttl
-      )
+    where('last_checksum_validation < ? or last_checksum_validation IS NULL', Time.zone.now - Settings.preservation_policy.fixity_ttl.seconds)
   }
 
   # TODO: create_missing_zipped_moab_versions! would be a better name


### PR DESCRIPTION
refs #2084

## Why was this change made? 🤔
Faster dashboard.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

Rails console.

