### PR TITLE
rename PlexerJob to DeliveryDispatcherJob

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,10 @@
 
 
 
+
 ## How was this change tested? 🤨
 
-⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
 
 
 
+⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

--- a/app/components/dashboard/replication_flow_component.html.erb
+++ b/app/components/dashboard/replication_flow_component.html.erb
@@ -33,7 +33,7 @@ for a diagram and a few words about replication queues/job flow.</p>
         <td class="fw-bold">ZipmakerJob</td>
         <td>Creates a new DruidVersionZip for S3 endpoint if it doesn't exist. If needed, write zip file(s) to zip cache and calculate checksum(s); otherwise, touch the file(s).</td>
         <td>zipmaker</td>
-        <td>DruidVersionZip.find_or_create_zip!; any returned partkeys each call PlexerJob</td>
+        <td>DruidVersionZip.find_or_create_zip!; any returned partkeys each call DeliveryDispatcherJob</td>
         <td>See sidekiq queues</td>
       </tr>
       <tr>
@@ -44,7 +44,7 @@ for a diagram and a few words about replication queues/job flow.</p>
         <td>Honeybadger</td>
       </tr>
       <tr>
-        <td class="fw-bold">PlexerJob</td>
+        <td class="fw-bold">DeliveryDispatcherJob</td>
         <td>If necessary, record zip part metadata info in DB. <br/>Call endpoint jobs for zip (parts)</td>
         <td>zips_made</td>
         <td>S3WestDeliveryJob<br/>S3EastDeliveryJob<br/>IbmSouthDeliveryJob</td>

--- a/app/jobs/README.md
+++ b/app/jobs/README.md
@@ -4,12 +4,12 @@ Basically just notes from an infrastructure team knowledge transfer meeting for 
 
 _Note: This is only an explanation of the replication flow, since the other workers are relatively straightforward, and don't hand off jobs to other workers._
 
-Much of the replication happens automatically via ActiveRecord hooks -- e.g. when a CompleteMoab is created, the associated records for the ZippedMoabVersions are automatically created.  Upon creation of those records, a job is queued for each so that the zip file for each version eventually gets created.  After that, each worker calls the next worker in the chain upon success (ZipmakerJob -> PlexerJob -> [S3WestDeliveryJob, IbmSouthDeliveryJob] -> ResultsRecorderJob).
+Much of the replication happens automatically via ActiveRecord hooks -- e.g. when a CompleteMoab is created, the associated records for the ZippedMoabVersions are automatically created. Upon creation of those records, a job is queued for each so that the zip file for each version eventually gets created. After that, each worker calls the next worker in the chain upon success (ZipmakerJob -> DeliveryDispatcherJob -> [S3WestDeliveryJob, IbmSouthDeliveryJob] -> ResultsRecorderJob).
 
-The worker that makes zips and the workers that do delivery are intentionally designed to not need the DB.  Though they are Rails workers in the Pres Cat app at the moment, we could rewrite them in something else in another codebase later, if we felt that would be more performant (and worth the effort).  Plexer and ResultsRecorder must query and update the DB, and so have to know about it.
+The worker that makes zips and the workers that do delivery are intentionally designed to not need the DB. Though they are Rails workers in the Pres Cat app at the moment, we could rewrite them in something else in another codebase later, if we felt that would be more performant (and worth the effort). DeliveryDispatcher and ResultsRecorder must query and update the DB, and so have to know about it.
 
 In general, all work that happens via a queue takes a variable (possibly long) amount of time, and/or is failure prone and benefits from retries, and/or is a chokepoint at which a further step is gated.
 
 ![Replication Flow Diagram](replication_flow_diagram_2019-04-24.png)
 
-The above was generated from this Lucid Chart diagram:  https://www.lucidchart.com/documents/edit/d680072f-68e3-4644-91d3-4f20a3fdcd12/0
+The above was generated from this Lucid Chart diagram: https://www.lucidchart.com/documents/edit/d680072f-68e3-4644-91d3-4f20a3fdcd12/0

