### PR TITLE
Add log formatter to application config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,11 @@ module PreservationCatalog
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    # Add timestamps to all loggers (both Rack-based ones and e.g. Sidekiq's)
+    config.log_formatter = proc do |severity, datetime, _progname, msg|
+      "[#{datetime.to_fs(:iso8601)}] [#{severity}] #{msg}\n"
+    end
+
     # accept_request_filter omits OKComputer & Sidekiq routes
     accept_proc = proc { |request| request.path.start_with?('/v1') }
     config.middleware.use(

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,10 +50,7 @@ Rails.application.configure do
   end
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [
-    ->(_request) { Time.now.iso8601 },
-    :request_id
-  ]
+  config.log_tags = [:request_id]
 
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you


### PR DESCRIPTION
# Why was this change made? 🤔




# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



