### PR TITLE
[HOLD] Rename queues to include replication_ and audit_ in the name

### DIFF
--- a/app/jobs/audit/catalog_to_moab_job.rb
+++ b/app/jobs/audit/catalog_to_moab_job.rb
@@ -4,7 +4,7 @@ module Audit
   # Check filesystem based on catalog, updating database
   # @see Audit::CatalogToMoab
   class CatalogToMoabJob < ApplicationJob
-    queue_as :c2m
+    queue_as :audit_catalog_to_moab
 
     before_enqueue do |job|
       raise ArgumentError, 'MoabRecord param required' unless job.arguments.first.is_a?(MoabRecord)

--- a/app/jobs/audit/checksum_validation_job.rb
+++ b/app/jobs/audit/checksum_validation_job.rb
@@ -4,7 +4,7 @@ module Audit
   # Confirm checksum for one Moab on storage and update MoabRecord in database
   # @see Audit::ChecksumValidator
   class ChecksumValidationJob < ApplicationJob
-    queue_as :checksum_validation
+    queue_as :audit_checksum_validation
 
     before_enqueue do |job|
       raise ArgumentError, 'MoabRecord param required' unless job.arguments.first.is_a?(MoabRecord)

--- a/app/jobs/audit/moab_to_catalog_job.rb
+++ b/app/jobs/audit/moab_to_catalog_job.rb
@@ -4,7 +4,7 @@ module Audit
   # Check catalog based on filesystem, updating database
   # @see MoabRecordService::CheckExistence
   class MoabToCatalogJob < ApplicationJob
-    queue_as :m2c
+    queue_as :audit_moab_to_catalog
 
     before_enqueue do |job|
       raise ArgumentError, 'MoabStorageRoot param required' unless job.arguments.first.is_a?(MoabStorageRoot)

--- a/app/jobs/replication/delivery_dispatcher_job.rb
+++ b/app/jobs/replication/delivery_dispatcher_job.rb
@@ -18,7 +18,7 @@ module Replication
   #   the VM is updated to a new vesrion). Therefore, we receive the zip
   #   metadata from the process that actually created the zip file.
   class DeliveryDispatcherJob < Replication::ZipPartJobBase
-    queue_as :zips_made
+    queue_as :replication_plexer
 
     before_enqueue do |job|
       job.zip_info_check!(job.arguments.fourth)

--- a/app/jobs/replication/delivery_dispatcher_job.rb
+++ b/app/jobs/replication/delivery_dispatcher_job.rb
@@ -18,7 +18,7 @@ module Replication
   #   the VM is updated to a new vesrion). Therefore, we receive the zip
   #   metadata from the process that actually created the zip file.
   class DeliveryDispatcherJob < Replication::ZipPartJobBase
-    queue_as :replication_plexer
+    queue_as :replication_delivery_dispatcher
 
     before_enqueue do |job|
       job.zip_info_check!(job.arguments.fourth)

--- a/app/jobs/replication/ibm_south_delivery_job.rb
+++ b/app/jobs/replication/ibm_south_delivery_job.rb
@@ -5,7 +5,7 @@ module Replication
   # @note this class name appears in config files for the endpoints for which it delivers content.
   #   Please update the configs for the various environments if it's renamed or moved.
   class IbmSouthDeliveryJob < Replication::DeliveryJobBase
-    queue_as :ibm_us_south_delivery
+    queue_as :replication_ibm_us_south_delivery
 
     # perform method is defined in DeliveryJobBase
 

--- a/app/jobs/replication/results_recorder_job.rb
+++ b/app/jobs/replication/results_recorder_job.rb
@@ -8,7 +8,7 @@ module Replication
   # 2. when all zip parts for the druid version are delivered to ONE endpoint,
   #   Report to DOR event service
   class ResultsRecorderJob < ApplicationJob
-    queue_as :zip_endpoint_events
+    queue_as :replication_results_recorder
 
     include UniqueJob
 

--- a/app/jobs/replication/s3_east_delivery_job.rb
+++ b/app/jobs/replication/s3_east_delivery_job.rb
@@ -6,7 +6,7 @@ module Replication
   #   Please update the configs for the various environments if it's renamed or moved.
   # @note This name is slightly misleading, as this class solely deals with AWS US East 1 endpoint
   class S3EastDeliveryJob < Replication::DeliveryJobBase
-    queue_as :s3_us_east_1_delivery
+    queue_as :replication_aws_us_east_1_delivery
 
     # perform method is defined in DeliveryJobBase
 

--- a/app/jobs/replication/s3_east_delivery_job.rb
+++ b/app/jobs/replication/s3_east_delivery_job.rb
@@ -6,7 +6,7 @@ module Replication
   #   Please update the configs for the various environments if it's renamed or moved.
   # @note This name is slightly misleading, as this class solely deals with AWS US East 1 endpoint
   class S3EastDeliveryJob < Replication::DeliveryJobBase
