### PR TITLE
Remove OKComputer feature-version-audit-window-check.

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -88,29 +88,8 @@ if worker_host?
   OkComputer::Registry.register 'feature-zip_storage_dir', OkComputer::DirectoryCheck.new(Settings.zip_storage)
 end
 
-# check MoabRecord#last_version_audit to ensure it isn't too old
-class VersionAuditWindowCheck < OkComputer::Check
-  def check
-    if MoabRecord.version_audit_expired(clause).first
-      mark_message "MoabRecord#last_version_audit older than #{clause}. "
-      mark_failure
-    else
-      mark_message "MoabRecord#last_version_audit all newer than #{clause}. "
-    end
-  end
-
-  private def clause
-    # currently: M2C and C2M are queued on the 1st and 15th of the month, respectively, and
-    # expiry time on CV is 3 months (those are the three audits that touch this timestamp).
-    # M2C should run at most 16 days after C2M (following a 31 day month), but give a little buffer
-    # since the queues might take a while to work down, and ordering for enqueue is uncertain.
-    21.days.ago
-  end
-end
-OkComputer::Registry.register 'feature-version-audit-window-check', VersionAuditWindowCheck.new
-
 # TODO: do we want anything about s3 credentials here?
 
-optional_checks = %w[feature-version-audit-window-check external-workflow-services-url]
+optional_checks = %w[external-workflow-services-url]
 optional_checks << 'feature-zip_storage_dir' if worker_host?
 OkComputer.make_optional optional_checks

--- a/spec/config/okcomputer_spec.rb
+++ b/spec/config/okcomputer_spec.rb
@@ -15,16 +15,6 @@ describe 'OkComputer custom checks' do # rubocop:disable RSpec/DescribeClass
     end
   end
 
-  describe VersionAuditWindowCheck do
-    it { is_expected.to be_successful }
-
-    context 'with old data' do
-      before { allow(MoabRecord).to receive(:version_audit_expired).with(any_args).and_return([double]) }
-
-      it { is_expected.not_to be_successful }
-    end
-  end
-
   describe DirectoryExistsCheck do
     it 'successful for existing directory' do
       expect(described_class.new(Settings.zip_storage)).to be_successful


### PR DESCRIPTION
closes #2195

## Why was this change made? 🤔
This is an expensive test to be performing every few seconds.



## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
