### PR TITLE
Remove replication-related result codes from audit workflow reporter

### DIFF
--- a/app/services/audit_reporters/audit_workflow_reporter.rb
+++ b/app/services/audit_reporters/audit_workflow_reporter.rb
@@ -11,6 +11,11 @@ module AuditReporters
       ]
     end
 
+    # We only want codes pertaining to local moabs reported to the audit
+    # workflow. I.e., we filter out codes about replication because when the
+    # audit workflow gets in an error state for a given druid, it cannot be
+    # further versioned (e.g., remediated). We monitor replication failures via
+    # other reporters.
     def handled_merge_codes
       [
         Audit::Results::ACTUAL_VERS_LT_DB_OBJ,
@@ -25,13 +30,7 @@ module AuditReporters
         Audit::Results::MOAB_NOT_FOUND,
         Audit::Results::SIGNATURE_CATALOG_NOT_IN_MOAB,
         Audit::Results::UNABLE_TO_CHECK_STATUS,
-        Audit::Results::UNEXPECTED_VERSION,
-        Audit::Results::ZIP_PART_CHECKSUM_MISMATCH,
-        Audit::Results::ZIP_PART_NOT_FOUND,
-        Audit::Results::ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL,
-        Audit::Results::ZIP_PARTS_COUNT_INCONSISTENCY,
-        Audit::Results::ZIP_PARTS_SIZE_INCONSISTENCY,
-        Audit::Results::ZIP_PARTS_NOT_ALL_REPLICATED
+        Audit::Results::UNEXPECTED_VERSION
       ].freeze
     end
 


### PR DESCRIPTION
# Why was this change made?

Fixes #2278

# How was this change tested?

CI
