### PR TITLE
Bump Ruby to 3.3.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ inherit_mode:
     - Exclude
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   DisplayCopNames: true
   Include:
     - './Rakefile'

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'aws-sdk-s3', '~> 1.17'
 gem 'committee' # Validates HTTP requests/responses per OpenAPI specification
 gem 'connection_pool' # Used for redis
 gem 'config' # Settings to manage configs on different instances
+gem 'csv' # will be removed from standard library in Ruby 3.4
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem "importmap-rails", "~> 1.2"
 gem 'jbuilder' # Build JSON APIs with ease.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    csv (3.2.8)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -469,6 +470,7 @@ DEPENDENCIES
   committee
   config
   connection_pool
+  csv
   debug
   dlss-capistrano
   dor-event-client

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 ##
 # ObjectsController allows consumers to interact with preserved objects
 #  (Note: methods will eventually be ported from sdr-services-app)

--- a/app/services/audit/checksum_validator_utils.rb
+++ b/app/services/audit/checksum_validator_utils.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 module Audit
   # Helper methods for invoking Audit::ChecksumValidator.
   # These are for use from the Rails console; they are not called from the app.

--- a/app/services/moab_storage_root_report_service.rb
+++ b/app/services/moab_storage_root_report_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 ##
 # run queries and produce reports from the results, for consumption
 # by preservation catalog maintainers

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 namespace :prescat do
   desc 'Diagnose failed replication'
   task :diagnose_replication, [:druid] => :environment do |_task, args|

--- a/spec/services/catalog_utils_spec.rb
+++ b/spec/services/catalog_utils_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'csv'
 
 RSpec.describe CatalogUtils do
   let(:storage_dir) { 'spec/fixtures/storage_root01/sdr2objects' }


### PR DESCRIPTION
# Why was this change made? 🤔




# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



