### PR TITLE
Attempt to fix flaky tests

### DIFF
--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,20 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-
-# A very simple job class that extends ApplicationJob to allow testing of basic queue locking behavior
-class RegularParameterJob < ApplicationJob
-  include UniqueJob
-  def self.lock_timeout
-    1
-  end
-
-  def perform(param_a, param_b, should_raise)
-    Rails.logger.info("simulate a running job to better test queue locking: (#{param_a}, #{param_b}, #{should_raise})")
-
-    raise 'oops' if should_raise
-  end
-end
+require 'regular_parameter_job'
 
 RSpec.describe ApplicationJob do
   include ActiveJob::TestHelper

--- a/spec/regular_parameter_job.rb
+++ b/spec/regular_parameter_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# A very simple job class that extends ApplicationJob to allow testing of basic queue locking behavior
+class RegularParameterJob < ApplicationJob
+  include UniqueJob
+  def self.lock_timeout
+    1
+  end
+
+  def perform(param_a, param_b, should_raise)
+    Rails.logger.info("simulate a running job to better test queue locking: (#{param_a}, #{param_b}, #{should_raise})")
+
+    raise 'oops' if should_raise
+  end
+end


### PR DESCRIPTION
# Why was this change made? 🤔

The `spec/jobs/application_job_spec.rb` specs are flaky and now fail repeatedly in CI (though pass locally).  This is an attempt to address it.
