### PR TITLE
add comments about use of ValidateMoabJob

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -12,7 +12,12 @@ class ObjectsController < ApiController
     render json: PreservedObject.find_by!(druid: druid).to_json
   end
 
-  # queue a ValidateMoab job for a specific druid, typically called by a preservationIngestWF robot
+  # queue a ValidateMoab job for a specific druid, typically called by a preservationIngestWF robot.
+  #   This guarantees that we are testing the content on PresCat, not the content before it is transferred AND it also
+  #   guarantees that, for the first time the robot step is run for a version, that we are checking the files on disk,
+  #   and are NOT checking file that are not yet fully written to storage.
+  #   In the past, checking the files within the pres-robots code was done before the files were fully flushed to disk,
+  #   and thus failures were not caught.
   # GET /v1/objects/:id/validate_moab
   def validate_moab
     # ActiveJob::Base.perform_later will return an instance of the job if it was added to the

--- a/app/jobs/validate_moab_job.rb
+++ b/app/jobs/validate_moab_job.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 # Confirm checksums for one Moab object on storage (not in database)
+# Called from ObjectsController, which is typically called by preservation-robots
+#   in validate-moab step of preservationIngestWF step
+# (https://github.com/sul-dlss/workflow-server-rails/blob/main/config/workflows/preservationIngestWF.xml#L18) -
 class ValidateMoabJob < ApplicationJob
   queue_as :validate_moab
 


### PR DESCRIPTION
## Why was this change made? 🤔

You pick:
1.  to make it clear why ValidateMoabJob is not considered an audit job, strictly speaking
2. to make hidden information readily available to any that peruse this code.
3. unknown reasons
4. all of the above
5. 1 and 2 only.


## How was this change tested? 🤨

it's just comments.


⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