--- a/app/jobs/abstract_delivery_job.rb
+++ b/app/jobs/abstract_delivery_job.rb
@@ -9,7 +9,7 @@ class AbstractDeliveryJob < ZipPartJobBase
   # @param [Integer] version
   # @param [String] part_s3_key
   # @param [Hash<Symbol => String, Integer>] metadata Zip info
-  # @see PlexerJob#perform warning about why metadata must be passed
+  # @see DeliveryDispatcherJob#perform warning about why metadata must be passed
   def perform(druid, version, part_s3_key, metadata)
     return unless Replication::ZipDeliveryService.deliver(
       s3_part: bucket.object(part_s3_key),

--- a/app/jobs/delivery_dispatcher_job.rb
+++ b/app/jobs/delivery_dispatcher_job.rb
@@ -15,7 +15,7 @@
 # Do not assume we can just get metadata from (the DruidVersionZip) zip.
 # Jobs are not run at the same time or on the same system, so the info may not match.
 # Therefore, we receive the info passed by the process that was there when the file was created.
-class PlexerJob < ZipPartJobBase
+class DeliveryDispatcherJob < ZipPartJobBase
   queue_as :zips_made
 
   before_enqueue do |job|
@@ -53,9 +53,7 @@ class PlexerJob < ZipPartJobBase
       parts_count: metadata[:parts_count],
       size: metadata[:size],
       suffix: File.extname(part_s3_key)
-    ).create_or_find_by(
-      suffix: File.extname(part_s3_key)
-    ) { |part| part.unreplicated! }
+    ).create_or_find_by(suffix: File.extname(part_s3_key), &:unreplicated!)
   end
 
   # @return [Array<Class>] target delivery worker classes

--- a/app/jobs/results_recorder_job.rb
+++ b/app/jobs/results_recorder_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Preconditions:
-# PlexerJob has made a matching ZipPart row
+# DeliveryDispatcherJob has made a matching ZipPart row
 #
 # Responsibilities:
 # Update DB per event info.

--- a/app/jobs/zipmaker_job.rb
+++ b/app/jobs/zipmaker_job.rb
@@ -3,7 +3,7 @@
 # Responsibilities:
 # If needed, zip files to zip storage and calculate checksum(s).
 # Otherwise, touch the existing main ".zip" file to freshen it in cache.
-# Invoke PlexerJob for each zip part.
+# Invoke DeliveryDispatcherJob for each zip part.
 class ZipmakerJob < ApplicationJob
   queue_as :zipmaker
   delegate :find_or_create_zip!, :file_path, :part_keys, to: :zip
@@ -32,7 +32,7 @@ class ZipmakerJob < ApplicationJob
 
     find_or_create_zip!
     part_keys.each do |part_key|
-      PlexerJob.perform_later(druid, version, part_key, Replication::DruidVersionZipPart.new(zip, part_key).metadata)
+      DeliveryDispatcherJob.perform_later(druid, version, part_key, Replication::DruidVersionZipPart.new(zip, part_key).metadata)
     end
   end
 end

--- a/app/models/zip_part.rb
+++ b/app/models/zip_part.rb
@@ -2,7 +2,7 @@
 
 # We chunk archives of Moab versions into multiple files, so we don't get
 # completely unwieldy file sizes.  This represents metadata for one such part.
-# This model's data is populated by PlexerJob.
+# This model's data is populated by DeliveryDispatcherJob.
 class ZipPart < ApplicationRecord
   belongs_to :zipped_moab_version, inverse_of: :zip_parts
   delegate :zip_endpoint, :preserved_object, to: :zipped_moab_version

--- a/spec/jobs/delivery_dispatcher_job_spec.rb
+++ b/spec/jobs/delivery_dispatcher_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PlexerJob do
+describe DeliveryDispatcherJob do
   let(:dvz) { Replication::DruidVersionZip.new(druid, version) }
   let(:druid) { 'bj102hs9687' }
   let(:version) { 1 }

