### PR TITLE
Deflappify application job spec

### DIFF
--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -17,15 +17,6 @@ class RegularParameterJob < ApplicationJob
 end
 
 RSpec.describe ApplicationJob do
-  include ActiveJob::TestHelper
-
-  around do |example|
-    old_adapter = ActiveJob::Base.queue_adapter
-    ActiveJob::Base.queue_adapter = :sidekiq
-    example.run
-    ActiveJob::Base.queue_adapter = old_adapter
-  end
-
   it 'queues start empty' do
     expect(enqueued_jobs.size).to eq 0
   end

--- a/spec/support/job_config.rb
+++ b/spec/support/job_config.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
+  config.include ActiveJob::TestHelper, type: :job
+
   config.before do
     next unless RSpec.current_example.metadata[:type] == :job
 
-    ActiveJob::Base.queue_adapter = :test
     allow(ActiveJob::Base.logger).to receive(:info) # keep the default logging quiet
 
     begin


### PR DESCRIPTION
# Why was this change made?

Flappy specs make for grumpy developers.

Closes #2394 

I used an RSpec seed from a failing build in CI and analyzed which tests were running when. From there I was able to determine that the application job spec *always* fails when run after the replication integration spec. That led me to removing all the manual queue adapter jazz and making job specs consistently use the test adapter. I have now run the job specs in the same order as used to reproducibly fail about thirty times in a row with no failures, and run the whole suite a bunch of times with other random seeds. Looks better to me now, at least.

I suspect that this used to work just fine, but then the job testing harness and adapter defaults changed circa Rails 5-to-6 or 6-to-7.

# How was this change tested?

See above.
