### PR TITLE
Speed up replication status

### DIFF
--- a/app/components/dashboard/replication_status_component.rb
+++ b/app/components/dashboard/replication_status_component.rb
@@ -4,6 +4,5 @@ module Dashboard
   # methods for dashboard pertaining to ReplicationStatusComponent
   class ReplicationStatusComponent < ViewComponent::Base
     include Dashboard::ReplicationService
-    include Dashboard::MoabOnStorageService
   end
 end

--- a/spec/services/dashboard/replication_service_spec.rb
+++ b/spec/services/dashboard/replication_service_spec.rb
@@ -101,12 +101,8 @@ RSpec.describe Dashboard::ReplicationService do
     let(:endpoint2) { ZipEndpoint.last }
 
     before do
-      zmv_rel1 = ZippedMoabVersion.where(zip_endpoint_id: endpoint1.id)
-      zmv_rel2 = ZippedMoabVersion.where(zip_endpoint_id: endpoint2.id)
-      allow(zmv_rel1).to receive(:count).and_return(5)
-      allow(zmv_rel2).to receive(:count).and_return(2)
-      allow(ZippedMoabVersion).to receive(:where).with(zip_endpoint_id: endpoint1.id).and_return(zmv_rel1)
-      allow(ZippedMoabVersion).to receive(:where).with(zip_endpoint_id: endpoint2.id).and_return(zmv_rel2)
+      5.times { create(:zipped_moab_version, zip_endpoint: endpoint1) }
+      2.times { create(:zipped_moab_version, zip_endpoint: endpoint2) }
     end
 
     it 'returns a hash with endpoint_name keys and values of Hash with delivery_class and replication_count' do


### PR DESCRIPTION
## Why was this change made? 🤔
Speed



## How was this change tested? 🤨

Prod


⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
