### PR TITLE
Audit zip part size

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'puma' # app server
 gem 'rails', '~> 7.0.0'
 gem 'redis', '~> 5.0'
 gem 'sidekiq', '~> 7.0'
+gem 'tty-progressbar' # to show progress of long-running tasks
 gem 'turbo-rails', '~> 1.0'
 gem 'view_component'
 gem 'whenever', require: false # Work around https://github.com/javan/whenever/issues/831

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,8 +406,16 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
     stringio (3.1.0)
+    strings-ansi (0.2.0)
     thor (1.3.1)
     timeout (0.4.1)
+    tty-cursor (0.7.1)
+    tty-progressbar (0.18.2)
+      strings-ansi (~> 0.2)
+      tty-cursor (~> 0.7)
+      tty-screen (~> 0.8)
+      unicode-display_width (>= 1.6, < 3.0)
+    tty-screen (0.8.1)
     turbo-rails (1.5.0)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
@@ -479,6 +487,7 @@ DEPENDENCIES
   sidekiq (~> 7.0)
   sidekiq-pro!
   simplecov
+  tty-progressbar
   turbo-rails (~> 1.0)
   view_component
   webmock


### PR DESCRIPTION
# Why was this change made? 🤔
Need a mechanism to run this audit against everything and output to CSV.



# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation (including cloud replication)_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



