### PR TITLE
Rubocop updates.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-capybara
 
 inherit_from: .rubocop_todo.yml
 inherit_mode:
@@ -525,4 +526,30 @@ RSpec/Rails/MinitestAssertions: # new in 2.17
 Gemspec/DevelopmentDependencies: # new in 1.44
   Enabled: true
 Style/ComparableClamp: # new in 1.44
+  Enabled: true
+
+Lint/DuplicateMatchPattern: # new in 1.50
+  Enabled: true
+Metrics/CollectionLiteralLength: # new in 1.47
+  Enabled: true
+Style/DataInheritance: # new in 1.49
+  Enabled: true
+Style/DirEmpty: # new in 1.48
+  Enabled: true
+Style/FileEmpty: # new in 1.48
+  Enabled: true
+Style/RedundantHeredocDelimiterQuotes: # new in 1.45
+  Enabled: true
+Style/RedundantLineContinuation: # new in 1.49
+  Enabled: true
+Rails/ResponseParsedBody: # new in 2.18
+  # False, since this wreaks havoc.
+  Enabled: false
+Rails/ThreeStateBooleanColumn: # new in 2.19
+  Enabled: true
+RSpec/RedundantAround: # new in 2.19
+  Enabled: true
+RSpec/SkipBlockInsideExample: # new in 2.19
+  Enabled: true
+RSpec/Rails/TravelAround: # new in 2.19
   Enabled: true


### PR DESCRIPTION
## Why was this change made? 🤔




## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
