### PR TITLE
Okcomputer 🐇 check and misc touchups

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,9 @@
 
 # How was this change tested? 🤨
 
-⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation (including cloud replication)_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡
+⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.
+
+The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
   redis:
-    image: redis:3
+    image: redis:7
     command: redis-server
     ports:
       - 6379:6379

--- a/spec/config/okcomputer_spec.rb
+++ b/spec/config/okcomputer_spec.rb
@@ -37,4 +37,35 @@ describe 'OkComputer custom checks' do # rubocop:disable RSpec/DescribeClass
       expect(described_class.new('i-do-not-exist')).not_to be_successful
     end
   end
+
+  describe RabbitQueueExistsCheck do
+    let(:bunny_conn) { instance_double(Bunny::Session) }
+    let(:queue_name1) { 'foo.first_queue' }
+    let(:queue_name2) { 'foo.second_queue' }
+
+    before do
+      allow(bunny_conn).to receive_messages(start: bunny_conn, status: :open, close: true)
+      allow(bunny_conn).to receive(:queue_exists?).with(queue_name1).and_return(queue_exists1)
+      allow(bunny_conn).to receive(:queue_exists?).with(queue_name2).and_return(queue_exists2)
+      allow(Bunny).to receive(:new).and_return(bunny_conn)
+    end
+
+    context 'when the expected queues are present' do
+      let(:queue_exists1) { true }
+      let(:queue_exists2) { true }
+
+      it 'succeeds if the expected queue exists' do
+        expect(described_class.new([queue_name1, queue_name2])).to be_successful
+      end
+    end
+
+    context 'when a queue is missing' do
+      let(:queue_exists1) { true }
+      let(:queue_exists2) { false }
+
+      it 'succeeds if the expected queue exists' do
+        expect(described_class.new([queue_name1, queue_name2])).not_to be_successful
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

* add okcomputer check for expected RabbitMQ queues as suggested in https://github.com/sul-dlss/preservation_catalog/issues/2291 (ironically, it was added to a [few](https://github.com/sul-dlss/happy-heron/pull/3436) [other](https://github.com/sul-dlss/dor-services-app/pull/4661) [apps](https://github.com/sul-dlss/dor_indexing_app/pull/1073) before pres cat).
* bump redis in docker compose to currently deployed major version
* freshen PR template (fix reference to renamed infra integration test, add a little whitespace to testing hint for readability)

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_image_accessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_image_accessioning_spec.rb) against stage as it tests preservation (including cloud replication)_**, and/or test in stage environment, in addition to specs. The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡

* unit tests
* deployed to stage to test new okcomputer check (see screenshot 1)
* viewed PR template updated by this PR (see screenshot 2)

_**okcomputer with added check for rabbitMQ connection:**_

![Screenshot 2024-01-10 at 5 46 29 PM](https://github.com/sul-dlss/preservation_catalog/assets/7741604/7e9124f8-7faa-4807-b11c-e6676a0c6a24)

_**updated PR template:**_

![Screenshot 2024-01-10 at 5 52 11 PM](https://github.com/sul-dlss/preservation_catalog/assets/7741604/f33f3a03-0b75-4c8c-969d-9629ca78f699)



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡

N/A, no web UI changes

