### PR TITLE
update gcp endpoint setting name again

### DIFF
--- a/app/jobs/replication/gcp_delivery_job.rb
+++ b/app/jobs/replication/gcp_delivery_job.rb
@@ -5,15 +5,15 @@ module Replication
   # @note this class name appears in config files for the endpoints for which it delivers content.
   #   Please update the configs for the various environments if it's renamed or moved.
   class GcpDeliveryJob < Replication::DeliveryJobBase
-    queue_as :gcp_us_central_delivery
+    queue_as :gcp_us_south_delivery
 
     # perform method is defined in DeliveryJobBase
 
     def bucket
       Replication::GcpProvider.new(
-        region: Settings.zip_endpoints.gcp_s3_central_1.region,
-        access_key_id: Settings.zip_endpoints.gcp_s3_central_1.access_key_id,
-        secret_access_key: Settings.zip_endpoints.gcp_s3_central_1.secret_access_key
+        region: Settings.zip_endpoints.gcp_s3_south_1.region,
+        access_key_id: Settings.zip_endpoints.gcp_s3_south_1.access_key_id,
+        secret_access_key: Settings.zip_endpoints.gcp_s3_south_1.secret_access_key
       ).bucket
     end
   end

--- a/app/services/replication/gcp_provider.rb
+++ b/app/services/replication/gcp_provider.rb
@@ -11,7 +11,7 @@ module Replication
         region: region,
         access_key_id: access_key_id,
         secret_access_key: secret_access_key,
-        endpoint: Settings.zip_endpoints.gcp_s3_central_1.endpoint_node
+        endpoint: Settings.zip_endpoints.gcp_s3_south_1.endpoint_node
       }
     end
 
@@ -22,7 +22,7 @@ module Replication
 
     # @return [String]
     def bucket_name
-      Settings.zip_endpoints.gcp_s3_central_1.storage_location
+      Settings.zip_endpoints.gcp_s3_south_1.storage_location
     end
 
     # @return [::Aws::S3::Resource]

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -31,10 +31,10 @@ zip_endpoints:
     audit_class: 'Audit::ReplicationToIbm'
     access_key_id: 'overridden-by-env-var-in-ci'
     secret_access_key: 'overridden-by-env-var-in-ci'
-  gcp_s3_central_1:
-    region: 'us-central1'
+  gcp_s3_south_1:
+    region: 'us-south1'
     endpoint_node: 'https://storage.googleapis.com'
-    storage_location: 'sdr-us-central-test'
+    storage_location: 'gcp-us-south-test'
     delivery_class: 'Replication::GcpDeliveryJob'
     audit_class: 'Audit::ReplicationToGcp'
     access_key_id: 'overridden-by-env-var-in-ci'

--- a/spec/jobs/audit/moab_replication_audit_job_spec.rb
+++ b/spec/jobs/audit/moab_replication_audit_job_spec.rb
@@ -44,7 +44,7 @@ describe Audit::MoabReplicationAuditJob do
       it 'creates missing zipped moab versions and logs a warning' do
         expect(preserved_object).to receive(:create_zipped_moab_versions!).and_call_original
         expect(logger).to receive(:warn)
-          .with(/backfilled 6 ZippedMoabVersions: 1 to aws_s3_west_2; 1 to gcp_s3_central_1; 1 to ibm_us_south; 2 to aws_s3_west_2; 2 to gcp_s3_central_1; 2 to ibm_us_south/) # rubocop:disable Layout/LineLength
+          .with(/backfilled 6 ZippedMoabVersions: 1 to aws_s3_west_2; 1 to gcp_s3_south_1; 1 to ibm_us_south; 2 to aws_s3_west_2; 2 to gcp_s3_south_1; 2 to ibm_us_south/) # rubocop:disable Layout/LineLength
         expect(Audit::Replication).not_to receive(:results)
         job.perform(preserved_object)
       end

