### PR TITLE
Switch from CodeClimate to CodeCov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@4.3.0
+  ruby-rails: sul-dlss/ruby-rails@4.4.0
 workflows:
   build:
     jobs:
@@ -15,6 +15,7 @@ workflows:
           name: test
           context: dlss
           api-only: true
+          use-codecov: true
           db-prepare-command: db:reset
           executor: ruby-rails/ruby-postgres-redis
       - ruby-rails/docker-publish:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+comment: false
+coverage:
+  status:
+    project: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # preservation_catalog (aka PresCat)
 
 [![CircleCI](https://circleci.com/gh/sul-dlss/preservation_catalog.svg?style=svg)](https://circleci.com/gh/sul-dlss/preservation_catalog)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/96b330db62f304b786cb/test_coverage)](https://codeclimate.com/github/sul-dlss/preservation_catalog/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/96b330db62f304b786cb/maintainability)](https://codeclimate.com/github/sul-dlss/preservation_catalog/maintainability)
+[![codecov](https://codecov.io/github/sul-dlss/preservation_catalog/graph/badge.svg?token=dyOwoVHZ1y)](https://codecov.io/github/sul-dlss/preservation_catalog)
 [![GitHub version](https://badge.fury.io/gh/sul-dlss%2Fpreservation_catalog.svg)](https://badge.fury.io/gh/sul-dlss%2Fpreservation_catalog)
 [![Docker image](https://img.shields.io/docker/pulls/suldlss/preservation_catalog.svg)](https://hub.docker.com/r/suldlss/preservation_catalog)
 [![OpenAPI Validator](https://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/preservation_catalog/main/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/preservation_catalog/main/openapi.yml)
@@ -56,7 +55,7 @@ Use `docker compose` to start supporting services (PostgreSQL and Redis)
 docker compose up -d db redis
 ```
 
-### Configure the database 
+### Configure the database
 
 Set up the database:
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,12 +3,19 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'simplecov'
-require 'webmock/rspec'
 SimpleCov.start :rails do
   add_filter '/spec/'
   add_filter '/vendor/'
   add_filter '/lib/'
+
+  if ENV['CI']
+    require 'simplecov_json_formatter'
+
+    formatter SimpleCov::Formatter::JSONFormatter
+  end
 end
+
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   config.filter_run_excluding(:live_s3) unless ENV['CI'] == 'true' # default exclude unless on CI


### PR DESCRIPTION
# Why was this change made? 🤔




# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



