### PR TITLE
Remove unnecessary json suffix from endpoint.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -143,7 +143,7 @@ paths:
           example: 'druid:bc123df4567'
           schema:
             $ref: '#/components/schemas/Druid'
-  /v1/objects/{id}/checksum.json:
+  /v1/objects/{id}/checksum:
     get:
       tags:
         - objects

--- a/spec/requests/objects_controller_checksums_spec.rb
+++ b/spec/requests/objects_controller_checksums_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ObjectsController do
   describe 'GET #checksum' do
     context 'when object found' do
       it 'response contains the object checksum when given a prefixed druid' do
-        get checksum_object_url(prefixed_druid, format: :json), headers: valid_auth_header
+        get checksum_object_url(prefixed_druid), headers: valid_auth_header
         expected_response = [
           { filename: 'eric-smith-dissertation.pdf',
             md5: 'aead2f6f734355c59af2d5b2689e4fb3',
@@ -31,7 +31,7 @@ RSpec.describe ObjectsController do
       end
 
       it 'response contains the object checksum when given a bare druid' do
-        get checksum_object_url(bare_druid, format: :json), headers: valid_auth_header
+        get checksum_object_url(bare_druid), headers: valid_auth_header
         expected_response = [
           { filename: 'eric-smith-dissertation.pdf',
             md5: 'aead2f6f734355c59af2d5b2689e4fb3',
@@ -51,14 +51,14 @@ RSpec.describe ObjectsController do
 
     context 'when object not found' do
       it 'returns a 404 response code' do
-        get checksum_object_url(prefixed_missing_druid, format: :json), headers: valid_auth_header
+        get checksum_object_url(prefixed_missing_druid), headers: valid_auth_header
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context 'when bad parameter passed in' do
       it 'returns a 400 response code' do
-        get checksum_object_url('not a druid', format: :json), headers: valid_auth_header
+        get checksum_object_url('not a druid'), headers: valid_auth_header
         expect(response).to have_http_status(:bad_request)
       end
     end


### PR DESCRIPTION
# Why was this change made? 🤔




# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation (including cloud replication)_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



