### PR TITLE
Extract replication endpoint status component

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,10 @@ Layout/EmptyLineAfterGuardClause:
 Layout/LineLength:
   Max: 150
 
+Lint/MissingSuper:
+  Exclude:
+    - 'app/components/**/*'
+
 Metrics/BlockLength:
   Exclude:
     - '**/*.rake'
@@ -459,9 +463,9 @@ RSpec/NoExpectationExample: # new in 2.13
   Enabled: true
 RSpec/VerifiedDoubleReference: # new in 2.10.0
   Enabled: true
-RSpec/Capybara/SpecificFinders: # new in 2.13
+Capybara/SpecificFinders: # new in 2.13
   Enabled: true
-RSpec/Capybara/SpecificMatcher: # new in 2.12
+Capybara/SpecificMatcher: # new in 2.12
   Enabled: true
 RSpec/Rails/HaveHttpStatus: # new in 2.12
   Enabled: true
@@ -480,9 +484,9 @@ Rails/WhereNotWithMultipleConditions: # new in 2.17
   Enabled: true
 RSpec/SortMetadata: # new in 2.14
   Enabled: true
-RSpec/Capybara/NegationMatcher: # new in 2.14
+Capybara/NegationMatcher: # new in 2.14
   Enabled: true
-RSpec/Capybara/SpecificActions: # new in 2.14
+Capybara/SpecificActions: # new in 2.14
   Enabled: true
 RSpec/FactoryBot/ConsistentParenthesesStyle: # new in 2.14
   Enabled: true
@@ -511,4 +515,14 @@ RSpec/DuplicatedMetadata: # new in 2.16
 RSpec/PendingWithoutReason: # new in 2.16
   Enabled: true
 RSpec/FactoryBot/FactoryNameStyle: # new in 2.16
+  Enabled: true
+Lint/UselessRescue: # new in 1.43
+  Enabled: true
+Capybara/MatchStyle: # new in <<next>>
+  Enabled: true
+RSpec/Rails/MinitestAssertions: # new in 2.17
+  Enabled: true
+Gemspec/DevelopmentDependencies: # new in 1.44
+  Enabled: true
+Style/ComparableClamp: # new in 1.44
   Enabled: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,7 +356,7 @@ GEM
     rspec-support (3.12.0)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.43.0)
+    rubocop (1.44.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)

--- a/app/components/dashboard/replication_endpoint_status_component.html.erb
+++ b/app/components/dashboard/replication_endpoint_status_component.html.erb
@@ -1,0 +1,9 @@
+<li class="list-group-item d-flex justify-content-between align-items-center">
+  <h6 class="d-flex justify-content-start pe-2">
+    <span class="text-secondary pe-1">Endpoint:</span>
+    <%= endpoint_name %>
+  </h6>
+  <span class="badge rounded-pill <%= endpoint_replication_badge_class %>">
+    <%= endpoint_replication_status_label %>
+  </span>
+</li>

--- a/app/components/dashboard/replication_endpoint_status_component.rb
+++ b/app/components/dashboard/replication_endpoint_status_component.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Dashboard
+  # methods for dashboard pertaining to ReplicationEndpointStatusComponent
+  class ReplicationEndpointStatusComponent < ViewComponent::Base
+    include Dashboard::ReplicationService
+
+    with_collection_parameter :endpoints
+
+    def initialize(endpoints:)
+      @endpoint_name, @endpoint_info = endpoints
+    end
+
+    attr_reader :endpoint_info, :endpoint_name
+
+    def replication_count
+      endpoint_info[:replication_count]
+    end
+
+    def endpoint_replication_badge_class
+      return OK_BADGE_CLASS if endpoint_replication_count_ok?(replication_count)
+
+      NOT_OK_BADGE_CLASS
+    end
+
+    def endpoint_replication_status_label
+      return OK_LABEL if endpoint_replication_count_ok?(replication_count)
+
+      NOT_OK_LABEL
+    end
+  end
+end