--- a/spec/jobs/integration_spec.rb
+++ b/spec/jobs/integration_spec.rb
@@ -44,7 +44,7 @@ describe 'the whole replication pipeline' do
 
   it 'gets from zipmaker queue to replication result message upon initial moab creation' do
     expect(ZipmakerJob).to receive(:perform_later).with(druid, version, moab_storage_root.storage_location).and_call_original
-    expect(PlexerJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
+    expect(DeliveryDispatcherJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
     expect(S3WestDeliveryJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
     expect(IbmSouthDeliveryJob).to receive(:perform_later).with(druid, version, s3_key, Hash).and_call_original
     # other endpoints as added...
@@ -75,7 +75,7 @@ describe 'the whole replication pipeline' do
       create(:moab_record, preserved_object: preserved_object, version: version, moab_storage_root: moab_storage_root)
 
       expect(ZipmakerJob).to receive(:perform_later).with(druid, next_version, moab_storage_root.storage_location).and_call_original
-      expect(PlexerJob).to receive(:perform_later).with(druid, next_version, s3_key, Hash).and_call_original
+      expect(DeliveryDispatcherJob).to receive(:perform_later).with(druid, next_version, s3_key, Hash).and_call_original
       expect(S3WestDeliveryJob).to receive(:perform_later).with(druid, next_version, s3_key, Hash).and_call_original
       expect(IbmSouthDeliveryJob).to receive(:perform_later).with(druid, next_version, s3_key, Hash).and_call_original
       # other endpoints as added...

--- a/spec/jobs/zipmaker_job_spec.rb
+++ b/spec/jobs/zipmaker_job_spec.rb
@@ -11,7 +11,7 @@ describe ZipmakerJob do
   let(:moab_replication_storage_location) { 'spec/fixtures/storage_root01/sdr2objects' }
 
   before do
-    allow(PlexerJob).to receive(:perform_later).with(any_args)
+    allow(DeliveryDispatcherJob).to receive(:perform_later).with(any_args)
     allow(Settings).to receive(:zip_storage).and_return(Rails.root.join('spec', 'fixtures', 'zip_storage'))
     allow(Replication::DruidVersionZip).to receive(:new).with(druid, version, moab_replication_storage_location).and_return(druid_version_zip)
   end
@@ -21,8 +21,8 @@ describe ZipmakerJob do
     FileUtils.rm_rf(File.join(Settings.zip_storage, 'bj/102/hs/9687/bj102hs9687.v0003.zip.md5'))
   end
 
-  it 'invokes PlexerJob (single part zip)' do
-    expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bj/102/hs/9687/bj102hs9687.v0003.zip', Hash)
+  it 'invokes DeliveryDispatcherJob (single part zip)' do
+    expect(DeliveryDispatcherJob).to receive(:perform_later).with(druid, version, 'bj/102/hs/9687/bj102hs9687.v0003.zip', Hash)
     described_class.perform_now(druid, version, moab_replication_storage_location)
   end
 
@@ -39,12 +39,12 @@ describe ZipmakerJob do
 
     after { FileUtils.rm_rf(File.join(Settings.zip_storage, 'bz/514/sm/9647')) }
 
-    it 'handles segmented zips, invokes PlexerJob per part' do
+    it 'handles segmented zips, invokes DeliveryDispatcherJob per part' do
       # v1 of bz514sm9647 is 232kB, so we'd expect 4 segments if we split at 64k
-      expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.zip', Hash)
-      expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.z01', Hash)
-      expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.z02', Hash)
-      expect(PlexerJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.z03', Hash)
+      expect(DeliveryDispatcherJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.zip', Hash)
+      expect(DeliveryDispatcherJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.z01', Hash)
+      expect(DeliveryDispatcherJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.z02', Hash)
+      expect(DeliveryDispatcherJob).to receive(:perform_later).with(druid, version, 'bz/514/sm/9647/bz514sm9647.v0001.z03', Hash)
       described_class.perform_now(druid, version, moab_replication_storage_location)
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

more obvious naming makes maintenance easier.

Part of #2063

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, ***run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation***, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `PlexerJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡



