### PR TITLE
Replication error query

### DIFF
--- a/app/services/dashboard/replication_service.rb
+++ b/app/services/dashboard/replication_service.rb
@@ -48,11 +48,16 @@ module Dashboard
     end
 
     def num_replication_errors
-      @num_replication_errors ||= ZipPart.where.not(status: 'ok').annotate(caller).count
+      # This is faster than querying .where.not(status: 'ok')
+      ZipPart.where(status: replication_error_statuses).annotate(caller).count
+    end
+
+    def replication_error_statuses
+      ZipPart.statuses.keys.excluding('ok')
     end
 
     def zip_parts_ok?
-      num_replication_errors.zero?
+      !ZipPart.where(status: replication_error_statuses).annotate(caller).exists?
     end
 
     def zip_parts_unreplicated?


### PR DESCRIPTION
## Why was this change made? 🤔
Faster dashboard


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

Rails / db console

