### PR TITLE
AuditReporters namespace instead of Reporters for clarity

### DIFF
--- a/app/services/audit_reporters/audit_workflow_reporter.rb
+++ b/app/services/audit_reporters/audit_workflow_reporter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Reporters
+module AuditReporters
   # Reports to DOR Workflow Service.
   class AuditWorkflowReporter < BaseReporter
     protected

--- a/app/services/audit_reporters/base_reporter.rb
+++ b/app/services/audit_reporters/base_reporter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Reporters
-  # Base class for Reporters.
+module AuditReporters
+  # Base class for AuditReporters.
   class BaseReporter
     # Report errors.
     # The reporter will only report the errors that it handles (based on the code). It may also merge errors and report once.

--- a/app/services/audit_reporters/event_service_reporter.rb
+++ b/app/services/audit_reporters/event_service_reporter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Reporters
+module AuditReporters
   # Reports to DOR Event Service.
   class EventServiceReporter < BaseReporter
     protected

--- a/app/services/audit_reporters/honeybadger_reporter.rb
+++ b/app/services/audit_reporters/honeybadger_reporter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Reporters
+module AuditReporters
   # Reports to Honeybadger.
   class HoneybadgerReporter < BaseReporter
     protected

--- a/app/services/audit_reporters/logger_reporter.rb
+++ b/app/services/audit_reporters/logger_reporter.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-module Reporters
+module AuditReporters
   # Reports to logger.
   class LoggerReporter < BaseReporter
-    def initialize(logger = nil)
+    def initialize(logger = nil) # rubocop:disable Lint/MissingSuper
       @logger = logger || Rails.logger
     end
 

--- a/app/services/audit_reporters/message_helper.rb
+++ b/app/services/audit_reporters/message_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Reporters
+module AuditReporters
   # Helper for formatting messages.
   class MessageHelper
     def self.invalid_moab_message(check_name, version, storage_area, result)

--- a/app/services/audit_results_reporter.rb
+++ b/app/services/audit_results_reporter.rb
@@ -29,10 +29,10 @@ class AuditResultsReporter
 
   def reporters
     @reporters ||= [
-      Reporters::LoggerReporter.new(logger),
-      Reporters::HoneybadgerReporter.new,
-      Reporters::AuditWorkflowReporter.new,
-      Reporters::EventServiceReporter.new
+      AuditReporters::LoggerReporter.new(logger),
+      AuditReporters::HoneybadgerReporter.new,
+      AuditReporters::AuditWorkflowReporter.new,
+      AuditReporters::EventServiceReporter.new
     ].freeze
   end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 RSpec.describe CatalogController do
-  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
+  let(:audit_workflow_reporter) { instance_double(AuditReporters::AuditWorkflowReporter, report_errors: nil) }
   let(:size) { 2342 }
   let(:ver) { 3 }
   let(:bare_druid) { 'bj102hs9687' }
@@ -10,16 +10,16 @@ RSpec.describe CatalogController do
   let(:storage_location) { "#{storage_location_param}/sdr2objects" }
   let(:storage_location_param) { 'spec/fixtures/storage_root01' }
   let(:moab_storage_root) { MoabStorageRoot.find_by!(name: 'fixture_sr1') }
-  let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
-  let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil) }
-  let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil) }
+  let(:event_service_reporter) { instance_double(AuditReporters::EventServiceReporter, report_errors: nil) }
+  let(:honeybadger_reporter) { instance_double(AuditReporters::HoneybadgerReporter, report_errors: nil) }
+  let(:logger_reporter) { instance_double(AuditReporters::LoggerReporter, report_errors: nil) }
 
   before do
     allow(described_class.logger).to receive(:info) # silence STDOUT chatter
-    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
-    allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
-    allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
-    allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
+    allow(AuditReporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
+    allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
+    allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
     allow(controller).to receive(:check_auth_token!) # gating on valid token tested in request specs and auth spec
   end
 

--- a/spec/services/audit/catalog_to_moab_spec.rb
+++ b/spec/services/audit/catalog_to_moab_spec.rb
@@ -25,16 +25,16 @@ RSpec.describe Audit::CatalogToMoab do
     'check_catalog_version\\(bj102hs9687, fixture_sr1\\)' \
       'db MoabRecord \\(created .*Z; last updated .*Z\\) exists but Moab not found'
   end
-  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
-  let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
-  let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil) }
-  let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil) }
+  let(:audit_workflow_reporter) { instance_double(AuditReporters::AuditWorkflowReporter, report_errors: nil) }
+  let(:event_service_reporter) { instance_double(AuditReporters::EventServiceReporter, report_errors: nil) }
+  let(:honeybadger_reporter) { instance_double(AuditReporters::HoneybadgerReporter, report_errors: nil) }
+  let(:logger_reporter) { instance_double(AuditReporters::LoggerReporter, report_errors: nil) }
 
   before do
