### PR TITLE
Adds index to ZipParts.

### DIFF
--- a/db/migrate/20221220212633_add_index_to_zip_parts.rb
+++ b/db/migrate/20221220212633_add_index_to_zip_parts.rb
@@ -1,0 +1,5 @@
+class AddIndexToZipParts < ActiveRecord::Migration[7.0]
+  def change
+    add_index :zip_parts, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_14_121216) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_20_212633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,6 +84,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_14_121216) do
     t.integer "status", default: 1, null: false
     t.datetime "last_existence_check", precision: nil
     t.datetime "last_checksum_validation", precision: nil
+    t.index ["status"], name: "index_zip_parts_on_status"
     t.index ["zipped_moab_version_id", "suffix"], name: "index_zip_parts_on_zipped_moab_version_id_and_suffix", unique: true
     t.index ["zipped_moab_version_id"], name: "index_zip_parts_on_zipped_moab_version_id"
   end


### PR DESCRIPTION
refs #2084

## Why was this change made? 🤔
Address slow queries:
```
{"time":"2022-12-20T09:56:00-08:00","duration_ms":1980,"source":"Dashboard::AuditInformationComponent.num_replication_errors (line 51)","query":"SELECT COUNT(*) FROM 'zip_parts' WHERE 'zip_parts'.'status' != $1","bindings":[0]}
{"time":"2022-12-20T09:56:03-08:00","duration_ms":3204,"source":"Dashboard::ReplicationStatusComponent.num_replication_errors (line 51)","query":"SELECT COUNT(*) FROM 'zip_parts' WHERE 'zip_parts'.'status' != $1","bindings":[0]}
```


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



