### PR TITLE
[HOLD] Replication job renames

### DIFF
--- a/app/components/dashboard/replication_flow_component.html.erb
+++ b/app/components/dashboard/replication_flow_component.html.erb
@@ -47,7 +47,7 @@ for a diagram and a few words about replication queues/job flow.</p>
         <td class="fw-bold">PlexerJob</td>
         <td>If necessary, record zip part metadata info in DB. <br/>Call endpoint jobs for zip (parts)</td>
         <td>zips_made</td>
-        <td>S3WestDeliveryJob<br/>AwsEastDeliveryJob<br/>IbmSouthDeliveryJob</td>
+        <td>AwsWestDeliveryJob<br/>AwsEastDeliveryJob<br/>IbmSouthDeliveryJob</td>
         <td>See sidekiq queues</td>
       </tr>
       <tr>

--- a/app/components/dashboard/replication_flow_component.html.erb
+++ b/app/components/dashboard/replication_flow_component.html.erb
@@ -47,11 +47,11 @@ for a diagram and a few words about replication queues/job flow.</p>
         <td class="fw-bold">PlexerJob</td>
         <td>If necessary, record zip part metadata info in DB. <br/>Call endpoint jobs for zip (parts)</td>
         <td>zips_made</td>
-        <td>S3WestDeliveryJob<br/>S3EastDeliveryJob<br/>IbmSouthDeliveryJob</td>
+        <td>S3WestDeliveryJob<br/>AwsEastDeliveryJob<br/>IbmSouthDeliveryJob</td>
         <td>See sidekiq queues</td>
       </tr>
       <tr>
-        <td>S3 endpoint jobs:<br/><strong>S3EastDeliveryJob</strong><br/><strong>S3WeDeliveryJob</strong><br/><strong>IBMSouthDeliveryJob</strong></td>
+        <td>S3 endpoint jobs:<br/><strong>AwsEastDeliveryJob</strong><br/><strong>S3WeDeliveryJob</strong><br/><strong>IBMSouthDeliveryJob</strong></td>
         <td>Posts individual zip (part) to S3 endpoint if not there already.</td>
         <td><br/>s3_us_east_1_delivery<br/>s3_us_west_2_delivery<br/>ibm_us_south_delivery</td>
         <td>ResultsRecorderJob if zip (part) posted</td>

--- a/app/jobs/README.md
+++ b/app/jobs/README.md
@@ -4,12 +4,12 @@ Basically just notes from an infrastructure team knowledge transfer meeting for 
 
 _Note: This is only an explanation of the replication flow, since the other workers are relatively straightforward, and don't hand off jobs to other workers._
 
-Much of the replication happens automatically via ActiveRecord hooks -- e.g. when a CompleteMoab is created, the associated records for the ZippedMoabVersions are automatically created.  Upon creation of those records, a job is queued for each so that the zip file for each version eventually gets created.  After that, each worker calls the next worker in the chain upon success (ZipmakerJob -> PlexerJob -> [S3WestDeliveryJob, IbmSouthDeliveryJob] -> ResultsRecorderJob).
+Much of the replication happens automatically via ActiveRecord hooks -- e.g. when a CompleteMoab is created, the associated records for the ZippedMoabVersions are automatically created. Upon creation of those records, a job is queued for each so that the zip file for each version eventually gets created. After that, each worker calls the next worker in the chain upon success (ZipmakerJob -> PlexerJob -> [AwsEastDeliveryJob, AwsWestDeliveryJob, IbmSouthDeliveryJob] -> ResultsRecorderJob).
 
-The worker that makes zips and the workers that do delivery are intentionally designed to not need the DB.  Though they are Rails workers in the Pres Cat app at the moment, we could rewrite them in something else in another codebase later, if we felt that would be more performant (and worth the effort).  Plexer and ResultsRecorder must query and update the DB, and so have to know about it.
+The worker that makes zips and the workers that do delivery are intentionally designed to not need the DB. Though they are Rails workers in the Pres Cat app at the moment, we could rewrite them in something else in another codebase later, if we felt that would be more performant (and worth the effort). Plexer and ResultsRecorder must query and update the DB, and so have to know about it.
 
 In general, all work that happens via a queue takes a variable (possibly long) amount of time, and/or is failure prone and benefits from retries, and/or is a chokepoint at which a further step is gated.
 
 ![Replication Flow Diagram](replication_flow_diagram_2019-04-24.png)
 