-    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
-    allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
-    allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
-    allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
+    allow(AuditReporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
+    allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
+    allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
     allow(c2m).to receive(:logger).and_return(logger_double) # silence log output
     allow(AuditResultsReporter).to receive(:report_results).and_return([])
   end

--- a/spec/services/audit/checksum_validator_spec.rb
+++ b/spec/services/audit/checksum_validator_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe Audit::ChecksumValidator do
   let(:moab_on_storage_validator) { checksum_validator.send(:moab_on_storage_validator) }
   let(:results) { instance_double(AuditResults) }
   let(:logger_double) { instance_double(ActiveSupport::Logger, info: nil, error: nil, add: nil) }
-  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
-  let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
-  let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
-  let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
+  let(:audit_workflow_reporter) { instance_double(AuditReporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
+  let(:honeybadger_reporter) { instance_double(AuditReporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
+  let(:event_service_reporter) { instance_double(AuditReporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
+  let(:logger_reporter) { instance_double(AuditReporters::LoggerReporter, report_errors: nil, report_completed: nil) }
 
   before do
-    allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
-    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
-    allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
-    allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
+    allow(AuditReporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
+    allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
+    allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
   end
 
   describe '#validate_checksums' do

--- a/spec/services/audit/checksum_validator_utils_spec.rb
+++ b/spec/services/audit/checksum_validator_utils_spec.rb
@@ -5,17 +5,17 @@ require 'rails_helper'
 RSpec.describe Audit::ChecksumValidatorUtils do
   let(:root_name) { 'fixture_sr1' }
   let(:logger_double) { instance_double(ActiveSupport::Logger, info: nil, add: nil, debug: nil, warn: nil) }
-  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
-  let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
-  let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
-  let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
+  let(:audit_workflow_reporter) { instance_double(AuditReporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
+  let(:event_service_reporter) { instance_double(AuditReporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
+  let(:honeybadger_reporter) { instance_double(AuditReporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
+  let(:logger_reporter) { instance_double(AuditReporters::LoggerReporter, report_errors: nil, report_completed: nil) }
 
   before do
     allow(described_class.logger).to receive(:info) # silence STDOUT chatter
-    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
-    allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
-    allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
-    allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
+    allow(AuditReporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
+    allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
+    allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
     allow(described_class).to receive(:logger).and_return(logger_double) # silence log output
   end
 

--- a/spec/services/audit_reporters/audit_workflow_reporter_spec.rb
+++ b/spec/services/audit_reporters/audit_workflow_reporter_spec.rb
@@ -2,9 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Reporters::AuditWorkflowReporter do
-  let(:subject) { described_class.new }
-
+RSpec.describe AuditReporters::AuditWorkflowReporter do
   let(:client) { instance_double(Dor::Workflow::Client) }
   let(:druid) { 'ab123cd4567' }
   let(:actual_version) { 6 }
@@ -34,7 +32,11 @@ RSpec.describe Reporters::AuditWorkflowReporter do
       end
 
       it 'updates workflow for each error' do
-        subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1, result2])
+        described_class.new.report_errors(druid: druid,
+                                          version: actual_version,
+                                          storage_area: ms_root,
+                                          check_name: check_name,
+                                          results: [result1, result2])
         error_msg1 = 'FooCheck (actual location: fixture_sr1; actual version: 6) || Invalid Moab, validation errors: ' \
                      "[Version directory name not in 'v00xx' format: original-v1]"
         expect(client).to have_received(:update_error_status).with(druid: "druid:#{druid}",
@@ -55,7 +57,11 @@ RSpec.describe Reporters::AuditWorkflowReporter do
       let(:result2) { { AuditResults::UNEXPECTED_VERSION => 'actual version (6) has unexpected relationship to db version' } }
 
       it 'merges errors and updates workflow' do
-        subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1, result2])
+        described_class.new.report_errors(druid: druid,
+                                          version: actual_version,
+                                          storage_area: ms_root,
+                                          check_name: check_name,
+                                          results: [result1, result2])
         error_msg = 'FooCheck (actual location: fixture_sr1; actual version: 6) does not match PreservedObject current_version ' \
                     '&& actual version (6) has unexpected relationship to db version'
         expect(client).to have_received(:update_error_status).with(druid: "druid:#{druid}",
@@ -78,7 +84,7 @@ RSpec.describe Reporters::AuditWorkflowReporter do
       end
 
       it 'creates the workflow and retries' do
-        subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result])
+        described_class.new.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result])
         error_msg = 'FooCheck (actual location: fixture_sr1; actual version: 6) does not match PreservedObject current_version'
         expect(client).to have_received(:update_error_status).with(druid: "druid:#{druid}",
                                                                    workflow: 'preservationAuditWF',
@@ -92,7 +98,7 @@ RSpec.describe Reporters::AuditWorkflowReporter do
       let(:result) { { AuditResults::ZIP_PARTS_NOT_CREATED => 'no zip_parts exist yet for this ZippedMoabVersion' } }
 
       it 'does not update workflow' do
-        subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result])
+        described_class.new.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result])
         expect(client).not_to have_received(:update_error_status)
       end
     end
@@ -102,7 +108,7 @@ RSpec.describe Reporters::AuditWorkflowReporter do
     let(:result) { { AuditResults::MOAB_RECORD_STATUS_CHANGED => 'MoabRecord status changed from invalid_moab' } }
 
     it 'updates workflow' do
-      subject.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
+      described_class.new.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
 
       expect(client).to have_received(:update_status).with(druid: "druid:#{druid}",
                                                            workflow: 'preservationAuditWF',
@@ -125,7 +131,7 @@ RSpec.describe Reporters::AuditWorkflowReporter do
       end
 
       it 'creates the workflow and retries' do
-        subject.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
+        described_class.new.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
 
         expect(client).to have_received(:update_status).with(druid: "druid:#{druid}",
                                                              workflow: 'preservationAuditWF',

--- a/spec/services/audit_reporters/event_service_reporter_spec.rb
+++ b/spec/services/audit_reporters/event_service_reporter_spec.rb
@@ -2,9 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Reporters::EventServiceReporter do
-  let(:subject) { described_class.new }
-
+RSpec.describe AuditReporters::EventServiceReporter do
   let(:druid) { 'ab123cd4567' }
   let(:actual_version) { 6 }
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
@@ -26,8 +24,12 @@ RSpec.describe Reporters::EventServiceReporter do
                                         "'v00xx' format: original-v2]" }
       end
 
-      it 'creates events' do
-        subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1, result2])
+      it 'creates events' do # rubocop:disable RSpec/ExampleLength
+        described_class.new.report_errors(druid: druid,
+                                          version: actual_version,
+                                          storage_area: ms_root,
+                                          check_name: check_name,
+                                          results: [result1, result2])
         error1 = 'FooCheck (actual location: fixture_sr1; actual version: 6) || Invalid Moab, validation errors: ' \
                  "[Version directory name not in 'v00xx' format: original-v1]"
         expect(Dor::Event::Client).to have_received(:create).with(
@@ -64,7 +66,11 @@ RSpec.describe Reporters::EventServiceReporter do
       let(:result2) { { AuditResults::UNEXPECTED_VERSION => 'actual version (6) has unexpected relationship to db version' } }
 
       it 'merges errors and creates single event' do
-        subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1, result2])
+        described_class.new.report_errors(druid: druid,
+                                          version: actual_version,
+                                          storage_area: ms_root,
+                                          check_name: check_name,
+                                          results: [result1, result2])
         expect(Dor::Event::Client).to have_received(:create).with(
           druid: "druid:#{druid}",
           type: 'preservation_audit_failure',
@@ -86,7 +92,7 @@ RSpec.describe Reporters::EventServiceReporter do
     let(:result) { { AuditResults::MOAB_RECORD_STATUS_CHANGED => 'MoabRecord status changed from invalid_moab' } }
 
     it 'creates events' do
-      subject.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
+      described_class.new.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
 
       expect(Dor::Event::Client).to have_received(:create).with(
         druid: "druid:#{druid}",

--- a/spec/services/audit_reporters/honeybadger_reporter_spec.rb
+++ b/spec/services/audit_reporters/honeybadger_reporter_spec.rb
@@ -2,9 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Reporters::HoneybadgerReporter do
-  let(:subject) { described_class.new }
-
+RSpec.describe AuditReporters::HoneybadgerReporter do
   let(:druid) { 'ab123cd4567' }
   let(:actual_version) { 6 }
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
@@ -20,7 +18,11 @@ RSpec.describe Reporters::HoneybadgerReporter do
       let(:result2) { { AuditResults::ZIP_PART_NOT_FOUND => 'replicated part not found' } }
 
       it 'notifies for each error' do
-        subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1, result2])
+        described_class.new.report_errors(druid: druid,
+                                          version: actual_version,
+                                          storage_area: ms_root,
+                                          check_name: check_name,
+                                          results: [result1, result2])
         expect(Honeybadger).to have_received(:notify).with('FooCheck(druid:ab123cd4567, fixture_sr1) db MoabRecord exists but Moab not found')
         expect(Honeybadger).to have_received(:notify).with('FooCheck(druid:ab123cd4567, fixture_sr1) replicated part not found')
       end
@@ -30,7 +32,7 @@ RSpec.describe Reporters::HoneybadgerReporter do
       let(:result) { { AuditResults::ZIP_PARTS_NOT_CREATED => 'no zip_parts exist yet for this ZippedMoabVersion' } }
 
       it 'does not notify' do
-        subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result])
+        described_class.new.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result])
         expect(Honeybadger).not_to have_received(:notify)
       end
     end
