### PR TITLE
add link to replication errors wiki in dashboard

### DIFF
--- a/app/views/dashboard/_replication_endpoints.html.erb
+++ b/app/views/dashboard/_replication_endpoints.html.erb
@@ -1,3 +1,4 @@
 <turbo-frame id="replication-endpoints">
+  <p>See <a href="https://github.com/sul-dlss/preservation_catalog/wiki/Replication-errors">Replication Errors wiki</a> for information on how to resolve errors.</p>
   <%= render Dashboard::ReplicationEndpointsComponent.new %>
 </turbo-frame>


### PR DESCRIPTION
## Why was this change made? 🤔

Because I think the wiki page is now stable enough to warrant linking from the part of the dashboard where we would most like to see it.

## How was this change tested? 🤨




⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/README.md).⚡
