### PR TITLE
Update to latest CI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@3.2.0
+  ruby-rails: sul-dlss/ruby-rails@4.0.0
 workflows:
   build:
     jobs:
@@ -9,17 +9,12 @@ workflows:
       - ruby-rails/lint:
           context: dlss
           name: lint
-          executor:
-            name: ruby-rails/ruby
-            ruby-tag: '3.2.2'
       - ruby-rails/test-rails:
           name: test
           context: dlss
           api-only: true
           db-prepare-command: db:reset
-          executor:
-            name: ruby-rails/ruby-postgres-redis
-            ruby-tag: '3.2.2'
+          executor: ruby-rails/ruby-postgres-redis
       - ruby-rails/docker-publish:
           context: dlss
           name: publish-latest


### PR DESCRIPTION
## Why was this change made? 🤔

It now defaults to Ruby 3.2.2 and has all the latest orb deps.

Keep pace with change.

## How was this change tested? 🤨

CI
