### PR TITLE
Adds rake task for deleting from cloud storage.

### DIFF
--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -40,6 +40,58 @@ namespace :prescat do
     puts "Backfilled with: #{zipped_moab_versions}"
   end
 
+  desc 'Purge zips from cloud storage'
+  # For purging zips from cloud storage one endpoint at a time.
+  # Ops will provide a time-limited access key and secret access key for the endpoint.
+  # CSV should be in the format of druid,version,endpoint_name without a header.
+  # For example: druid:bd632bd2980,3,aws_s3_east_1
+  task :purge_zips, [:csv_filename, :endpoint_name, :access_key, :secret_access_key, :dry_run] => :environment do |_task, args|
+    args.with_defaults(dry_run: 'true')
+
+    provider = case args[:endpoint_name]
+               when 'aws_s3_east_1'
+                 Replication::AwsProvider.new(region: Settings.zip_endpoints.aws_s3_east_1.region,
+                                              access_key_id: args[:access_key],
+                                              secret_access_key: args[:secret_access_key])
+               when 'aws_s3_west_2'
+                 Replication::AwsProvider.new(region: Settings.zip_endpoints.aws_s3_west_2.region,
+                                              access_key_id: args[:access_key],
+                                              secret_access_key: args[:secret_access_key])
+               when 'ibm_us_south'
+                 Replication::IbmProvider.new(region: Settings.zip_endpoints.ibm_us_south.region,
+                                              access_key_id: args[:access_key],
+                                              secret_access_key: args[:secret_access_key])
+               else
+                 raise ArgumentError, "Unknown endpoint_name: #{args[:endpoint_name]}"
+               end
+    zip_endpoint = ZipEndpoint.find_by(endpoint_name: args[:endpoint_name])
+
+    CSV.foreach(args[:csv_filename], headers: [:druid, :version, :endpoint_name]) do |row|
+      next unless row[:endpoint_name] == args[:endpoint_name]
+
+      druid = row[:druid].delete_prefix('druid:')
+      version = row[:version].to_i
+      zipped_moab_version = ZippedMoabVersion.by_druid(druid).find_by(zip_endpoint: zip_endpoint, version: version)
+      next unless zipped_moab_version
+
+      zipped_moab_version.zip_parts.each do |zip_part|
+        zip_info = "#{druid} (#{version}) #{zip_part.s3_key} from #{args[:endpoint_name]}"
+        s3_object = provider.bucket.object(zip_part.s3_key)
+        unless s3_object.exists?
+          puts "Skipping since does not exist: #{zip_info}"
+          next
+        end
+        if args[:dry_run] == 'false'
+          puts "Deleting: #{zip_info}"
+          s3_object.delete
+          zip_part.not_found!
+        else
+          puts "Dry run deleting: #{zip_info}"
+        end
+      end
+    end
+  end
+
   namespace :cache_cleaner do
     desc 'Clean zip storage cache of empty directories'
     task empty_directories: :environment do


### PR DESCRIPTION
# Why was this change made? 🤔
Ops is handing over responsibility for deleting from production cloud storage. This rake task support this.



# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation (including cloud replication)_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡

production

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



