### PR TITLE
Fix build and silence deprecation warning

### DIFF
--- a/app/services/audit/checksum_validator.rb
+++ b/app/services/audit/checksum_validator.rb
@@ -103,7 +103,7 @@ module Audit
     end
 
     def logger
-      @logger ||= Logger.new($stdout).extend(ActiveSupport::Logger.broadcast(Logger.new(Rails.root.join('log', 'cv.log'))))
+      @logger ||= Logger.new($stdout).extend(ActiveSupport::Logger.broadcast(Logger.new(Rails.root.join('log', 'audit_checksum_validation.log'))))
     end
 
     # Validates files on storage against the manifest inventory

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,7 +44,8 @@ module PreservationCatalog
       error_class: JSONAPIError,
       accept_request_filter: accept_proc,
       parse_response_by_content_type: false,
-      query_hash_key: 'action_dispatch.request.query_parameters'
+      query_hash_key: 'action_dispatch.request.query_parameters',
+      strict_reference_validation: true
     )
     # TODO: we can uncomment this at a later date to ensure we are passing back
     #       valid responses. Currently, uncommenting this line causes 24 spec

--- a/spec/services/audit/checksum_validator_utils_spec.rb
+++ b/spec/services/audit/checksum_validator_utils_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Audit::ChecksumValidatorUtils do
   end
 
   describe '.logger' do
-    let(:logfile) { Rails.root.join('log', 'cv.log') }
+    let(:logfile) { Rails.root.join('log', 'audit_checksum_validation.log') }
 
     before { allow(described_class).to receive(:logger).and_call_original } # undo silencing for 1 test
 


### PR DESCRIPTION
## Why was this change made? 🤔

- build is currently broken, see e.g. [here](https://app.circleci.com/pipelines/github/sul-dlss/preservation_catalog/1847/workflows/fe1b590e-b835-4700-8a46-ce82d2a2b040/jobs/4702/tests#failed-test-0).  this gets rid of a couple straggler references to `cv.log`
- we're getting some annoying deprecation warnings from `Committee::Middleware::RequestValidation`, which the config param here should silence


## How was this change tested? 🤨

unit/CI, `preassembly_image_accessioning_spec.rb` and `preassembly_hfs_accessioning_spec.rb`


⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
