### PR TITLE
Do not bundle exec when using runner in whenever.

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -13,6 +13,8 @@ Config.load_and_set_settings(Config.setting_files('config', 'production'))
 # If changing the schedule of one of these jobs, also update at https://app.honeybadger.io/projects/54415/check_ins
 job_type :rake_rb, 'cd :path && :environment_variable=:environment bundle exec rake --silent ":task" :output && curl --silent https://api.honeybadger.io/v1/check_in/:check_in'
 job_type :runner_hb, 'cd :path && bin/rails runner -e :environment ":task" :output && curl --silent https://api.honeybadger.io/v1/check_in/:check_in'
+# Overriding default runner job_type to remove invoking bundle exec.
+job_type :runner, 'cd :path && bin/rails runner -e :environment ":task" :output'
 
 # 11 am on the 1st of every month
 # If changing schedule, also change for HB checkin


### PR DESCRIPTION
## Why was this change made? 🤔
Executing with the default runner was failing.



## How was this change tested? 🤨

```
0 20 * * * /bin/bash -l -c 'cd /Users/jlittman/data/sdr/preservation_catalog && bin/rails runner -e production "PreservedObject.order(last_archive_audit: :asc).limit(PreservedObject.daily_check_count).find_each(&:audit_moab_version_replication!)" >> /dev/null 2>> log/c2a-err.log'

0 22 * * * /bin/bash -l -c 'cd /Users/jlittman/data/sdr/preservation_catalog && bin/rails runner -e production "MoabRecord.order(last_checksum_validation: :asc).limit(MoabRecord.daily_check_count).find_each(&:validate_checksums!)" >> /dev/null 2>> log/cv-err.log'``
```

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