--- a/spec/jobs/replication/integration_spec.rb
+++ b/spec/jobs/replication/integration_spec.rb
@@ -66,7 +66,7 @@ describe 'the whole replication pipeline' do # rubocop:disable RSpec/DescribeCla
     expect(Dor::Event::Client).to receive(:create).with(
       druid: "druid:#{druid}",
       type: 'druid_version_replicated',
-      data: a_hash_including({ host: 'fakehost', version: 1, endpoint_name: 'gcp_s3_central_1' })
+      data: a_hash_including({ host: 'fakehost', version: 1, endpoint_name: 'gcp_s3_south_1' })
     )
 
     # creating or updating a MoabRecord should trigger its parent PreservedObject to replicate any missing versions to any target endpoints
@@ -110,7 +110,7 @@ describe 'the whole replication pipeline' do # rubocop:disable RSpec/DescribeCla
       expect(Dor::Event::Client).to receive(:create).with(
         druid: "druid:#{druid}",
         type: 'druid_version_replicated',
-        data: a_hash_including({ host: 'fakehost', version: 3, endpoint_name: 'gcp_s3_central_1' })
+        data: a_hash_including({ host: 'fakehost', version: 3, endpoint_name: 'gcp_s3_south_1' })
       )
 
       perform_enqueued_jobs do

--- a/spec/models/zip_endpoint_spec.rb
+++ b/spec/models/zip_endpoint_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe ZipEndpoint do
       # run it a second time
       expect { described_class.seed_from_config }
         .not_to change { described_class.pluck(:endpoint_name).sort }
-        .from(%w[aws_s3_west_2 gcp_s3_central_1 ibm_us_south zip-endpoint])
+        .from(%w[aws_s3_west_2 gcp_s3_south_1 ibm_us_south zip-endpoint])
     end
 
     it 'adds new ZipEndpoint record if there are new Settings.zip_endpoint key names' do
@@ -95,7 +95,7 @@ RSpec.describe ZipEndpoint do
 
       # run it a second time
       described_class.seed_from_config
-      expected_ep_names = %w[aws_s3_west_2 fixture_archiveTest gcp_s3_central_1 ibm_us_south zip-endpoint]
+      expected_ep_names = %w[aws_s3_west_2 fixture_archiveTest gcp_s3_south_1 ibm_us_south zip-endpoint]
       expect(described_class.pluck(:endpoint_name).sort).to eq expected_ep_names
     end
 
@@ -113,7 +113,7 @@ RSpec.describe ZipEndpoint do
 
       # run it a second time
       described_class.seed_from_config
-      expected_ep_names = %w[aws_s3_west_2 gcp_s3_central_1 ibm_us_south zip-endpoint]
+      expected_ep_names = %w[aws_s3_west_2 gcp_s3_south_1 ibm_us_south zip-endpoint]
       expect(described_class.pluck(:endpoint_name).sort).to eq expected_ep_names
       expect(Honeybadger).to have_received(:notify).with(
         'Error trying to insert record for new zip endpoint, skipping entry',
@@ -178,7 +178,7 @@ RSpec.describe ZipEndpoint do
 
         po.zipped_moab_versions.create!(version: version, zip_endpoint: other_ep1)
         expect(described_class.which_need_archive_copy(druid, version).pluck(:endpoint_name).sort).to eq %w[
-          gcp_s3_central_1 ibm_us_south zip-endpoint
+          gcp_s3_south_1 ibm_us_south zip-endpoint
         ]
         expect(described_class.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name).sort).to eq names
         expect(described_class.which_need_archive_copy(other_druid, version).pluck(:endpoint_name).sort).to eq names
