### PR TITLE
Pin turbo to avoid getting 2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'puma' # app server
 gem 'rails', '~> 7.0.0'
 gem 'redis', '~> 5.0'
 gem 'sidekiq', '~> 7.0'
-gem 'turbo-rails'
+gem 'turbo-rails', '~> 1.0'
 gem 'view_component'
 gem 'whenever', require: false # Work around https://github.com/javan/whenever/issues/831
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,7 +492,7 @@ DEPENDENCIES
   sidekiq (~> 7.0)
   sidekiq-pro!
   simplecov
-  turbo-rails
+  turbo-rails (~> 1.0)
   view_component
   webmock
   whenever


### PR DESCRIPTION
# Why was this change made? 🤔
To void getting breaking v2.

<img width="759" alt="image" src="https://github.com/sul-dlss/preservation_catalog/assets/588335/49c8e7b6-cb94-4093-a846-58e9ea10c167">



# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation (including cloud replication)_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



