### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -6,7 +6,6 @@ server 'preservation-catalog-prod-02.stanford.edu', user: 'pres', roles: %w[app 
 server 'preservation-catalog-prod-03.stanford.edu', user: 'pres', roles: %w[app worker]
 server 'preservation-catalog-prod-04.stanford.edu', user: 'pres', roles: %w[app worker cache_cleaner]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 set :bundle_without, 'deploy test'
 set :deploy_to, '/opt/app/pres/preservation_catalog'

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -4,7 +4,6 @@ server 'preservation-catalog-web-qa-01.stanford.edu', user: 'pres', roles: %w[ap
 server 'preservation-catalog-web-qa-02.stanford.edu', user: 'pres', roles: %w[app web]
 server 'preservation-catalog-qa-02.stanford.edu', user: 'pres', roles: %w[app worker db queue_populator cache_cleaner]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 set :bundle_without, 'deploy test'
 set :deploy_to, '/opt/app/pres/preservation_catalog'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -4,7 +4,6 @@ server 'preservation-catalog-web-stage-01.stanford.edu', user: 'pres', roles: %w
 server 'preservation-catalog-web-stage-02.stanford.edu', user: 'pres', roles: %w[app web]
 server 'preservation-catalog-stage-02.stanford.edu', user: 'pres', roles: %w[app db worker queue_populator cache_cleaner]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 set :bundle_without, 'deploy test'
 set :deploy_to, '/opt/app/pres/preservation_catalog'


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.