### PR TITLE
avoid possible S3 key conflict conflict in live S3 test

### DIFF
--- a/spec/services/replication/shared_examples_provider.rb
+++ b/spec/services/replication/shared_examples_provider.rb
@@ -44,7 +44,8 @@ RSpec.shared_examples 'provider' do |provider_class, bucket_name, region, access
     describe '::Aws::S3::Object#upload_file' do
       subject(:s3_object) { bucket.object("test_key_#{test_key_id}") }
 
-      let(:test_key_id) { ENV.fetch('CIRCLE_SHA1', '000')[0..6] }
+      # ensure a unique S3 key so that there aren't collisions between runs (e.g. GCP CI bucket is configured as write-once, like deployed envs)
+      let(:test_key_id) { "#{DateTime.now.strftime('%Y%m%d_%H%M%S')}_#{SecureRandom.alphanumeric}" }
       let(:dvz) { Replication::DruidVersionZip.new('bj102hs9687', 2) }
       let(:dvz_part) { Replication::DruidVersionZipPart.new(dvz, dvz.s3_key('.zip')) }
       let(:digest) { dvz_part.base64digest }


### PR DESCRIPTION
# Why was this change made? 🤔

see e.g. `Aws::S3::Errors::AccessDenied` error at https://app.circleci.com/pipelines/github/sul-dlss/preservation_catalog/2455/workflows/98b3ce04-c6a6-44d4-9b46-c19e8f47281c/jobs/6663

@edsu ran into this issue when working on dependency updates this week.  we thought something like this would be a reasonable fix when pairing.


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



