### PR TITLE
move Audit::Results::DB_OBJ_ALREADY_EXISTS from audit workflow report codes to honeybadger report codes

### DIFF
--- a/app/services/audit_reporters/audit_workflow_reporter.rb
+++ b/app/services/audit_reporters/audit_workflow_reporter.rb
@@ -14,7 +14,6 @@ module AuditReporters
     def handled_merge_codes
       [
         Audit::Results::ACTUAL_VERS_LT_DB_OBJ,
-        Audit::Results::DB_OBJ_ALREADY_EXISTS,
         Audit::Results::DB_UPDATE_FAILED,
         Audit::Results::DB_VERSIONS_DISAGREE,
         Audit::Results::FILE_NOT_IN_MANIFEST,

--- a/app/services/audit_reporters/honeybadger_reporter.rb
+++ b/app/services/audit_reporters/honeybadger_reporter.rb
@@ -7,6 +7,7 @@ module AuditReporters
 
     def handled_single_codes
       [
+        Audit::Results::DB_OBJ_ALREADY_EXISTS,
         Audit::Results::MOAB_FILE_CHECKSUM_MISMATCH,
         Audit::Results::MOAB_NOT_FOUND,
         Audit::Results::ZIP_PART_CHECKSUM_MISMATCH,


### PR DESCRIPTION
## Why was this change made? 🤔

this can happen when pres robots alerts pres cat to a moab version that's already been cataloged, as might happen when the update-catalog workflow step sits after having failed, and the moab version is detected by e.g. moab-to-catalog audit before the step is retried.

it's unusual, and worth a glance, but shouldn't wedge preservation or accessioning workflows.

will take this out of draft if/when https://github.com/sul-dlss/preservation_robots/pull/469 is merged.

once this and the pres robots PR are merged and deployed, we should (hopefully) be able to easily clear the druids wedged at the `update-catalog` step atm, by using argo to reset the workflow step en masse, instead of manually marking the step complete for individual druids (whether via argo show page or WFS rails console/rake task)

## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
