### PR TITLE
Remove total zipparts and ok from replication files dashboard.

### DIFF
--- a/app/components/dashboard/replication_files_component.html.erb
+++ b/app/components/dashboard/replication_files_component.html.erb
@@ -7,8 +7,6 @@
     <table class="table table-bordered table-hover">
       <thead class="table-info">
         <tr>
-          <th>Total ZipParts (count)</th>
-          <th class="text-center">ok</th>
           <th class="text-center">replicated checksum mismatch</th>
           <th class="text-center">unreplicated</th>
           <th class="text-center">not found</th>
@@ -16,8 +14,6 @@
       </thead>
       <tbody class="table-group-divider">
         <tr>
-          <td><%= ZipPart.count %></td>
-          <td class="text-end"><%= ZipPart.ok.count %></td>
           <td class="text-end<%= ' table-danger' if zip_parts_replicated_checksum_mismatch? %>"><%= zip_parts_replicated_checksum_mismatch_count %></td>
           <td class="text-end<%= ' table-warning' if zip_parts_unreplicated? %>"><%= zip_parts_unreplicated_count %></td>
           <td class="text-end<%= ' table-danger' if zip_parts_not_found? %>"><%= zip_parts_not_found_count %></td>

--- a/spec/components/dashboard/replication_files_component_spec.rb
+++ b/spec/components/dashboard/replication_files_component_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe Dashboard::ReplicationFilesComponent, type: :component do
     expect(rendered_html).to match(/0/) # table data
   end
 
-  it 'renders ok status count with plain styling' do
-    create(:zip_part, status: 'ok')
-    expect(rendered_html).to match('<td class="text-end">1</td>')
-  end
-
   it 'renders replicated_checksum_mismatch status count with danger styling' do
     create(:zip_part, status: 'replicated_checksum_mismatch')
     expect(rendered_html).to match('<td class="text-end table-danger">1</td>')

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe DashboardController do
 
     it 'renders replicated files data' do
       expect(response.body).to match(/Replication Files/)
-      expect(response.body).to match(/Total ZipParts/) # table header
+      expect(response.body).to match(/unreplicated/) # table header
       expect(response.body).to match(/0/) # table data
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
Slow queries that didn't add actionable info.



## How was this change tested? 🤨
Unit



⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡

![image](https://user-images.githubusercontent.com/588335/212905539-a4d9c5aa-1ff1-4e41-bfeb-5d8f84ecad31.png)

