### PR TITLE
Do not attempt to replicate to endpoints that are already replicated.

### DIFF
--- a/app/jobs/replication/delivery_dispatcher_job.rb
+++ b/app/jobs/replication/delivery_dispatcher_job.rb
@@ -60,7 +60,9 @@ module Replication
 
     # @return [Array<Class>] endpoint specific delivery classes
     def deliverers
-      zipped_moab_versions.map { |zmv| zmv.zip_endpoint.delivery_class.constantize }.uniq
+      zipped_moab_versions
+        .filter { |zmv| !zmv.all_parts_replicated? }
+        .map { |zmv| zmv.zip_endpoint.delivery_class.constantize }.uniq
     end
   end
 end


### PR DESCRIPTION
closes #2172

## Why was this change made? 🤔
Allow retry of DeliveryDispatchJob for partially replicated moabs.



## How was this change tested? 🤨

Unit


⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
