### PR TITLE
Adds connection pool for redis. Increases timeout for redis.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # general Ruby/Rails gems
 gem 'aws-sdk-s3', '~> 1.17'
 gem 'committee' # Validates HTTP requests/responses per OpenAPI specification
+gem 'connection_pool' # Used for redis
 gem 'config' # Settings to manage configs on different instances
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'jbuilder', '~> 2.5' # Build JSON APIs with ease.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -461,6 +461,7 @@ DEPENDENCIES
   capybara
   committee
   config
+  connection_pool
   debug
   dlss-capistrano
   dor-event-client (~> 1.0)

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+pool_size = ENV.fetch('RAILS_MAX_THREADS', 5)
+
+REDIS = ConnectionPool.new(size: pool_size) do
+  Redis.new(url: Settings.redis_url, timeout: Settings.redis_timeout)
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
+# See separate initializer for redis used by unique job.
+
+# Note the increased timeouts to try to address Redis timeouts
 Sidekiq.configure_server do |config|
-  config.redis = { url: Settings.redis_url }
+  config.redis = { url: Settings.redis_url, network_timeout: Settings.redis_timeout, pool_timeout: Settings.redis_timeout }
   # For Sidekiq Pro
   config.super_fetch!
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: Settings.redis_url }
+  config.redis = { url: Settings.redis_url, network_timeout: Settings.redis_timeout, pool_timeout: Settings.redis_timeout }
 end
 Sidekiq::Client.reliable_push! unless Rails.env.test?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -59,6 +59,7 @@ rabbitmq:
   password: guest
 
 redis_url: redis://localhost:6379/
+redis_timeout: 5 # seconds
 
 honeybadger_checkins:
   moab_to_catalog: xyzzy
@@ -69,3 +70,4 @@ honeybadger_checkins:
 slow_queries:
   enable: false
   threshold: 500
+


### PR DESCRIPTION
# Why was this change made? 🤔
To try to address redis timeouts in production.



# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation (including cloud replication)_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡

Ran c2m and sdr deposit spec in stage.


# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



