### PR TITLE
add missing Audit::ChecksumValidator#validate method

### DIFF
--- a/app/services/audit/checksum_validator.rb
+++ b/app/services/audit/checksum_validator.rb
@@ -16,6 +16,11 @@ module Audit
       @emit_results = emit_results
     end
 
+    def validate
+      validate_manifest_inventories
+      validate_signature_catalog
+    end
+
     def validate_manifest_inventories
       # This will populate the results object
       moab_storage_object.version_list.each { |moab_version| ManifestInventoryValidator.validate(moab_version:, checksum_validator: self) }

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -181,7 +181,7 @@ namespace :prescat do
       Audit::ChecksumValidator.new(
         moab_storage_object: MoabOnStorage.moab(storage_location: args[:storage_location], druid: args[:druid]),
         emit_results: true
-      ).validate!
+      ).validate
     end
 
     desc 'run replication audit for a single druid'

--- a/spec/services/audit/checksum_validator_spec.rb
+++ b/spec/services/audit/checksum_validator_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::ChecksumValidator do
+  let(:checksum_validator) { described_class.new(moab_storage_object:, emit_results:) }
+
+  let(:moab_storage_object) { MoabOnStorage.moab(storage_location:, druid:) }
+  let(:emit_results) { true }
+
+  describe '#validate' do
+    context 'valid moab' do
+      let(:storage_location) { Rails.root.join('spec/fixtures/storage_root01/sdr2objects/') }
+      let(:druid) { 'bj102hs9687' }
+      let(:expected_result_string) do
+        "validate_checksums (actual location: #{storage_location}; actual version: 3)"
+      end
+
+      context 'emit_results is false' do
+        let(:emit_results) { false }
+
+        it 'does not print anything to stdout' do
+          expect { checksum_validator.validate }.not_to output.to_stdout
+        end
+      end
+
+      it 'does not detect errors' do
+        expect { checksum_validator.validate }.to output(/#{Regexp.escape(expected_result_string)}/).to_stdout
+        expect(checksum_validator.results.results_as_string).not_to include('errors')
+        expect(checksum_validator.results.results_as_string).to include(expected_result_string)
+      end
+    end
+
+    context 'invalid_moab' do
+      let(:storage_location) { Rails.root.join('spec/fixtures/checksum_root01/sdr2objects/') }
+      let(:druid) { 'zz925bx9565' }
+      let(:expected_result_string) do
+        "validate_checksums (actual location: #{storage_location}; actual version: 2) " \
+          "checksums or size for #{storage_location}zz/925/bx/9565/zz925bx9565/v0001/manifests/versionAdditions.xml version v1 do not " \
+          'match entry in latest signatureCatalog.xml. ' \
+          "&& checksums or size for #{storage_location}zz/925/bx/9565/zz925bx9565/v0002/manifests/versionInventory.xml version v2 do not " \
+          'match entry in latest signatureCatalog.xml. ' \
+          '&& Invalid Moab, validation errors: ["manifestInventory object_id does not match druid"]'
+      end
+
+      it 'detects errors' do
+        expect { checksum_validator.validate }.to output(/#{Regexp.escape(expected_result_string)}/).to_stdout
+        expect(checksum_validator.results.results_as_string).to include('errors')
+        expect(checksum_validator.results.results_as_string).to include(expected_result_string)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Why was this change made? 🤔

tweak call in `prescat:audit:validate_uncataloged` rake task to call `validate` instead of `validate!` (small method rename since the method doesn't have side-effects).

this got the rake task working in my basic command line testing, otherwise i got e.g.
```
% be rake  prescat:audit:validate_uncataloged\['bj102hs9687','spec/fixtures/storage_root01/sdr2objects/'\]
Starting checksum validation for bj102hs9687 in spec/fixtures/storage_root01/sdr2objects/ (NOTE: this may take some time!)
rake aborted!
NoMethodError: undefined method 'validate!' for an instance of Audit::ChecksumValidator (NoMethodError)

      ).validate!
       ^^^^^^^^^^
```

after that i got e.g.
```
% be rake  prescat:audit:validate_uncataloged\['bj102hs9687','spec/fixtures/storage_root01/sdr2objects/'\]                           
Starting checksum validation for bj102hs9687 in spec/fixtures/storage_root01/sdr2objects/ (NOTE: this may take some time!)
I, [2025-04-03T15:44:52.065193 #34367]  INFO -- : validate_checksums (actual location: spec/fixtures/storage_root01/sdr2objects/; actual version: 3)
```

i was also able to detect errors:
```
% be rake  prescat:audit:validate_uncataloged\['zz925bx9565','spec/fixtures/checksum_root01/sdr2objects/'\]
Starting checksum validation for zz925bx9565 in spec/fixtures/checksum_root01/sdr2objects/ (NOTE: this may take some time!)
I, [2025-04-03T16:09:50.640320 #35665]  INFO -- : validate_checksums (actual location: spec/fixtures/checksum_root01/sdr2objects/; actual version: 2) checksums or size for spec/fixtures/checksum_root01/sdr2objects/zz/925/bx/9565/zz925bx9565/v0001/manifests/versionAdditions.xml version v1 do not match entry in latest signatureCatalog.xml. && checksums or size for spec/fixtures/checksum_root01/sdr2objects/zz/925/bx/9565/zz925bx9565/v0002/manifests/versionInventory.xml version v2 do not match entry in latest signatureCatalog.xml. && Invalid Moab, validation errors: ["manifestInventory object_id does not match druid"]
```

# How was this change tested? 🤨

above described manual testing, unit tests

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



