### PR TITLE
per request from ops, halve expiry time for the zip files that we generate to send to cloud archive endpoints

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,7 +28,7 @@ workflow_services_url: 'https://workflows.example.org/workflow/'
 
 checksum_algos: ['md5'] # 'sha1' 'sha256'
 
-zip_cache_expiry_time: '+20160' # this is UNIX `find` speak for "greater than 14 days"
+zip_cache_expiry_time: '+10080' # this is UNIX `find` speak for "greater than 7 days"
 zip_storage: '/tmp' # override in #{RAILS_ENV}.yml
 
 # When the backlog of unreplicated moabs is very large, e.g. when first spinning up


### PR DESCRIPTION
# Why was this change made? 🤔

requested by @julianmorley in slack conversation: https://stanfordlib.slack.com/archives/C04D8DJDRJ9/p1743787754692749



# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



