### PR TITLE
Adds additional fields to replication diagnosis.

### DIFF
--- a/app/services/audit/replication_support.rb
+++ b/app/services/audit/replication_support.rb
@@ -68,6 +68,8 @@ module Audit
           zip_part.suffix,
           zip_part.parts_count,
           zip_part.size,
+          zip_part.md5,
+          zip_part.id,
           zip_part.created_at,
           zip_part.updated_at,
           zip_part.s3_key,

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -9,8 +9,9 @@ namespace :prescat do
     CSV do |csv|
       csv << ['druid', 'preserved object version', 'zipped moab version', 'endpoint',
               'zip part status', 'zip part suffix', 'zipped moab parts count', 'zip part size',
+              'zip part md5', 'zip part id',
               'zip part created at', 'zip part updated at', 'zip part s3 key', 'zip part endpoint status',
-              'zip part size']
+              'zip part endpoint md5']
       debug_infos.each { |debug_info| csv << debug_info }
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
More helpful replication diagnosis.



## How was this change tested? 🤨
QA



⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
