### PR TITLE
For dashboard, do not load any tabs by default.

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -24,7 +24,7 @@
   <div class="row row-cols-2">
     <div class="col-3 col-rows-3 sidenav">
       <ul class="nav nav-pills row-3" id="dashboardTab">
-        <li class="nav-link active text-reset" id="catalog-tab" data-bs-toggle="pill" data-bs-target="#catalog-tab-pane" type="button" aria-selected="true">
+        <li class="nav-link text-reset" id="catalog-tab" data-bs-toggle="pill" data-bs-target="#catalog-tab-pane" type="button" aria-selected="true">
           <turbo-frame id="moab-status" src="<%= dashboard_moab_storage_status_path %>" loading="lazy">
             <%= render Spinner.new %>
           </turbo-frame>
@@ -42,7 +42,7 @@
       </ul>
     </div>
     <div class="tab-content col-9" id="main">
-      <div class="tab-pane fade show active" id="catalog-tab-pane" role="tabpanel" aria-selected="true" tabindex="0">
+      <div class="tab-pane fade" id="catalog-tab-pane" role="tabpanel" aria-selected="true" tabindex="0">
         <%= render partial: 'moab_information' %>
       </div>
       <div class="tab-pane fade" id="replication-tab-pane" role="tabpanel" aria-labelledby="replication-tab" tabindex="0">


### PR DESCRIPTION
## Why was this change made? 🤔
Performance.



## How was this change tested? 🤨

QA


⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
