### PR TITLE
Changes for performance of replication files component.

### DIFF
--- a/app/components/dashboard/replication_files_component.html.erb
+++ b/app/components/dashboard/replication_files_component.html.erb
@@ -18,9 +18,9 @@
         <tr>
           <td><%= ZipPart.count %></td>
           <td class="text-end"><%= ZipPart.ok.count %></td>
-          <td class="text-end<%= ' table-danger' if zip_parts_replicated_checksum_mismatch? %>"><%= ZipPart.replicated_checksum_mismatch.count %></td>
-          <td class="text-end<%= ' table-warning' if zip_parts_unreplicated? %>"><%= ZipPart.unreplicated.count %></td>
-          <td class="text-end<%= ' table-danger' if zip_parts_not_found? %>"><%= ZipPart.not_found.count %></td>
+          <td class="text-end<%= ' table-danger' if zip_parts_replicated_checksum_mismatch? %>"><%= zip_parts_replicated_checksum_mismatch_count %></td>
+          <td class="text-end<%= ' table-warning' if zip_parts_unreplicated? %>"><%= zip_parts_unreplicated_count %></td>
+          <td class="text-end<%= ' table-danger' if zip_parts_not_found? %>"><%= zip_parts_not_found_count %></td>
         </tr>
       </tbody>
     </table>

--- a/app/services/dashboard/replication_service.rb
+++ b/app/services/dashboard/replication_service.rb
@@ -52,16 +52,28 @@ module Dashboard
       !ZipPart.where(status: replication_error_statuses).annotate(caller).exists?
     end
 
+    def zip_parts_unreplicated_count
+      ZipPart.unreplicated.annotate(caller).count
+    end
+
     def zip_parts_unreplicated?
-      ZipPart.unreplicated.annotate(caller).count.positive?
+      zip_parts_unreplicated_count.positive?
+    end
+
+    def zip_parts_not_found_count
+      ZipPart.not_found.annotate(caller).count
     end
 
     def zip_parts_not_found?
-      ZipPart.not_found.annotate(caller).count.positive?
+      zip_parts_not_found_count.positive?
+    end
+
+    def zip_parts_replicated_checksum_mismatch_count
+      ZipPart.replicated_checksum_mismatch.annotate(caller).count
     end
 
     def zip_parts_replicated_checksum_mismatch?
-      ZipPart.replicated_checksum_mismatch.annotate(caller).count.positive?
+      zip_parts_replicated_checksum_mismatch_count.positive?
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Improve performance and move some hidden queries out of the component views.



## How was this change tested? 🤨

Prod


⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
