### PR TITLE
[HOLD] Rename audit queues

### DIFF
--- a/app/jobs/audit/catalog_to_moab_job.rb
+++ b/app/jobs/audit/catalog_to_moab_job.rb
@@ -4,7 +4,7 @@ module Audit
   # Check filesystem based on catalog, updating database
   # @see Audit::CatalogToMoab
   class CatalogToMoabJob < ApplicationJob
-    queue_as :c2m
+    queue_as :audit_catalog_to_moab
 
     before_enqueue do |job|
       raise ArgumentError, 'MoabRecord param required' unless job.arguments.first.is_a?(MoabRecord)

--- a/app/jobs/audit/checksum_validation_job.rb
+++ b/app/jobs/audit/checksum_validation_job.rb
@@ -4,7 +4,7 @@ module Audit
   # Confirm checksum for one Moab on storage and update MoabRecord in database
   # @see Audit::ChecksumValidator
   class ChecksumValidationJob < ApplicationJob
-    queue_as :checksum_validation
+    queue_as :audit_checksum_validation
 
     before_enqueue do |job|
       raise ArgumentError, 'MoabRecord param required' unless job.arguments.first.is_a?(MoabRecord)

--- a/app/jobs/audit/moab_to_catalog_job.rb
+++ b/app/jobs/audit/moab_to_catalog_job.rb
@@ -4,7 +4,7 @@ module Audit
   # Check catalog based on filesystem, updating database
   # @see MoabRecordService::CheckExistence
   class MoabToCatalogJob < ApplicationJob
-    queue_as :m2c
+    queue_as :audit_moab_to_catalog
 
     before_enqueue do |job|
       raise ArgumentError, 'MoabStorageRoot param required' unless job.arguments.first.is_a?(MoabStorageRoot)


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #2056 

HELD until shared_configs PRs in place.


## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