@@ -40,7 +42,7 @@ RSpec.describe Reporters::HoneybadgerReporter do
     let(:result) { { AuditResults::MOAB_RECORD_STATUS_CHANGED => 'MoabRecord status changed from invalid_moab' } }
 
     it 'does not notify' do
-      subject.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
+      described_class.new.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
       expect(Honeybadger).not_to have_received(:notify)
     end
   end

--- a/spec/services/audit_reporters/logger_reporter_spec.rb
+++ b/spec/services/audit_reporters/logger_reporter_spec.rb
@@ -2,9 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Reporters::LoggerReporter do
-  let(:subject) { described_class.new }
-
+RSpec.describe AuditReporters::LoggerReporter do
   let(:druid) { 'ab123cd4567' }
   let(:actual_version) { 6 }
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
@@ -21,7 +19,7 @@ RSpec.describe Reporters::LoggerReporter do
     let(:version_not_matched_str) { 'does not match PreservedObject current_version' }
 
     it 'logs to Rails logger' do
-      subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1])
+      described_class.new.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1])
       # Logs with check name, druid, storage root, and message
       expect(Rails.logger).to have_received(:add)
         .with(Logger::ERROR, 'FooCheck(ab123cd4567, fixture_sr1) does not match PreservedObject current_version')