@@ -186,12 +186,12 @@ RSpec.describe ZipEndpoint do
 
         po2.zipped_moab_versions.create!(version: version - 1, zip_endpoint: other_ep1)
         expect(described_class.which_need_archive_copy(druid, version).pluck(:endpoint_name).sort).to eq %w[
-          gcp_s3_central_1 ibm_us_south zip-endpoint
+          gcp_s3_south_1 ibm_us_south zip-endpoint
         ]
         expect(described_class.which_need_archive_copy(druid, version - 1).pluck(:endpoint_name).sort).to eq names
         expect(described_class.which_need_archive_copy(other_druid, version).pluck(:endpoint_name).sort).to eq names
         expect(described_class.which_need_archive_copy(other_druid, version - 1).pluck(:endpoint_name).sort).to eq %w[
-          gcp_s3_central_1 ibm_us_south zip-endpoint
+          gcp_s3_south_1 ibm_us_south zip-endpoint
         ]
       end
     end

--- a/spec/services/audit/replication_to_gcp_spec.rb
+++ b/spec/services/audit/replication_to_gcp_spec.rb
@@ -5,5 +5,5 @@ require 'services/audit/shared_examples_replication_to_endpoint'
 
 RSpec.describe Audit::ReplicationToGcp do
   # Shared examples takes: klass, bucket_name, check_name, endpoint_name, region
-  it_behaves_like 'replication to endpoint', Replication::GcpProvider, 'sul-sdr-gcp-bucket', 'GcpAuditSpec', 'gcp_s3_central_1', 'us-central1'
+  it_behaves_like 'replication to endpoint', Replication::GcpProvider, 'sul-sdr-gcp-bucket', 'GcpAuditSpec', 'gcp_s3_south_1', 'us-south1'
 end

--- a/spec/services/replication/gcp_provider_spec.rb
+++ b/spec/services/replication/gcp_provider_spec.rb
@@ -5,22 +5,22 @@ require 'services/replication/shared_examples_provider'
 
 describe Replication::GcpProvider do
   it_behaves_like 'provider', described_class,
-                  Settings.zip_endpoints.gcp_s3_central_1.storage_location,
-                  Settings.zip_endpoints.gcp_s3_central_1.region,
-                  Settings.zip_endpoints.gcp_s3_central_1.access_key_id,
-                  Settings.zip_endpoints.gcp_s3_central_1.secret_access_key
+                  Settings.zip_endpoints.gcp_s3_south_1.storage_location,
+                  Settings.zip_endpoints.gcp_s3_south_1.region,
+                  Settings.zip_endpoints.gcp_s3_south_1.access_key_id,
+                  Settings.zip_endpoints.gcp_s3_south_1.secret_access_key
 
   describe '.resource' do
     let(:provider) do
       described_class.new(
-        region: Settings.zip_endpoints.gcp_s3_central_1.region,
+        region: Settings.zip_endpoints.gcp_s3_south_1.region,
         access_key_id: 'some_key',
         secret_access_key: 'secret'
       )
     end
 
     it 'builds a client with an http/s endpoint setting' do
-      expect(Aws::S3::Resource).to receive(:new).with(hash_including(endpoint: Settings.zip_endpoints.gcp_s3_central_1.endpoint_node))
+      expect(Aws::S3::Resource).to receive(:new).with(hash_including(endpoint: Settings.zip_endpoints.gcp_s3_south_1.endpoint_node))
       provider.resource
     end
   end


### PR DESCRIPTION
# Why was this change made? 🤔

turns out the new endpoint is going to be in the US south region afterall, for parity with IBM, since that region was chosen specifically for geographic diversity compared to the AWS endpionts (which aren't changing in any way at present).

i have an idea, which i'll ticket, for making the code more flexible with respect to hardcoded endpoint names in settings references and the need to coordinate endpoint names across all environments because of the hardcoding.  for now, churn for accuracy and expediency.

there is a current puppet PR for access info in stage and prod that lines up with this PR.  i'll update QA settings in shared_configs and puppet to match this PR, and will deal with the cleanup for in flight jobs (QA GCP creds already needed rotating due to a desire to switch it to a new service account as our GCP setup has shaped up).

similar to https://github.com/sul-dlss/preservation_catalog/pull/2413


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



