### PR TITLE
Upgrade to Sidekiq7.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ gem 'pry-byebug' # call 'binding.pry' anywhere in the code to stop execution and
 gem 'pry' # make it possible to use pry for IRB
 gem 'puma', '~> 5.5' # app server
 gem 'rails', '~> 7.0.0'
-gem 'redis', '~> 4.0' # Constrained by Sidekiq
-gem 'sidekiq', '~> 6.4'
+gem 'redis', '~> 5.0'
+gem 'sidekiq', '~> 7.0'
 gem 'turbo-rails'
 gem 'view_component'
 gem 'whenever' # manage cron for audit checks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://gems.contribsys.com/
   specs:
-    sidekiq-pro (5.5.8)
-      sidekiq (~> 6.0, >= 6.5.6)
+    sidekiq-pro (7.0.8)
+      sidekiq (>= 7.0.0, < 8)
 
 GEM
   remote: https://rubygems.org/
@@ -333,7 +333,10 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rbtree (0.4.6)
-    redis (4.8.1)
+    redis (5.0.6)
+      redis-client (>= 0.9.0)
+    redis-client (0.14.0)
+      connection_pool
     regexp_parser (2.7.0)
     reline (0.3.3)
       io-console (~> 0.5)
@@ -385,10 +388,11 @@ GEM
     set (1.0.3)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.5.8)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.0.7)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.11.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -460,14 +464,14 @@ DEPENDENCIES
   puma (~> 5.5)
   rails (~> 7.0.0)
   rails-controller-testing
-  redis (~> 4.0)
+  redis (~> 5.0)
   rspec-rails (~> 4.0)
   rspec_junit_formatter
   rubocop (~> 1.0)
   rubocop-rails
   rubocop-rspec
   shoulda-matchers
-  sidekiq (~> 6.4)
+  sidekiq (~> 7.0)
   sidekiq-pro!
   simplecov
   turbo-rails

--- a/app/jobs/concerns/unique_job.rb
+++ b/app/jobs/concerns/unique_job.rb
@@ -72,8 +72,10 @@ module UniqueJob
       3600
     end
 
-    def redis_connection(&block)
-      Sidekiq.redis(&block)
+    def redis_connection
+      Redis.new(url: Settings.redis_url).tap do |conn|
+        yield conn if block_given?
+      end
     end
 
     # @return [String] the key for locking this job/payload combination, e.g. 'lock:MySpecificJob-bt821jk7040;1'

--- a/config/resque.yml
+++ b/config/resque.yml
@@ -1,2 +1,0 @@
-development: <%= ENV.fetch('REDIS_URL', 'localhost:6379') %>
-test: <%= ENV.fetch('REDIS_URL', 'localhost:6379') %>

--- a/spec/support/job_config.rb
+++ b/spec/support/job_config.rb
@@ -8,7 +8,7 @@ RSpec.configure do |config|
     allow(ActiveJob::Base.logger).to receive(:info) # keep the default logging quiet
 
     begin
-      Sidekiq.redis(&:flushall) # clear queues and locks
+      Redis.new(url: Settings.redis_url).flushall
     rescue Redis::CannotConnectError
       p 'we are rescuing!'
     end


### PR DESCRIPTION
## Why was this change made? 🤔
Latest, greatest.



## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
