### PR TITLE
Rename log files for clarity

### DIFF
--- a/app/services/audit/catalog_to_moab.rb
+++ b/app/services/audit/catalog_to_moab.rb
@@ -7,7 +7,7 @@ module Audit
 
     def initialize(moab_record)
       @moab_record = moab_record
-      @logger = Logger.new(Rails.root.join('log', 'c2m.log'))
+      @logger = Logger.new(Rails.root.join('log', 'audit_catalog_to_moab.log'))
     end
 
     # Check the catalog version (MoabRecord version) against versions of the preserved object and the moab on storage,

--- a/app/services/audit/checksum_validator_utils.rb
+++ b/app/services/audit/checksum_validator_utils.rb
@@ -8,7 +8,7 @@ module Audit
   class ChecksumValidatorUtils
     def self.logger
       @logger ||= Logger.new($stdout)
-                        .extend(ActiveSupport::Logger.broadcast(Logger.new(Rails.root.join('log', 'cv.log'))))
+                        .extend(ActiveSupport::Logger.broadcast(Logger.new(Rails.root.join('log', 'audit_checksum_validation.log'))))
     end
 
     # @return [Array<AuditResults>] results from Audit::ChecksumValidator runs

--- a/app/services/catalog_utils.rb
+++ b/app/services/catalog_utils.rb
@@ -8,7 +8,7 @@
 class CatalogUtils
   def self.logger
     @logger ||= Logger.new($stdout)
-                      .extend(ActiveSupport::Logger.broadcast(Logger.new(Rails.root.join('log', 'm2c.log'))))
+                      .extend(ActiveSupport::Logger.broadcast(Logger.new(Rails.root.join('log', 'audit_moab_to_catalog.log'))))
   end
 
   # this method intended to be called from rake task or via ReST call

--- a/spec/services/catalog_utils_spec.rb
+++ b/spec/services/catalog_utils_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CatalogUtils do
   end
 
   describe '.logger' do
-    let(:logfile) { Rails.root.join('log', 'm2c.log') }
+    let(:logfile) { Rails.root.join('log', 'audit_moab_to_catalog.log') }
 
     after { FileUtils.rm_f(logfile) }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #2071 


## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