@@ -32,7 +30,11 @@ RSpec.describe Reporters::LoggerReporter do
       let(:zip_parts_not_created_str) { 'no zip_parts exist yet for this ZippedMoabVersion' }
 
       it 'logs each result' do
-        subject.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result1, result2])
+        described_class.new.report_errors(druid: druid,
+                                          version: actual_version,
+                                          storage_area: ms_root,
+                                          check_name: check_name,
+                                          results: [result1, result2])
         expect(Rails.logger).to have_received(:add).with(Logger::ERROR, a_string_matching(version_not_matched_str))
         expect(Rails.logger).to have_received(:add).with(Logger::WARN, a_string_matching(zip_parts_not_created_str))
       end
@@ -43,7 +45,7 @@ RSpec.describe Reporters::LoggerReporter do
     let(:result) { { AuditResults::MOAB_RECORD_STATUS_CHANGED => 'MoabRecord status changed from invalid_moab' } }
 
     it 'logs to Rails logger' do
-      subject.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
+      described_class.new.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
       expect(Rails.logger).to have_received(:add)
         .with(Logger::INFO, 'FooCheck(ab123cd4567, fixture_sr1) MoabRecord status changed from invalid_moab')
     end
@@ -51,19 +53,19 @@ RSpec.describe Reporters::LoggerReporter do
 
   describe '.logger_severity_level' do
     it 'DB_VERSIONS_DISAGREE is an ERROR' do
-      expect(subject.send(:logger_severity_level, AuditResults::DB_VERSIONS_DISAGREE)).to eq Logger::ERROR
+      expect(described_class.new.send(:logger_severity_level, AuditResults::DB_VERSIONS_DISAGREE)).to eq Logger::ERROR
     end
 
     it 'DB_OBJ_DOES_NOT_EXIST is WARN' do
-      expect(subject.send(:logger_severity_level, AuditResults::DB_OBJ_DOES_NOT_EXIST)).to eq Logger::WARN
+      expect(described_class.new.send(:logger_severity_level, AuditResults::DB_OBJ_DOES_NOT_EXIST)).to eq Logger::WARN
     end
 
     it 'CREATED_NEW_OBJECT is INFO' do