-The above was generated from this Lucid Chart diagram:  https://www.lucidchart.com/documents/edit/d680072f-68e3-4644-91d3-4f20a3fdcd12/0
+The above was generated from this Lucid Chart diagram: https://www.lucidchart.com/documents/edit/d680072f-68e3-4644-91d3-4f20a3fdcd12/0

--- a/app/jobs/aws_east_delivery_job.rb
+++ b/app/jobs/aws_east_delivery_job.rb
@@ -4,7 +4,7 @@
 # @note this class name appears in the configuration for the endpoints for which it delivers content.
 #   Please update the configs for the various environments if it's renamed or moved.
 # @note This name is slightly misleading, as this class solely deals with AWS US East 1 endpoint
-class S3EastDeliveryJob < AbstractDeliveryJob
+class AwsEastDeliveryJob < AbstractDeliveryJob
   queue_as :s3_us_east_1_delivery
 
   def bucket

--- a/app/jobs/aws_west_delivery_job.rb
+++ b/app/jobs/aws_west_delivery_job.rb
@@ -4,7 +4,7 @@
 # @note this class name appears in the configuration for the endpoints for which it delivers content.
 #   Please update the configs for the various environments if it's renamed or moved.
 # @note This name is slightly misleading, as this class solely deals with AWS US West 2 endpoint
-class S3WestDeliveryJob < AbstractDeliveryJob
+class AwsWestDeliveryJob < AbstractDeliveryJob
   queue_as :s3_us_west_2_delivery
 
   def bucket

--- a/app/models/zip_endpoint.rb
+++ b/app/models/zip_endpoint.rb
@@ -8,7 +8,7 @@ class ZipEndpoint < ApplicationRecord
   # @note Hash values cannot be modified without migrating any associated persisted data.
   # @see [enum docs] http://api.rubyonrails.org/classes/ActiveRecord/Enum.html
   enum delivery_class: {
-    'S3WestDeliveryJob' => 1,
+    'AwsWestDeliveryJob' => 1,
     'AwsEastDeliveryJob' => 2,
     'IbmSouthDeliveryJob' => 3
   }

--- a/app/models/zip_endpoint.rb
+++ b/app/models/zip_endpoint.rb
@@ -9,7 +9,7 @@ class ZipEndpoint < ApplicationRecord
   # @see [enum docs] http://api.rubyonrails.org/classes/ActiveRecord/Enum.html
   enum delivery_class: {
     'S3WestDeliveryJob' => 1,
-    'S3EastDeliveryJob' => 2,
+    'AwsEastDeliveryJob' => 2,
     'IbmSouthDeliveryJob' => 3
   }
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -18,7 +18,7 @@ zip_endpoints:
     region: 'localhost'
     endpoint_node: 'localhost'
     storage_location: 'bucket_name'
-    delivery_class: 'S3WestDeliveryJob'
+    delivery_class: 'AwsWestDeliveryJob'
     audit_class: 'Audit::ReplicationToAws'
     access_key_id: 'foo'
     secret_access_key: 'bar'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -19,7 +19,7 @@ zip_endpoints:
     region: 'us-west-2'
     endpoint_node: 'us-west-2'
     storage_location: 'sul-sdr-aws-us-west-2-test'
-    delivery_class: 'S3WestDeliveryJob'
+    delivery_class: 'AwsWestDeliveryJob'
     audit_class: 'Audit::ReplicationToAws'
     access_key_id: 'overridden-by-env-var-in-ci'
     secret_access_key: 'overridden-by-env-var-in-ci'

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe DashboardController do
     it 'renders replication endpoints data' do
       expect(response.body).to match(/Endpoint Data/)
       expect(response.body).to match(/ActiveJob class for replication/) # table header
-      expect(response.body).to match(/S3WestDeliveryJob/) # table data
+      expect(response.body).to match(/AwsWestDeliveryJob/) # table data
     end
   end
 

