### PR TITLE
add instructions for doing a complete reset of QA or stage (including wiping out preserved SDR content), other touchups

### DIFF
--- a/app/services/catalog_utils.rb
+++ b/app/services/catalog_utils.rb
@@ -34,8 +34,8 @@ class CatalogUtils
     end
   end
 
-  def self.seed_catalog_for_dir(storage_dir)
-    logger.info "#{Time.now.utc.iso8601} Seeding starting for '#{storage_dir}'"
+  def self.populate_catalog_for_dir(storage_dir)
+    logger.info "#{Time.now.utc.iso8601} Starting to populate catalog for '#{storage_dir}'"
     results = []
     ms_root = MoabStorageRoot.find_by!(storage_location: storage_dir)
     MoabOnStorage::StorageDirectory.find_moab_paths(storage_dir) do |druid, path, _path_match_data|
@@ -45,16 +45,15 @@ class CatalogUtils
     end
     results
   ensure
-    logger.info "#{Time.now.utc.iso8601} Seeding ended for '#{storage_dir}'"
+    logger.info "#{Time.now.utc.iso8601} Ended populating catalog for '#{storage_dir}'"
   end
 
-  # TODO: If needing to run several seed jobs in parallel, convert seeding to queues.
-  def self.seed_catalog_for_all_storage_roots
-    MoabStorageRoot.pluck(:storage_location).each { |location| seed_catalog_for_dir(location) }
+  def self.populate_catalog_for_all_storage_roots
+    MoabStorageRoot.pluck(:storage_location).each { |location| populate_catalog_for_dir(location) }
   end
 
   def self.populate_moab_storage_root(name)
     ms_root = MoabStorageRoot.find_by!(name: name)
-    seed_catalog_for_dir(ms_root.storage_location)
+    populate_catalog_for_dir(ms_root.storage_location)
   end
 end


### PR DESCRIPTION
* remove some redundancy from the README
* fix some ambiguous/unnecessary Rails terminology re-use in our own util methods and documentation, see https://github.com/sul-dlss/preservation_catalog/issues/1154

# Why was this change made? 🤔

* part of sul-dlss/argo#4052
* closes sul-dlss/preservation_catalog#1154


# How was this change tested? 🤨

CI, and a slightly different version of the reset procedure will be tried as part of the upcoming QA and stage reset (see this [comment describing the one-off this first reset will use](https://github.com/sul-dlss/argo/issues/4052#issuecomment-1690550978))

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation (including cloud replication)_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



