### PR TITLE
[README] fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/96b330db62f304b786cb/test_coverage)](https://codeclimate.com/github/sul-dlss/preservation_catalog/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/96b330db62f304b786cb/maintainability)](https://codeclimate.com/github/sul-dlss/preservation_catalog/maintainability)
 [![GitHub version](https://badge.fury.io/gh/sul-dlss%2Fpreservation_catalog.svg)](https://badge.fury.io/gh/sul-dlss%2Fpreservation_catalog)
-[![Docker image](https://images.microbadger.com/badges/image/suldlss/preservation_catalog.svg)](https://microbadger.com/images/suldlss/preservation_catalog "Get your own image badge on microbadger.com")
-[![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/preservation_catalog/main/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/preservation_catalog/main/openapi.yml)
+[![Docker image](https://img.shields.io/docker/pulls/suldlss/preservation_catalog.svg)](https://hub.docker.com/r/suldlss/preservation_catalog)
+[![OpenAPI Validator](https://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/preservation_catalog/main/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/preservation_catalog/main/openapi.yml)
 
 ## Overview
 


### PR DESCRIPTION

# Why was this change made? 🤔

fix docker hub and openapi validation status badges

* badge service previously in use for docker hub seems defunct, use a working image and link directly to docker hub
* need to make openapi validation link https


# How was this change tested? 🤨

via markdown preview:

before fix:
<img width="860" alt="Screenshot 2025-01-21 at 9 17 36 PM" src="https://github.com/user-attachments/assets/feccda6d-768d-4d4a-a2cd-183c3fd3b51d" />

after this PR:
<img width="982" alt="Screenshot 2025-01-21 at 9 18 34 PM" src="https://github.com/user-attachments/assets/f643bdba-27e9-4d93-acda-085cbb469fb3" />





# Does your change introduce accessibility violations? 🩺

no