### PR TITLE
Remove newrelic from qa deploy steps

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -9,4 +9,3 @@ set :rails_env, 'production'
 set :bundle_without, 'deploy test'
 set :deploy_to, '/opt/app/pres/preservation_catalog'
 set :whenever_roles, [:queue_populator, :cache_cleaner]
-append :linked_files, 'config/newrelic.yml'


### PR DESCRIPTION
Prescat does not use newrelic (not even in the Gemfile), and the newrelic.yml file is removed from shared_configs.
