### PR TITLE
openapi spec: allow POST/PUT/PATCH requests to /v1/catalog* to use Content-Type=application/json

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -63,7 +63,13 @@ class CatalogController < ApiController
 
   # @return boolean
   def checksums_validated
-    return params[:checksums_validated].casecmp('true').zero? if params[:checksums_validated]
-    false
+    case params[:checksums_validated]
+    when TrueClass, FalseClass
+      params[:checksums_validated]
+    when String
+      params[:checksums_validated].casecmp('true').zero?
+    else
+      false
+    end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -372,20 +372,19 @@ components:
         application/x-www-form-urlencoded:
           schema:
             $ref: '#/components/schemas/CatalogOptions'
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CatalogOptions'
     CatalogOptionsWithDruid:
       description: Common options (plus druid) for PUT/POST/PATCH operations to the catalog controller
       required: true
       content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CatalogOptionsWithDruid'
         application/x-www-form-urlencoded:
           schema:
-            allOf:
-              - $ref: '#/components/schemas/CatalogOptions'
-              - type: object
-                properties:
-                  druid:
-                    $ref: '#/components/schemas/Druid'
-                required:
-                  - druid
+            $ref: '#/components/schemas/CatalogOptionsWithDruid'
   schemas:
     Druid:
       description: Digital Repository Unique Identifier (bare or prefixed)
@@ -427,6 +426,16 @@ components:
         - incoming_version
         - incoming_size
         - storage_location
+    CatalogOptionsWithDruid:
+      allOf:
+        - $ref: '#/components/schemas/CatalogOptions'
+        - type: object
+          properties:
+            druid:
+              $ref: '#/components/schemas/Druid'
+          required:
+            - druid
+
     ContentDiff:
       description: A diff between given and existing content metadata (XML)
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -411,17 +411,19 @@ components:
           type: string
         checksums_validated:
           description: If the checksums for the moab object have previously been validated by caller (boolean/int as string)
-          type: string
-          enum:
-            - 'true'
-            - 'True'
-            - 'TRUE'
-            - 'nil'
-            - '1'
-            - 'on'
-            - 'false'
-            - 'False'
-            - 'FALSE'
+          oneOf:
+            - type: boolean
+            - type: string
+              enum:
+                - 'true'
+                - 'True'
+                - 'TRUE'
+                - 'nil'
+                - '1'
+                - 'on'
+                - 'false'
+                - 'False'
+                - 'FALSE'
       required:
         - incoming_version
         - incoming_size

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe CatalogController do
         post :create, params: { druid: bare_druid, incoming_version: ver, incoming_size: size, storage_location: storage_location_param }
       end
 
-      ['true', 'True', 'TRUE'].each do |t_val|
+      ['true', 'True', 'TRUE', true].each do |t_val|
         it "#{t_val} evaluates to true" do
           expect(MoabRecordService::Create).to receive(:execute).with(druid: bare_druid, incoming_version: ver, incoming_size: size,
                                                                       moab_storage_root: moab_storage_root, checksums_validated: true)
@@ -313,7 +313,7 @@ RSpec.describe CatalogController do
                                   checksums_validated: t_val }
         end
       end
-      ['nil', '1', 'on', 'false', 'False', 'FALSE'].each do |t_val|
+      ['nil', '1', 'on', 'false', 'False', 'FALSE', false].each do |t_val|
         it "#{t_val} evaluates to false" do
           expect(MoabRecordService::UpdateVersion).to receive(:execute).with(druid: bare_druid, incoming_version: ver, incoming_size: size,
                                                                              moab_storage_root: moab_storage_root, checksums_validated: false)


### PR DESCRIPTION
## Why was this change made? 🤔

follow on to https://github.com/sul-dlss/preservation_robots/pull/469 and https://github.com/sul-dlss/preservation-client/pull/97

discovered during integration testing on QA of (the updated pres client consumers):
- https://github.com/sul-dlss/dor-services-app/pull/4358
- https://github.com/sul-dlss/argo/pull/3948
- https://github.com/sul-dlss/happy-heron/pull/3006
- https://github.com/sul-dlss/preservation_robots/pull/469

the only trouble spot was that pres robots' updated pres client call is now sending a `Content-Type` of `application/json` instead of `application/x-www-form-urlencoded`.  that resulted in errors like:

addressed in first commit:
```
Preservation::Client::UnexpectedResponseError: Preservation::Client.http_response got 400 from Preservation at v1/catalog: {"errors":[{"status":"bad_request","detail":"\"Content-Type\" request header must be set to \"application/x-www-form-urlencoded\"."}]}
```

addressed in second commit:
```
Preservation::Client::UnexpectedResponseError: Preservation::Client.http_response got 400 from Preservation at v1/catalog: {"errors":[{"status":"bad_request","detail":"#/components/schemas/CatalogOptions/properties/checksums_validated expected string, but received TrueClass: true"}]}
```

see https://app.honeybadger.io/projects/55564/faults/89947127

this PR allows both the openapi spec and the controller method to handle the slightly updated request structure, without changing any other logic.

## How was this change tested? 🤨

unit tests (added one for the new ability to take a boolean for `checksums_validated`), full integration test suite on QA with happy-heron, dor-services-app, pres robots all on the new pres client version (and pres cat on this branch).


⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
