### PR TITLE
Stop auto-requiring whenever gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'redis', '~> 5.0'
 gem 'sidekiq', '~> 7.0'
 gem 'turbo-rails'
 gem 'view_component'
-gem 'whenever' # manage cron for audit checks
+gem 'whenever', require: false # Work around https://github.com/javan/whenever/issues/831
 
 source 'https://gems.contribsys.com/' do
   gem 'sidekiq-pro'


### PR DESCRIPTION
## Why was this change made? 🤔

This commits works around a bug in the whenever gem that has begun crashing the Rails console when doing auto-
complete under Ruby 3.2: https://github.com/javan/whenever/issues/831

We shouldn't need the whenever gem required outside of the Capistrano deploy anyway.

## How was this change tested? 🤨

CI
