### PR TITLE
unpin gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'druid-tools' # for druid validation and druid-tree parsing
 gem 'moab-versioning', '~> 6.0' # work with Moab Objects
 
 group :development, :test do
-  gem 'rspec-rails', '~> 4.0'
+  gem 'rspec-rails'
   # Ruby static code analyzer https://rubocop.readthedocs.io/en/latest/
   gem 'rubocop', '~> 1.0'
   gem 'rubocop-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ source 'https://gems.contribsys.com/' do
 end
 
 # Stanford gems
-gem 'dor-event-client', '~> 1.0'
+gem 'dor-event-client'
 gem 'dor-workflow-client' # audit errors are reported to the workflow service
 gem 'druid-tools' # for druid validation and druid-tree parsing
 gem 'moab-versioning', '~> 6.0' # work with Moab Objects

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ end
 
 # Stanford gems
 gem 'dor-event-client', '~> 1.0'
-gem 'dor-workflow-client', '~> 5.0' # audit errors are reported to the workflow service
+gem 'dor-workflow-client' # audit errors are reported to the workflow service
 gem 'druid-tools' # for druid validation and druid-tree parsing
 gem 'moab-versioning', '~> 6.0' # work with Moab Objects
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'postgresql_cursor' # for paging over large result sets efficiently
 # pry is useful for debugging, even in prod
 gem 'pry-byebug' # call 'binding.pry' anywhere in the code to stop execution and get a pry-byebug console
 gem 'pry' # make it possible to use pry for IRB
-gem 'puma', '~> 5.5' # app server
+gem 'puma' # app server
 gem 'rails', '~> 7.0.0'
 gem 'redis', '~> 5.0'
 gem 'sidekiq', '~> 7.0'

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ end
 group :test do
   gem 'capybara'
   gem 'debug'
-  gem 'factory_bot_rails', '~> 4.0'
+  gem 'factory_bot_rails'
   gem 'rails-controller-testing'
   gem 'shoulda-matchers'
   gem 'simplecov'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'committee' # Validates HTTP requests/responses per OpenAPI specification
 gem 'connection_pool' # Used for redis
 gem 'config' # Settings to manage configs on different instances
 gem 'honeybadger' # for error reporting / tracking / notifications
-gem 'jbuilder', '~> 2.5' # Build JSON APIs with ease.
+gem 'jbuilder' # Build JSON APIs with ease.
 gem 'jwt' # for gating programmatic access to the application
 gem 'lograge'
 gem 'okcomputer' # ReST endpoint with upness status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,7 +479,7 @@ DEPENDENCIES
   postgresql_cursor
   pry
   pry-byebug
-  puma (~> 5.5)
+  puma
   rails (~> 7.0.0)
   rails-controller-testing
   redis (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,7 +469,7 @@ DEPENDENCIES
   druid-tools
   factory_bot_rails
   honeybadger
-  jbuilder (~> 2.5)
+  jbuilder
   jwt
   listen (~> 3.7)
   lograge

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,14 +362,14 @@ GEM
     rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (4.1.2)
-      actionpack (>= 4.2)
-      activesupport (>= 4.2)
-      railties (>= 4.2)
-      rspec-core (~> 3.10)
-      rspec-expectations (~> 3.10)
-      rspec-mocks (~> 3.10)
-      rspec-support (~> 3.10)
+    rspec-rails (6.0.3)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      railties (>= 6.1)
+      rspec-core (~> 3.12)
+      rspec-expectations (~> 3.12)
+      rspec-mocks (~> 3.12)
+      rspec-support (~> 3.12)
     rspec-support (3.12.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -483,7 +483,7 @@ DEPENDENCIES
   rails (~> 7.0.0)
   rails-controller-testing
   redis (~> 5.0)
-  rspec-rails (~> 4.0)
+  rspec-rails
   rspec_junit_formatter
   rubocop (~> 1.0)
   rubocop-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,11 +204,11 @@ GEM
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
     erubi (1.12.0)
-    factory_bot (4.11.1)
-      activesupport (>= 3.0.0)
-    factory_bot_rails (4.11.1)
-      factory_bot (~> 4.11.1)
-      railties (>= 3.0.0)
+    factory_bot (6.4.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.0)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
     faraday (2.7.11)
       base64
       faraday-net_http (>= 2.0, < 3.1)
@@ -467,7 +467,7 @@ DEPENDENCIES
   dor-event-client (~> 1.0)
   dor-workflow-client (~> 5.0)
   druid-tools
-  factory_bot_rails (~> 4.0)
+  factory_bot_rails
   honeybadger
   jbuilder (~> 2.5)
   jwt

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GEM
       activesupport (>= 4.2, < 8)
       bunny (~> 2.17)
       zeitwerk (~> 2.1)
-    dor-workflow-client (5.1.0)
+    dor-workflow-client (6.0.0)
       activesupport (>= 3.2.1, < 8)
       deprecation (>= 0.99.0)
       faraday (~> 2.0)
@@ -465,7 +465,7 @@ DEPENDENCIES
   debug
   dlss-capistrano
   dor-event-client (~> 1.0)
-  dor-workflow-client (~> 5.0)
+  dor-workflow-client
   druid-tools
   factory_bot_rails
   honeybadger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,7 +464,7 @@ DEPENDENCIES
   connection_pool
   debug
   dlss-capistrano
-  dor-event-client (~> 1.0)
+  dor-event-client
   dor-workflow-client
   druid-tools
   factory_bot_rails


### PR DESCRIPTION
# Why was this change made? 

pinning is only useful when it's to solve a problem, and even then, an explanation of the problem or what is needed to unpin should be provided.

I left a bunch of gems pinned as I think they might have more impact (sidekiq, redis, rails, aws-sdk ...)


# How was this change tested?

CI.  


