### PR TITLE
Remove unnecessary dashboard render.

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -49,7 +49,9 @@
         <%= render partial: 'replication_information' %>
       </div>
       <div class="tab-pane fade" id="audit-tab-pane" role="tabpanel" aria-labelledby="audit-tab" tabindex="0">
-        <%= render partial: 'audit_info' %>
+        <turbo-frame id="audit-info" src="<%= dashboard_audit_info_path %>" loading="lazy">
+          <%= render Spinner.new %>
+        </turbo-frame>
       </div>
     </div>
   </div>

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe DashboardController do
       end
     end
 
-    it 'renders _audit_info template' do
-      expect(response).to render_template('dashboard/_audit_info')
+    it 'renders turbo-frame for audit_info path' do
+      expect(response.body).to match(/<turbo-frame id="audit-info" src="#{dashboard_audit_info_path}"/)
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔
Speedier rendering



## How was this change tested? 🤨
Production



⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
