### PR TITLE
Remove total zip part size.

### DIFF
--- a/app/components/dashboard/replication_files_component.html.erb
+++ b/app/components/dashboard/replication_files_component.html.erb
@@ -8,7 +8,6 @@
       <thead class="table-info">
         <tr>
           <th>Total ZipParts (count)</th>
-          <th>Total Size of all ZipParts</th>
           <th class="text-center">ok</th>
           <th class="text-center">replicated checksum mismatch</th>
           <th class="text-center">unreplicated</th>
@@ -18,7 +17,6 @@
       <tbody class="table-group-divider">
         <tr>
           <td><%= ZipPart.count %></td>
-          <td><%= zip_parts_total_size %></td>
           <td class="text-end"><%= ZipPart.ok.count %></td>
           <td class="text-end<%= ' table-danger' if zip_parts_replicated_checksum_mismatch? %>"><%= ZipPart.replicated_checksum_mismatch.count %></td>
           <td class="text-end<%= ' table-warning' if zip_parts_unreplicated? %>"><%= ZipPart.unreplicated.count %></td>

--- a/app/services/dashboard/replication_service.rb
+++ b/app/services/dashboard/replication_service.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-require 'action_view' # for number_to_human_size
-
 # services for dashboard
 module Dashboard
   # methods pertaining to replication (cloud storage) tables in database for dashboard
   module ReplicationService
-    include ActionView::Helpers::NumberHelper # for number_to_human_size
     include InstrumentationSupport
 
     def replication_and_zip_parts_ok?
@@ -45,10 +42,6 @@ module Dashboard
     def zip_part_suffixes
       # called multiple times, so memoize to avoid db queries
       @zip_part_suffixes ||= ZipPart.group(:suffix).annotate(caller).count
-    end
-
-    def zip_parts_total_size
-      number_to_human_size(ZipPart.all.annotate(caller).sum(:size))
     end
 
     def num_replication_errors

--- a/spec/components/dashboard/replication_files_component_spec.rb
+++ b/spec/components/dashboard/replication_files_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dashboard::ReplicationFilesComponent, type: :component do
   it 'renders Replication Files information' do
     expect(rendered).to match(/Replication Files/)
     expect(rendered).to match(/unreplicated/) # table header
-    expect(rendered_html).to match(/0 Bytes/) # table data
+    expect(rendered_html).to match(/0/) # table data
   end
 
   it 'renders ok status count with plain styling' do

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe DashboardController do
     it 'renders replicated files data' do
       expect(response.body).to match(/Replication Files/)
       expect(response.body).to match(/Total ZipParts/) # table header
-      expect(response.body).to match(/Bytes/) # table data
+      expect(response.body).to match(/0/) # table data
     end
   end
 

--- a/spec/services/dashboard/replication_service_spec.rb
+++ b/spec/services/dashboard/replication_service_spec.rb
@@ -124,18 +124,6 @@ RSpec.describe Dashboard::ReplicationService do
     end
   end
 
-  describe '#zip_parts_total_size' do
-    before do
-      create(:zip_part, size: Numeric::TERABYTE * 1)
-      create(:zip_part, size: ((Numeric::TERABYTE * 2) + (Numeric::GIGABYTE * 500)))
-      create(:zip_part, size: (Numeric::TERABYTE * 3))
-    end
-
-    it 'returns the total size of ZipParts in Terabytes as a string' do
-      expect(outer_class.new.zip_parts_total_size).to eq '6.49 TB'
-    end
-  end
-
   describe '#num_replication_errors' do
     before do
       create(:zip_part, status: 'unreplicated')


### PR DESCRIPTION
refs #2084

## Why was this change made? 🤔
This query is slow and not crucial.



## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