--- a/spec/jobs/integration_spec.rb
+++ b/spec/jobs/integration_spec.rb
@@ -45,10 +45,10 @@ describe 'the whole replication pipeline' do
   it 'gets from zipmaker queue to replication result message upon initial moab creation' do
     expect(ZipmakerJob).to receive(:perform_later).with(druid, version, moab_storage_root.storage_location).and_call_original
     expect(PlexerJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
-    expect(S3WestDeliveryJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
+    expect(AwsWestDeliveryJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
     expect(IbmSouthDeliveryJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
     # other endpoints as added...
-    expect(ResultsRecorderJob).to receive(:perform_later).with(druid, version, s3_key, 'S3WestDeliveryJob').and_call_original
+    expect(ResultsRecorderJob).to receive(:perform_later).with(druid, version, s3_key, 'AwsWestDeliveryJob').and_call_original
     expect(ResultsRecorderJob).to receive(:perform_later).with(druid, version, s3_key, 'IbmSouthDeliveryJob').and_call_original
     expect(Dor::Event::Client).to receive(:create).with(
       druid: "druid:#{druid}",
@@ -76,10 +76,10 @@ describe 'the whole replication pipeline' do
 
       expect(ZipmakerJob).to receive(:perform_later).with(druid, next_version, moab_storage_root.storage_location).and_call_original
       expect(PlexerJob).to receive(:perform_later).with(druid, next_version, s3_key, Hash).and_call_original
-      expect(S3WestDeliveryJob).to receive(:perform_later).with(druid, next_version, s3_key, Hash).and_call_original
+      expect(AwsWestDeliveryJob).to receive(:perform_later).with(druid, next_version, s3_key, Hash).and_call_original
       expect(IbmSouthDeliveryJob).to receive(:perform_later).with(druid, next_version, s3_key, Hash).and_call_original
       # other endpoints as added...
-      expect(ResultsRecorderJob).to receive(:perform_later).with(druid, next_version, s3_key, 'S3WestDeliveryJob').and_call_original
+      expect(ResultsRecorderJob).to receive(:perform_later).with(druid, next_version, s3_key, 'AwsWestDeliveryJob').and_call_original
       expect(ResultsRecorderJob).to receive(:perform_later).with(druid, next_version, s3_key, 'IbmSouthDeliveryJob').and_call_original
       expect(Dor::Event::Client).to receive(:create).with(
         druid: "druid:#{druid}",

--- a/spec/jobs/integration_spec.rb
+++ b/spec/jobs/integration_spec.rb
@@ -45,9 +45,11 @@ describe 'the whole replication pipeline' do
   it 'gets from zipmaker queue to replication result message upon initial moab creation' do
     expect(ZipmakerJob).to receive(:perform_later).with(druid, version, moab_storage_root.storage_location).and_call_original
     expect(PlexerJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
+    expect(AwsEastDeliveryJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
     expect(AwsWestDeliveryJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
     expect(IbmSouthDeliveryJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
     # other endpoints as added...
+    expect(ResultsRecorderJob).to receive(:perform_later).with(druid, version, s3_key, 'AwsEastDeliveryJob').and_call_original
     expect(ResultsRecorderJob).to receive(:perform_later).with(druid, version, s3_key, 'AwsWestDeliveryJob').and_call_original
     expect(ResultsRecorderJob).to receive(:perform_later).with(druid, version, s3_key, 'IbmSouthDeliveryJob').and_call_original
     expect(Dor::Event::Client).to receive(:create).with(

--- a/spec/jobs/plexer_job_spec.rb
+++ b/spec/jobs/plexer_job_spec.rb
@@ -69,7 +69,7 @@ describe PlexerJob do
     it 'splits the message out to endpoints' do
       expect(S3WestDeliveryJob).to receive(:perform_later)
         .with(druid, version, s3_key, a_hash_including(:checksum_md5, :size, :zip_cmd, :zip_version))
-      expect(S3EastDeliveryJob).to receive(:perform_later)
+      expect(AwsEastDeliveryJob).to receive(:perform_later)
         .with(druid, version, s3_key, a_hash_including(:checksum_md5, :size, :zip_cmd, :zip_version))
       expect(IbmSouthDeliveryJob).to receive(:perform_later)
         .with(druid, version, s3_key, a_hash_including(:checksum_md5, :size, :zip_cmd, :zip_version))
@@ -79,7 +79,7 @@ describe PlexerJob do
     it 'ensures zip_part exists with status unreplicated before queueing for delivery' do
       # intercept the jobs that'd try to deliver and mark 'ok'
       allow(S3WestDeliveryJob).to receive(:perform_later)
-      allow(S3EastDeliveryJob).to receive(:perform_later)
+      allow(AwsEastDeliveryJob).to receive(:perform_later)
       allow(IbmSouthDeliveryJob).to receive(:perform_later)
 
       described_class.perform_now(druid, version, s3_key, metadata)

--- a/spec/jobs/plexer_job_spec.rb
+++ b/spec/jobs/plexer_job_spec.rb
@@ -67,7 +67,7 @@ describe PlexerJob do
     end
 
     it 'splits the message out to endpoints' do
-      expect(S3WestDeliveryJob).to receive(:perform_later)
+      expect(AwsWestDeliveryJob).to receive(:perform_later)
         .with(druid, version, s3_key, a_hash_including(:checksum_md5, :size, :zip_cmd, :zip_version))
       expect(AwsEastDeliveryJob).to receive(:perform_later)
         .with(druid, version, s3_key, a_hash_including(:checksum_md5, :size, :zip_cmd, :zip_version))
@@ -78,7 +78,7 @@ describe PlexerJob do
 
     it 'ensures zip_part exists with status unreplicated before queueing for delivery' do
       # intercept the jobs that'd try to deliver and mark 'ok'
-      allow(S3WestDeliveryJob).to receive(:perform_later)
+      allow(AwsWestDeliveryJob).to receive(:perform_later)
       allow(AwsEastDeliveryJob).to receive(:perform_later)
       allow(IbmSouthDeliveryJob).to receive(:perform_later)
 

--- a/spec/jobs/s3_east_delivery_job_spec.rb
+++ b/spec/jobs/s3_east_delivery_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe S3EastDeliveryJob do
+describe AwsEastDeliveryJob do
   it 'descends from AbstractDeliveryJob' do
     expect(described_class.new).to be_an(AbstractDeliveryJob)
   end

--- a/spec/jobs/s3_west_delivery_job_spec.rb
+++ b/spec/jobs/s3_west_delivery_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe S3WestDeliveryJob do
+describe AwsWestDeliveryJob do
   it 'descends from AbstractDeliveryJob' do
     expect(described_class.new).to be_an(AbstractDeliveryJob)
   end

--- a/spec/models/zip_endpoint_spec.rb
+++ b/spec/models/zip_endpoint_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ZipEndpoint do
   end
 
   it 'has multiple delivery_classes' do
-    expect(described_class.delivery_classes).to include('S3WestDeliveryJob', 'AwsEastDeliveryJob')
+    expect(described_class.delivery_classes).to include('AwsWestDeliveryJob', 'AwsEastDeliveryJob')
   end
 
   it { is_expected.to have_many(:zipped_moab_versions) }
@@ -50,7 +50,7 @@ RSpec.describe ZipEndpoint do
           Config::Options.new(
             endpoint_node: 'endpoint_node',
             storage_location: 'storage_location',
-            delivery_class: 'S3WestDeliveryJob',
+            delivery_class: 'AwsWestDeliveryJob',
             audit_class: 'S3::Hal::Audit'
           )
       )
@@ -86,7 +86,7 @@ RSpec.describe ZipEndpoint do
           Config::Options.new(
             endpoint_node: 'endpoint_node',
             storage_location: 'storage_location',
-            delivery_class: 'S3WestDeliveryJob'
+            delivery_class: 'AwsWestDeliveryJob'
           )
       )
       allow(Settings).to receive(:zip_endpoints).and_return(zip_endpoints_setting)

--- a/spec/models/zip_endpoint_spec.rb
+++ b/spec/models/zip_endpoint_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ZipEndpoint do
 
   it 'enforces unique constraint on endpoint_name (model level)' do
     expect do
-      described_class.create!(endpoint_name: 'zip-endpoint', delivery_class: 'S3EastDeliveryJob')
+      described_class.create!(endpoint_name: 'zip-endpoint', delivery_class: 'AwsEastDeliveryJob')
     end.to raise_error(ActiveRecord::RecordInvalid)
   end
 
@@ -25,7 +25,7 @@ RSpec.describe ZipEndpoint do
   end
 
   it 'has multiple delivery_classes' do
-    expect(described_class.delivery_classes).to include('S3WestDeliveryJob', 'S3EastDeliveryJob')
+    expect(described_class.delivery_classes).to include('S3WestDeliveryJob', 'AwsEastDeliveryJob')
   end
 
   it { is_expected.to have_many(:zipped_moab_versions) }


### PR DESCRIPTION
Hold for setting up shared_configs for new, shorter settings name.

## Why was this change made? 🤔

To make code easier to understand, for maintenance.

After this is merged, and deployed, please edit shared_configs to remove old settings names
- [ ] qa
- [ ] stage
- [ ] prod

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