--- a/app/components/dashboard/replication_status_component.html.erb
+++ b/app/components/dashboard/replication_status_component.html.erb
@@ -2,30 +2,18 @@
   <div class="card-body" />
     <div class="card-title fs-4 fw-semibold d-flex justify-content-between">
       Replication Zips
-      <span class="badge rounded-pill <%= replication_and_zip_parts_ok? ? 'bg-success' : 'bg-danger' %>">
-        <%= replication_and_zip_parts_ok? ? 'OK' : 'Error' %>
+      <span class="badge rounded-pill <%= replication_zips_badge_class %>">
+        <%= replication_zips_status_label %>
       </span>
     </div>
     <ul class="list-group border border-2 border-secondary">
       <li class="list-group-item d-flex justify-content-between align-items-center">
         <h6 class="d-flex justify-content-start">ZipPart Statuses</h6>
-        <span class="badge rounded-pill <%= zip_parts_ok? ? 'bg-success' : 'bg-danger' %>">
-          <%= zip_parts_ok? ? 'OK' : 'Error' %>
+        <span class="badge rounded-pill <%= zip_parts_badge_class %>">
+          <%= zip_parts_status_label %>
         </span>
       </li>
-      <% endpoint_data.each do |endpoint_name, endpoint_info| %>
-        <% replication_count = endpoint_info[:replication_count] %>
-        <% endpoint_replication_ok = replication_count == num_object_versions_per_preserved_object %>
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          <h6 class="d-flex justify-content-start pe-2">
-            <span class="text-secondary pe-1">Endpoint:</span>
-            <%= endpoint_name %>
-          </h6>
-          <span class="badge rounded-pill <%= endpoint_replication_ok ? 'bg-success' : 'bg-danger' %>">
-            <%= endpoint_replication_ok ? 'OK' : 'Error' %>
-          </span>
-        </li>
-      <% end %>
+      <%= render Dashboard::ReplicationEndpointStatusComponent.with_collection(endpoints) %>
       <li class="list-group-item d-flex justify-content-between align-items-center">
         <h6><a href="queues">Redis queues</a></h6>
       </li>

--- a/app/components/dashboard/replication_status_component.rb
+++ b/app/components/dashboard/replication_status_component.rb
@@ -4,5 +4,29 @@ module Dashboard
   # methods for dashboard pertaining to ReplicationStatusComponent
   class ReplicationStatusComponent < ViewComponent::Base
     include Dashboard::ReplicationService
+
+    def replication_zips_badge_class
+      return OK_BADGE_CLASS if replication_and_zip_parts_ok?
+
+      NOT_OK_BADGE_CLASS
+    end
+
+    def replication_zips_status_label
+      return OK_LABEL if replication_and_zip_parts_ok?
+
+      NOT_OK_LABEL
+    end
+
+    def zip_parts_badge_class
+      return OK_BADGE_CLASS if zip_parts_ok?
+
+      NOT_OK_BADGE_CLASS
+    end
+
+    def zip_parts_status_label
+      return OK_LABEL if zip_parts_ok?
+
+      NOT_OK_LABEL
+    end
   end
 end

--- a/app/components/spinner.rb
+++ b/app/components/spinner.rb
@@ -2,6 +2,5 @@
 
 # A spinner
 class Spinner < ViewComponent::Base
-  def initialize(*) # rubocop:disable Lint/MissingSuper
-  end
+  def initialize(*); end
 end

--- a/app/services/dashboard/replication_service.rb
+++ b/app/services/dashboard/replication_service.rb
@@ -6,6 +6,11 @@ module Dashboard
   module ReplicationService
     include InstrumentationSupport
 
+    OK_BADGE_CLASS = 'bg-success'
+    NOT_OK_BADGE_CLASS = 'bg-danger'
+    OK_LABEL = 'OK'
+    NOT_OK_LABEL = 'Error'
+
     def replication_and_zip_parts_ok?
       zip_parts_ok? && replication_ok?
     end
