### PR TITLE
Switch to importmap and propshaft.

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -8,9 +8,8 @@ require "capistrano/scm/git"
 install_plugin Capistrano::SCM::Git
 
 require "capistrano/bundler"
-# require "capistrano/rails/assets"
-require "capistrano/rails/migrations"
 require "capistrano/passenger"
+require "capistrano/rails"
 require "capistrano/honeybadger"
 require "dlss/capistrano"
 require 'whenever/capistrano'

--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,14 @@ gem 'committee' # Validates HTTP requests/responses per OpenAPI specification
 gem 'connection_pool' # Used for redis
 gem 'config' # Settings to manage configs on different instances
 gem 'honeybadger' # for error reporting / tracking / notifications
+gem "importmap-rails", "~> 1.2"
 gem 'jbuilder' # Build JSON APIs with ease.
 gem 'jwt' # for gating programmatic access to the application
 gem 'lograge'
 gem 'okcomputer' # ReST endpoint with upness status
 gem 'pg' # postgres database
 gem 'postgresql_cursor' # for paging over large result sets efficiently
+gem 'propshaft', '~> 0.8.0' # asset pipeline
 # pry is useful for debugging, even in prod
 gem 'pry-byebug' # call 'binding.pry' anywhere in the code to stop execution and get a pry-byebug console
 gem 'pry' # make it possible to use pry for IRB

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,10 @@ GEM
     honeybadger (5.3.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    importmap-rails (1.2.3)
+      actionpack (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      railties (>= 6.0.0)
     io-console (0.6.0)
     irb (1.9.1)
       rdoc
@@ -289,6 +293,11 @@ GEM
     pg (1.5.4)
     postgresql_cursor (0.6.8)
       activerecord (>= 6.0)
+    propshaft (0.8.0)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
+      railties (>= 7.0.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -469,6 +478,7 @@ DEPENDENCIES
   druid-tools
   factory_bot_rails
   honeybadger
+  importmap-rails (~> 1.2)
   jbuilder
   jwt
   listen (~> 3.7)
@@ -477,6 +487,7 @@ DEPENDENCIES
   okcomputer
   pg
   postgresql_cursor
+  propshaft (~> 0.8.0)
   pry
   pry-byebug
   puma

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,2 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "@hotwired/turbo-rails"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,9 +8,7 @@
     <title>SUL - Preservation Catalog</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
-    <script type="module">
-      import hotwiredTurbo from 'https://cdn.skypack.dev/@hotwired/turbo';
-    </script>
+    <%= javascript_importmap_tags %>
   </head>
 
   <body>

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -20,7 +20,7 @@ set :deploy_to, "/opt/app/pres/#{fetch(:application)}"
 append :linked_files, 'config/database.yml'
 
 # Default value for linked_dirs is []
-append :linked_dirs, 'log', 'config/settings', 'tmp/pids'
+append :linked_dirs, 'log', 'config/settings', 'tmp/pids', 'vendor/bundle'
 
 set :honeybadger_env, fetch(:stage)
 
@@ -52,3 +52,9 @@ end
 
 set :sidekiq_systemd_role, :worker
 set :sidekiq_systemd_use_hooks, true
+
+# configure capistrano-rails to work with propshaft instead of sprockets
+# (we don't have public/assets/.sprockets-manifest* or public/assets/manifest*.*)
+set :assets_manifests, lambda {
+  [release_path.join('public', fetch(:assets_prefix), '.manifest.json')]
+}

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Pin npm packages by running ./bin/importmap
+
+pin 'application', preload: true
+pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true


### PR DESCRIPTION
closes #2288

# Why was this change made? 🤔
So that dashboard will render.



# How was this change tested? 🤨

QA

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation (including cloud replication)_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



