### PR TITLE
Speed up PreservedObject.archive_check_expired

### DIFF
--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -27,7 +27,7 @@ class PreservedObject < ApplicationRecord
 
   scope :archive_check_expired, lambda {
     where(
-      '(last_archive_audit + (? * INTERVAL \'1 SECOND\')) < CURRENT_TIMESTAMP OR last_archive_audit IS NULL',
+      'last_archive_audit < (CURRENT_TIMESTAMP - (? * INTERVAL \'1 SECOND\')) OR last_archive_audit IS NULL',
       Settings.preservation_policy.archive_ttl
     )
   }


### PR DESCRIPTION
refs #2084

## Why was this change made? 🤔
Speed


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

Rails db / console

