### PR TITLE
Allow installing Sidekiq Pro in docker image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@3.1.2
+  ruby-rails: sul-dlss/ruby-rails@3.2.0
 workflows:
   build:
     jobs:
@@ -17,6 +17,7 @@ workflows:
           context: dlss
           name: publish-latest
           image: suldlss/preservation_catalog
+          extra_build_args: --build-arg BUNDLE_GEMS__CONTRIBSYS__COM
           requires:
             - validate
             - lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ WORKDIR /app
 # Using argument for conditional setup in conf file  
 ARG RAILS_ENV
 ENV RAILS_ENV $RAILS_ENV
+ARG BUNDLE_GEMS__CONTRIBSYS__COM
+ENV BUNDLE_GEMS__CONTRIBSYS__COM $BUNDLE_GEMS__CONTRIBSYS__COM
 
 RUN gem update --system && \
   gem install bundler && \


### PR DESCRIPTION
## Why was this change made? 🤔
So that docker image will build.



## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
