### PR TITLE
Handle nil returned when creating zipped moab versions in MoabReplica…

### DIFF
--- a/app/jobs/audit/moab_replication_audit_job.rb
+++ b/app/jobs/audit/moab_replication_audit_job.rb
@@ -22,7 +22,7 @@ module Audit
     def backfill_missing_zipped_moab_versions(preserved_object)
       return false unless Settings.replication.audit_should_backfill
       zipped_moab_versions = preserved_object.create_zipped_moab_versions!
-      return false if zipped_moab_versions.empty?
+      return false if zipped_moab_versions.blank?
       Audit::ReplicationSupport.logger.warn(
         "#{self.class}: #{preserved_object.druid} backfilled #{zipped_moab_versions.count} ZippedMoabVersions: #{format_zmvs(zipped_moab_versions)}"
       )


### PR DESCRIPTION
…tionAuditJob.

closes #2314

# Why was this change made? 🤔
Bug fix based on HB alert.



# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



