### PR TITLE
Add rake task for validating checksum of single druid.

### DIFF
--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -112,5 +112,12 @@ namespace :prescat do
     task :cv, [:storage_root_name] => [:environment] do |_task, args|
       MoabStorageRoot.find_by!(name: args[:storage_root_name]).moab_records.find_each(&:validate_checksums!)
     end
+
+    desc 'run CV (checksum validation) for a single druid'
+    task :cv_single, [:druid] => [:environment] do |_task, args|
+      puts "Starting checksum validation for #{args[:druid]}"
+      MoabRecord.by_druid(args[:druid]).first.validate_checksums!
+      puts 'This may take some time. Any issues will be reported to Honeybadger.'
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Easier FR.



## How was this change tested? 🤨
Prod



⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