-      expect(subject.send(:logger_severity_level, AuditResults::CREATED_NEW_OBJECT)).to eq Logger::INFO
+      expect(described_class.new.send(:logger_severity_level, AuditResults::CREATED_NEW_OBJECT)).to eq Logger::INFO
     end
 
     it 'default for unrecognized value is ERROR' do
-      expect(subject.send(:logger_severity_level, :whatever)).to eq Logger::ERROR
+      expect(described_class.new.send(:logger_severity_level, :whatever)).to eq Logger::ERROR
     end
   end
 end

--- a/spec/services/audit_results_reporter_spec.rb
+++ b/spec/services/audit_results_reporter_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe AuditResultsReporter do
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
 
   describe '#report_results' do
-    let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
-    let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
-    let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
-    let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
+    let(:audit_workflow_reporter) { instance_double(AuditReporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
+    let(:event_service_reporter) { instance_double(AuditReporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
+    let(:honeybadger_reporter) { instance_double(AuditReporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
+    let(:logger_reporter) { instance_double(AuditReporters::LoggerReporter, report_errors: nil, report_completed: nil) }
 
     before do
-      allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
-      allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
-      allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
-      allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
+      allow(AuditReporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
+      allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+      allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
+      allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
 
       audit_results.add_result(AuditResults::INVALID_MOAB, [
                                  "Version directory name not in 'v00xx' format: original-v1",

--- a/spec/services/catalog_utils_spec.rb
+++ b/spec/services/catalog_utils_spec.rb
@@ -11,19 +11,19 @@ RSpec.describe CatalogUtils do
     allow(Moab::StorageObject).to receive(:new).and_return(moab)
     moab
   end
-  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
-  let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
-  let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
-  let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
+  let(:audit_workflow_reporter) { instance_double(AuditReporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
+  let(:event_service_reporter) { instance_double(AuditReporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
+  let(:honeybadger_reporter) { instance_double(AuditReporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
+  let(:logger_reporter) { instance_double(AuditReporters::LoggerReporter, report_errors: nil, report_completed: nil) }
   let(:audit_results) { instance_double(AuditResults, results: results) }
   let(:results) { [] }
 
   before do
     allow(described_class.logger).to receive(:info) # silence STDOUT chatter
-    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
-    allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
-    allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
-    allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
+    allow(AuditReporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
+    allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
+    allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
   end
 
   describe '.logger' do

--- a/spec/services/moab_record_service/check_existence_spec.rb
+++ b/spec/services/moab_record_service/check_existence_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'services/moab_record_service/shared_examples'
 
 RSpec.describe MoabRecordService::CheckExistence do
-  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
+  let(:audit_workflow_reporter) { instance_double(AuditReporters::AuditWorkflowReporter, report_errors: nil) }
   let(:druid) { 'ab123cd4567' }
   let(:incoming_version) { 6 }
   let(:incoming_size) { 9876 }
@@ -17,15 +17,15 @@ RSpec.describe MoabRecordService::CheckExistence do
   end
 
   let(:moab_on_storage_validator) { moab_record_service.send(:moab_on_storage_validator) }
-  let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil) }
-  let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil) }
-  let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
+  let(:logger_reporter) { instance_double(AuditReporters::LoggerReporter, report_errors: nil) }
+  let(:honeybadger_reporter) { instance_double(AuditReporters::HoneybadgerReporter, report_errors: nil) }
+  let(:event_service_reporter) { instance_double(AuditReporters::EventServiceReporter, report_errors: nil) }
 
   before do
-    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
-    allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
-    allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
-    allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(AuditReporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
+    allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
+    allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
+    allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
   end
 
   describe '#check_existence' do

--- a/spec/services/moab_record_service/create_after_validation_spec.rb
+++ b/spec/services/moab_record_service/create_after_validation_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe MoabRecordService::CreateAfterValidation do
   let(:storage_dir) { 'spec/fixtures/storage_root01/sdr2objects' }
   let(:moab_storage_root) { MoabStorageRoot.find_by(storage_location: storage_dir) }
   let(:expected_msg) { 'added object to db as it did not exist' }
-  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
-  let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil) }
-  let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil) }
-  let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
+  let(:audit_workflow_reporter) { instance_double(AuditReporters::AuditWorkflowReporter, report_errors: nil) }
+  let(:logger_reporter) { instance_double(AuditReporters::LoggerReporter, report_errors: nil) }
+  let(:honeybadger_reporter) { instance_double(AuditReporters::HoneybadgerReporter, report_errors: nil) }
+  let(:event_service_reporter) { instance_double(AuditReporters::EventServiceReporter, report_errors: nil) }
 
   before do
-    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
-    allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
-    allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
-    allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(AuditReporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
+    allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
+    allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
+    allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
   end
 
   describe '#execute' do

--- a/spec/services/moab_record_service/create_spec.rb
+++ b/spec/services/moab_record_service/create_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe MoabRecordService::Create do
     described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: incoming_size, moab_storage_root: moab_storage_root)
   end
   let(:expected_msg) { 'added object to db as it did not exist' }
-  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil) }
-  let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil) }
-  let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil) }
-  let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil) }
+  let(:audit_workflow_reporter) { instance_double(AuditReporters::AuditWorkflowReporter, report_errors: nil) }
+  let(:logger_reporter) { instance_double(AuditReporters::LoggerReporter, report_errors: nil) }
+  let(:honeybadger_reporter) { instance_double(AuditReporters::HoneybadgerReporter, report_errors: nil) }
+  let(:event_service_reporter) { instance_double(AuditReporters::EventServiceReporter, report_errors: nil) }
 
   before do
-    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
-    allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
-    allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
-    allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(AuditReporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
+    allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
+    allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
+    allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
   end
 
   describe '#execute' do

--- a/spec/services/moab_record_service/update_version_after_validation_spec.rb
+++ b/spec/services/moab_record_service/update_version_after_validation_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'services/moab_record_service/shared_examples'
 
 RSpec.describe MoabRecordService::UpdateVersionAfterValidation do
-  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
+  let(:audit_workflow_reporter) { instance_double(AuditReporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
   let(:db_update_failed_prefix) { 'db update failed' }
   let(:druid) { 'ab123cd4567' }
   let(:incoming_size) { 9876 }
@@ -15,15 +15,15 @@ RSpec.describe MoabRecordService::UpdateVersionAfterValidation do
   let(:moab_record_service) do
     described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: incoming_size, moab_storage_root: moab_storage_root)
   end
-  let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
-  let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
-  let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
+  let(:logger_reporter) { instance_double(AuditReporters::LoggerReporter, report_errors: nil, report_completed: nil) }
+  let(:honeybadger_reporter) { instance_double(AuditReporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
+  let(:event_service_reporter) { instance_double(AuditReporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
 
   before do
-    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
-    allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
-    allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
-    allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(AuditReporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
+    allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
+    allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
+    allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
   end
 
   describe 'execute' do

--- a/spec/services/moab_record_service/update_version_spec.rb
+++ b/spec/services/moab_record_service/update_version_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'services/moab_record_service/shared_examples'
 
 RSpec.describe MoabRecordService::UpdateVersion do
-  let(:audit_workflow_reporter) { instance_double(Reporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
+  let(:audit_workflow_reporter) { instance_double(AuditReporters::AuditWorkflowReporter, report_errors: nil, report_completed: nil) }
   let(:db_update_failed_prefix) { 'db update failed' }
   let(:druid) { 'ab123cd4567' }
   let(:incoming_size) { 9876 }
@@ -15,15 +15,15 @@ RSpec.describe MoabRecordService::UpdateVersion do
   let(:moab_record_service) do
     described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: incoming_size, moab_storage_root: moab_storage_root)
   end
-  let(:logger_reporter) { instance_double(Reporters::LoggerReporter, report_errors: nil, report_completed: nil) }
-  let(:honeybadger_reporter) { instance_double(Reporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
-  let(:event_service_reporter) { instance_double(Reporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
+  let(:logger_reporter) { instance_double(AuditReporters::LoggerReporter, report_errors: nil, report_completed: nil) }
+  let(:honeybadger_reporter) { instance_double(AuditReporters::HoneybadgerReporter, report_errors: nil, report_completed: nil) }
+  let(:event_service_reporter) { instance_double(AuditReporters::EventServiceReporter, report_errors: nil, report_completed: nil) }
 
   before do
-    allow(Reporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
-    allow(Reporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
-    allow(Reporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
-    allow(Reporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(AuditReporters::AuditWorkflowReporter).to receive(:new).and_return(audit_workflow_reporter)
+    allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
+    allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
+    allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
   end
 
   describe '#execute' do


### PR DESCRIPTION
## Why was this change made? 🤔

per discussion 2023-01-09, this clarifies that the classes in the namespace are used only by the audit_results_reporter

## How was this change tested? 🤨

specs.


⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
