### PR TITLE
Fix to prune rake task.

### DIFF
--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -18,10 +18,12 @@ namespace :prescat do
 
   desc 'Prune failed replication records from catalog'
   task :prune_failed_replication, [:druid, :version, :verify_expiration] => :environment do |_task, args|
-    args.with_defaults(verify_expiration: true)
-    Replication::FailureRemediator.prune_replication_failures(druid: args[:druid],
-                                                              version: args[:version],
-                                                              verify_expiration: args[:verify_expiration]).each do |zmv_version, endpoint_name|
+    args.with_defaults(verify_expiration: 'true')
+    Replication::FailureRemediator.prune_replication_failures(
+      druid: args[:druid],
+      version: args[:version],
+      verify_expiration: args[:verify_expiration] == 'true'
+    ).each do |zmv_version, endpoint_name|
       puts "pruned zipped moab version #{zmv_version} on #{endpoint_name}"
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
So rake task correctly handles boolean arg.



## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
