### PR TITLE
Adds checking of cloud endpoint to zip_part_debug_info

### DIFF
--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -5,7 +5,14 @@ require 'csv'
 namespace :prescat do
   desc 'Diagnose failed replication'
   task :diagnose_replication, [:druid] => :environment do |_task, args|
-    puts Audit::ReplicationSupport.zip_part_debug_info(args[:druid])
+    debug_infos = Audit::ReplicationSupport.zip_part_debug_info(args[:druid])
+    CSV do |csv|
+      csv << ['druid', 'preserved object version', 'zipped moab version', 'endpoint',
+              'zip part status', 'zip part suffix', 'zipped moab parts count', 'zip part size',
+              'zip part created at', 'zip part updated at', 'zip part s3 key', 'zip part endpoint status',
+              'zip part size']
+      debug_infos.each { |debug_info| csv << debug_info }
+    end
   end
 
   desc 'Prune failed replication records from catalog'


### PR DESCRIPTION
## Why was this change made? 🤔
Easier troubleshooting by providing debug info from clound endpoints.



## How was this change tested? 🤨
Prod



⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
