### PR TITLE
Report ZIP_PARTS_SIZE_INCONSISTENCY to HB and event service, and other smallt touchups

### DIFF
--- a/app/jobs/validate_moab_job.rb
+++ b/app/jobs/validate_moab_job.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 # Confirm checksums for one Moab object on storage (not in database)
-# Called from ObjectsController, which is typically called by preservation-robots
-#   in validate-moab step of preservationIngestWF step
+# @note Called from ObjectsController, which is typically called by preservation-robots
+#   in validate-moab step of preservationIngestWF
 # (https://github.com/sul-dlss/workflow-server-rails/blob/main/config/workflows/preservationIngestWF.xml#L18) -
+# For explanation as to why, see comment in preservation_robots Robots::SdrRepo::PreservationIngest::ValidateMoab.
 class ValidateMoabJob < ApplicationJob
   queue_as :validate_moab
 

--- a/app/services/audit_reporters/audit_workflow_reporter.rb
+++ b/app/services/audit_reporters/audit_workflow_reporter.rb
@@ -25,14 +25,13 @@ module AuditReporters
         Audit::Results::MOAB_NOT_FOUND,
         Audit::Results::SIGNATURE_CATALOG_NOT_IN_MOAB,
         Audit::Results::UNABLE_TO_CHECK_STATUS,
-        Audit::Results::UNEXPECTED_VERSION
-        # Temporary fix for workflow-service throwing exceptions
-        # because some error reports from MoabReplicationAudit are too long
-        # ZIP_PART_CHECKSUM_MISMATCH,
-        # ZIP_PART_NOT_FOUND,
-        # ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL,
-        # ZIP_PARTS_COUNT_INCONSISTENCY,
-        # ZIP_PARTS_NOT_ALL_REPLICATED
+        Audit::Results::UNEXPECTED_VERSION,
+        Audit::Results::ZIP_PART_CHECKSUM_MISMATCH,
+        Audit::Results::ZIP_PART_NOT_FOUND,
+        Audit::Results::ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL,
+        Audit::Results::ZIP_PARTS_COUNT_INCONSISTENCY,
+        Audit::Results::ZIP_PARTS_SIZE_INCONSISTENCY,
+        Audit::Results::ZIP_PARTS_NOT_ALL_REPLICATED
       ].freeze
     end
 

--- a/app/services/audit_reporters/event_service_reporter.rb
+++ b/app/services/audit_reporters/event_service_reporter.rb
@@ -31,7 +31,8 @@ module AuditReporters
         Audit::Results::ZIP_PART_NOT_FOUND,
         Audit::Results::ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL,
         Audit::Results::ZIP_PARTS_COUNT_INCONSISTENCY,
-        Audit::Results::ZIP_PARTS_NOT_ALL_REPLICATED
+        Audit::Results::ZIP_PARTS_NOT_ALL_REPLICATED,
+        Audit::Results::ZIP_PARTS_SIZE_INCONSISTENCY
       ].freeze
     end
 

--- a/app/services/audit_reporters/honeybadger_reporter.rb
+++ b/app/services/audit_reporters/honeybadger_reporter.rb
@@ -14,7 +14,8 @@ module AuditReporters
         Audit::Results::ZIP_PART_NOT_FOUND,
         Audit::Results::ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL,
         Audit::Results::ZIP_PARTS_COUNT_INCONSISTENCY,
-        Audit::Results::ZIP_PARTS_NOT_ALL_REPLICATED
+        Audit::Results::ZIP_PARTS_NOT_ALL_REPLICATED,
+        Audit::Results::ZIP_PARTS_SIZE_INCONSISTENCY
       ].freeze
     end
 

--- a/spec/services/audit/checksum_validator_spec.rb
+++ b/spec/services/audit/checksum_validator_spec.rb
@@ -486,7 +486,7 @@ RSpec.describe Audit::ChecksumValidator do
 
       before { allow(Audit::Results).to receive(:new).and_return(results) }
 
-      it 'adds a MANIFEST_NOT_IN_MOAB error' do
+      it 'adds a SIGNATURE_CATALOG_NOT_IN_MOAB error' do
         expect(results).to receive(:add_result).with(
           Audit::Results::SIGNATURE_CATALOG_NOT_IN_MOAB, signature_catalog_path: "#{object_dir}/v0002/manifests/signatureCatalog.xml"
         )


### PR DESCRIPTION
# Why was this change made? 🤔

ideally we would've done this at the time we added the check, but we forgot, and then declined to fix it at the time because QA and stage were a mess, and we were worried about noise.  now that QA and stage have been reset, we should have less concern about noise, so we'll see how widespread an issue this is in prod.  see https://github.com/sul-dlss/preservation_catalog/pull/1993


# How was this change tested? 🤨

CI

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation (including cloud replication)_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

N/A, no UI change

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