@@ -23,6 +28,11 @@ module Dashboard
     # total number of object versions according to PreservedObject table
     def num_object_versions_per_preserved_object
       PreservedObject.all.annotate(caller).sum(:current_version)
+    end
+
+    # Array-ify the endpoint data so it's renderable via the ViewComponent `#with_collection` method
+    def endpoints
+      endpoint_data.to_a
     end
 
     def endpoint_data

--- a/spec/components/dashboard/replication_endpoint_status_component_spec.rb
+++ b/spec/components/dashboard/replication_endpoint_status_component_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::ReplicationEndpointStatusComponent, type: :component do
+  let(:component) { described_class.new(endpoints: [endpoint_name, endpoint_info]) }
+  let(:endpoint_name) { ZipEndpoint.first.endpoint_name }
+  let(:endpoint_info) { { replication_count: 0 } }
+  let(:rendered) { render_inline(component) }
+  let(:rendered_html) { rendered.to_html }
+
+  context 'when happy path' do
+    it 'renders Replication Status with everything hunky-dory' do
+      expect(rendered).to match(/Endpoint:/) # sub status
+      expect(rendered_html).to match(Dashboard::ReplicationService::OK_LABEL) # actual status data
+    end
+  end
+
+  context 'when count is not OK' do
+    before do
+      allow(component).to receive(:endpoint_replication_count_ok?).and_return(false)
+    end
+
+    it 'renders Replication Status with errors called out' do
+      expect(rendered_html).to match(Dashboard::ReplicationService::NOT_OK_LABEL)
+    end
+  end
+end

--- a/spec/components/dashboard/replication_status_component_spec.rb
+++ b/spec/components/dashboard/replication_status_component_spec.rb
@@ -3,14 +3,37 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard::ReplicationStatusComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new) }
+  let(:component) { described_class.new }
+  let(:rendered) { render_inline(component) }
   let(:rendered_html) { rendered.to_html }
 
-  it 'renders Replication Status' do
-    expect(rendered).to match(/Replication Zips/) # top level status
-    expect(rendered).to match(/ZipPart Statuses/) # sub status
-    expect(rendered).to match(/Endpoint:/) # sub status
-    expect(rendered_html).to match('OK') # actual status data
-    expect(rendered_html).to match(%r{<a href="queues">Redis queues</a>}) # link to redis
+  context 'when happy path' do
+    it 'renders Replication Status with everything hunky-dory' do
+      expect(rendered).to match(/Replication Zips/) # top level status
+      expect(rendered).to match(/ZipPart Statuses/) # sub status
+      expect(rendered).to match(/Endpoint:/) # sub status
+      expect(rendered_html).to match(Dashboard::ReplicationService::OK_LABEL) # actual status data
+      expect(rendered_html).to match(%r{<a href="queues">Redis queues</a>}) # link to redis
+    end
+  end
+
+  context 'when replication & zip parts are not OK' do
+    before do
+      allow(component).to receive(:replication_and_zip_parts_ok?).and_return(false)
+    end
+
+    it 'renders Replication Status with errors called out' do
+      expect(rendered_html).to match(Dashboard::ReplicationService::NOT_OK_LABEL)
+    end
+  end
+
+  context 'when zip parts are not OK' do
+    before do
+      allow(component).to receive(:zip_parts_ok?).and_return(false)
+    end
+
+    it 'renders Replication Status with errors called out' do
+      expect(rendered_html).to match(Dashboard::ReplicationService::NOT_OK_LABEL)
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2089

* Extract replication endpoint status component
  * Extracts a new subcomponent of the replication status component to reflect that endpoint replication statuses are distinct from the overall replication status. In doing this work, move logic out of component ERB templates into the component Ruby (reducing logic in views).
* Update rubocop version and config and make it happy

## How was this change tested? 🤨

Tested locally and in QA