-    queue_as :replication_aws_us_east_1_delivery
+    queue_as :replication_s3_east_delivery
 
     # perform method is defined in DeliveryJobBase
 

--- a/app/jobs/replication/s3_west_delivery_job.rb
+++ b/app/jobs/replication/s3_west_delivery_job.rb
@@ -6,7 +6,7 @@ module Replication
   #   Please update the configs for the various environments if it's renamed or moved.
   # @note This name is slightly misleading, as this class solely deals with AWS US West 2 endpoint
   class S3WestDeliveryJob < Replication::DeliveryJobBase
-    queue_as :s3_us_west_2_delivery
+    queue_as :replication_aws_us_west_2_delivery
 
     # perform method is defined in DeliveryJobBase
 

--- a/app/jobs/replication/s3_west_delivery_job.rb
+++ b/app/jobs/replication/s3_west_delivery_job.rb
@@ -6,7 +6,7 @@ module Replication
   #   Please update the configs for the various environments if it's renamed or moved.
   # @note This name is slightly misleading, as this class solely deals with AWS US West 2 endpoint
   class S3WestDeliveryJob < Replication::DeliveryJobBase
-    queue_as :replication_aws_us_west_2_delivery
+    queue_as :replication_s3_west_delivery
 
     # perform method is defined in DeliveryJobBase
 

--- a/app/jobs/replication/zipmaker_job.rb
+++ b/app/jobs/replication/zipmaker_job.rb
@@ -7,7 +7,7 @@ module Replication
   #        Note: a single DruidVersionZip may have more than one ZipPart.
   #   2. Invoke Replication::DeliveryDispatcherJob for each ZipPart.
   class ZipmakerJob < ApplicationJob
-    queue_as :zipmaker
+    queue_as :replication_zipmaker
     delegate :find_or_create_zip!, :file_path, :part_keys, to: :zip
 
     attr_accessor :zip

--- a/spec/jobs/replication/ibm_south_delivery_job_spec.rb
+++ b/spec/jobs/replication/ibm_south_delivery_job_spec.rb
@@ -8,6 +8,6 @@ describe Replication::IbmSouthDeliveryJob do
   end
 
   it 'uses its own queue' do
-    expect(described_class.new.queue_name).to eq 'ibm_us_south_delivery'
+    expect(described_class.new.queue_name).to eq 'replication_ibm_us_south_delivery'
   end
 end

--- a/spec/jobs/replication/s3_east_delivery_job_spec.rb
+++ b/spec/jobs/replication/s3_east_delivery_job_spec.rb
@@ -8,6 +8,6 @@ describe Replication::S3EastDeliveryJob do
   end
 
   it 'uses its own queue' do
-    expect(described_class.new.queue_name).to eq 's3_us_east_1_delivery'
+    expect(described_class.new.queue_name).to eq 'replication_aws_us_east_1_delivery'
   end
 end

--- a/spec/jobs/replication/s3_east_delivery_job_spec.rb
+++ b/spec/jobs/replication/s3_east_delivery_job_spec.rb
@@ -8,6 +8,6 @@ describe Replication::S3EastDeliveryJob do
   end
 
   it 'uses its own queue' do
-    expect(described_class.new.queue_name).to eq 'replication_aws_us_east_1_delivery'
+    expect(described_class.new.queue_name).to eq 'replication_s3_east_delivery'
   end
 end

--- a/spec/jobs/replication/s3_west_delivery_job_spec.rb
+++ b/spec/jobs/replication/s3_west_delivery_job_spec.rb
@@ -8,6 +8,6 @@ describe Replication::S3WestDeliveryJob do
   end
 
   it 'uses its own queue' do
-    expect(described_class.new.queue_name).to eq 'replication_aws_us_west_2_delivery'
+    expect(described_class.new.queue_name).to eq 'replication_s3_west_delivery'
   end
 end

--- a/spec/jobs/replication/s3_west_delivery_job_spec.rb
+++ b/spec/jobs/replication/s3_west_delivery_job_spec.rb
@@ -8,6 +8,6 @@ describe Replication::S3WestDeliveryJob do
   end
 
   it 'uses its own queue' do
-    expect(described_class.new.queue_name).to eq 's3_us_west_2_delivery'
+    expect(described_class.new.queue_name).to eq 'replication_aws_us_west_2_delivery'
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #2064 by renaming the replication job queues. 
Closes #2056 by renaming the audit job queues.

When merging note the required shared configs PRs: https://github.com/sul-dlss/shared_configs/pulls/aaron-collier


## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
