### PR TITLE
schedule.rb - improve comments

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -30,7 +30,7 @@ every '0 11 15 * *', roles: [:queue_populator] do
   runner_hb 'MoabStorageRoot.find_each(&:c2m_check!)'
 end
 
-# Proactivily audit to spread out load.
+# Proactively spread out replication audit TTL to keep replication audit queue from having a huge backlog due to similar TTL values.
 # Any that are not validated but hit fixity TTL will be validated by weekly audit below.
 every :day, at: '8pm', roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/c2a-err.log'
@@ -43,7 +43,7 @@ every :wednesday, roles: [:queue_populator] do
   runner_hb 'PreservedObject.archive_check_expired.find_each(&:audit_moab_version_replication!)'
 end
 
-# Proactivily validate to spread out load.
+# Proactively spread out checksum validation TTL to keep validate_checksum audit queue from having a huge backlog due to similar TTL values.
 # Any that are not validated but hit fixity TTL will be validated by weekly validation below.
 every :day, at: '10pm', roles: [:queue_populator] do
   set :output, standard: nil, error: 'log/cv-err.log'


### PR DESCRIPTION
## Why was this change made? 🤔

Less confusion is good for all.


## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
