### PR TITLE
Switch to dor-services-client over dor-workflow-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'config' # Settings to manage configs on different instances
 gem 'connection_pool' # Used for redis
 gem 'csv' # will be removed from standard library in Ruby 3.4
 gem 'dor-event-client'
-gem 'dor-workflow-client' # audit errors are reported to the workflow service
+gem 'dor-services-client'
 gem 'druid-tools' # for druid validation and druid-tree parsing
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'importmap-rails', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     amq-protocol (2.3.4)
     ast (2.4.3)
+    attr_extras (7.1.0)
     aws-eventstream (1.4.0)
     aws-partitions (1.1122.0)
     aws-sdk-core (3.226.1)
@@ -152,11 +153,25 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chronic (0.10.2)
+    cocina-models (0.104.1)
+      activesupport
+      deprecation
+      dry-struct (~> 1.0)
+      dry-types (~> 1.1)
+      edtf
+      equivalent-xml
+      i18n
+      jsonpath
+      nokogiri
+      openapi_parser (~> 1.0)
+      super_diff
+      thor
+      zeitwerk (~> 2.1)
     coderay (1.1.3)
-    committee (5.5.4)
+    committee (5.0.0)
       json_schema (~> 0.14, >= 0.14.3)
-      openapi_parser (~> 2.0)
-      rack (>= 1.5, < 3.2)
+      openapi_parser (~> 1.0)
+      rack (>= 1.5)
     concurrent-ruby (1.3.5)
     config (5.5.2)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -187,16 +202,43 @@ GEM
       activesupport (>= 4.2)
       bunny (~> 2.17)
       zeitwerk (~> 2.1)
-    dor-workflow-client (7.8.0)
+    dor-services-client (15.15.1)
       activesupport (>= 7.0.0)
-      deprecation (>= 0.99.0)
+      cocina-models (~> 0.104.1)
+      deprecation
       faraday (~> 2.0)
-      faraday-retry (~> 2.0)
-      nokogiri (~> 1.6)
+      faraday-retry
+      nokogiri
       zeitwerk (~> 2.1)
     drb (2.2.3)
     druid-tools (3.0.0)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
+    dry-inflector (1.2.0)
+    dry-logic (1.6.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-struct (1.8.0)
+      dry-core (~> 1.1)
+      dry-types (~> 1.8, >= 1.8.2)
+      ice_nine (~> 0.11)
+      zeitwerk (~> 2.6)
+    dry-types (1.8.3)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
     ed25519 (1.4.0)
+    edtf (3.2.0)
+      activesupport (>= 3.0, < 9.0)
+    equivalent-xml (0.6.0)
+      nokogiri (>= 1.4.3)
     erb (5.0.1)
     erb_lint (0.9.0)
       activesupport
@@ -211,7 +253,7 @@ GEM
     factory_bot_rails (6.5.0)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faraday (2.13.1)
+    faraday (2.13.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -232,6 +274,7 @@ GEM
       ostruct
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     importmap-rails (1.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -247,6 +290,8 @@ GEM
     jmespath (1.6.2)
     json (2.12.2)
     json_schema (0.21.0)
+    jsonpath (1.1.5)
+      multi_json
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
@@ -278,6 +323,7 @@ GEM
       json
       nokogiri
       nokogiri-happymapper
+    multi_json (1.15.0)
     net-http (0.6.0)
       uri
     net-imap (0.5.9)
@@ -308,12 +354,15 @@ GEM
     nokogiri-happymapper (0.10.0)
       nokogiri (~> 1.5)
     okcomputer (1.19.0)
-    openapi_parser (2.2.6)
+    openapi_parser (1.0.0)
+    optimist (3.2.1)
     ostruct (0.6.2)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    patience_diff (1.2.0)
+      optimist (~> 3.0)
     pg (1.5.9)
     postgresql_cursor (0.6.9)
       activerecord (>= 6.0)
@@ -483,6 +532,10 @@ GEM
       net-ssh (>= 2.8.0)
       ostruct
     stringio (3.1.7)
+    super_diff (0.16.0)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
     thor (1.3.2)
     timeout (0.4.3)
     turbo-rails (1.5.0)
@@ -536,7 +589,7 @@ DEPENDENCIES
   debug
   dlss-capistrano
   dor-event-client
-  dor-workflow-client
+  dor-services-client
   druid-tools
   erb_lint
   factory_bot_rails

--- a/app/jobs/validate_moab_job.rb
+++ b/app/jobs/validate_moab_job.rb
@@ -87,34 +87,21 @@ class ValidateMoabJob < ApplicationJob
   end
 
   def log_started
-    workflow_client.update_status(druid: druid,
-                                  workflow: 'preservationIngestWF',
-                                  process: 'validate-moab',
-                                  status: 'started',
-                                  note: "Started by preservation_catalog on #{Socket.gethostname}.")
+    workflow_process.update(status: 'started',
+                            note: "Started by preservation_catalog on #{Socket.gethostname}.")
   end
 
   def log_success(elapsed)
-    workflow_client.update_status(druid: druid,
-                                  workflow: 'preservationIngestWF',
-                                  process: 'validate-moab',
-                                  status: 'completed',
-                                  elapsed: elapsed,
-                                  note: "Completed by preservation_catalog on #{Socket.gethostname}.")
+    workflow_process.update(status: 'completed',
+                            elapsed: elapsed,
+                            note: "Completed by preservation_catalog on #{Socket.gethostname}.")
   end
 
   def log_failure(errors)
-    workflow_client.update_error_status(druid: druid,
-                                        workflow: 'preservationIngestWF',
-                                        process: 'validate-moab',
-                                        error_msg: "Problem with Moab validation run on #{Socket.gethostname}: #{errors}")
+    workflow_process.update_error(error_msg: "Problem with Moab validation run on #{Socket.gethostname}: #{errors}")
   end
 
-  def workflow_client
-    @workflow_client ||=
-      begin
-        wf_log = Logger.new('log/workflow_service.log', 'weekly')
-        Dor::Workflow::Client.new(url: Settings.workflow_services_url, logger: wf_log)
-      end
+  def workflow_process
+    @workflow_process ||= Dor::Services::Client.object(druid).workflow('preservationIngestWF').process('validate-moab')
   end
 end

--- a/config/initializers/dor_services_client.rb
+++ b/config/initializers/dor_services_client.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Configure dor-services-client to use the dor-services URL
+Dor::Services::Client.configure(url: Settings.dor_services.url,
+                                token: Settings.dor_services.token)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,7 +24,9 @@ provlog:
 storage_root_map: # empty here, override in #{RAILS_ENV}.yml
   default: {}
 
-workflow_services_url: 'https://workflows.example.org/workflow/'
+dor_services:
+  url: http://localhost:3003
+  token: TOKEN_GOES_HERE # for token see https://github.com/sul-dlss/dor-services-app#authentication
 
 checksum_algos: ['md5'] # 'sha1' 'sha256'
 

--- a/spec/services/audit_reporters/audit_workflow_reporter_spec.rb
+++ b/spec/services/audit_reporters/audit_workflow_reporter_spec.rb
@@ -3,17 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe AuditReporters::AuditWorkflowReporter do
-  let(:client) { instance_double(Dor::Workflow::Client) }
+  let(:client) { instance_double(Dor::Services::Client::Object, workflow: object_workflow) }
+  let(:object_workflow) { instance_double(Dor::Services::Client::ObjectWorkflow, process:) }
+  let(:process) { instance_double(Dor::Services::Client::Process, update: true, update_error: true) }
   let(:druid) { 'ab123cd4567' }
   let(:actual_version) { 6 }
   let(:ms_root) { MoabStorageRoot.find_by(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
   let(:check_name) { 'FooCheck' }
 
   before do
-    allow(Dor::Workflow::Client).to receive(:new).and_return(client)
-    allow(Settings).to receive(:workflow_services_url).and_return('http://workflow')
-    allow(client).to receive(:update_error_status)
-    allow(client).to receive(:update_status)
+    allow(Dor::Services::Client).to receive(:object).with("druid:#{druid}").and_return(client)
   end
 
   describe '#report_errors' do
@@ -39,16 +38,10 @@ RSpec.describe AuditReporters::AuditWorkflowReporter do
                                           results: [result1, result2])
         error_msg1 = 'FooCheck (actual location: fixture_sr1; actual version: 6) || Invalid Moab, validation errors: ' \
                      "[Version directory name not in 'v00xx' format: original-v1]"
-        expect(client).to have_received(:update_error_status).with(druid: "druid:#{druid}",
-                                                                   workflow: 'preservationAuditWF',
-                                                                   process: 'moab-valid',
-                                                                   error_msg: error_msg1)
+        expect(process).to have_received(:update_error).with(error_msg: error_msg1)
         error_msg2 = 'FooCheck (actual location: fixture_sr1; actual version: 6) || Invalid Moab, validation errors: ' \
                      "[Version directory name not in 'v00xx' format: original-v2]"
-        expect(client).to have_received(:update_error_status).with(druid: "druid:#{druid}",
-                                                                   workflow: 'preservationAuditWF',
-                                                                   process: 'moab-valid',
-                                                                   error_msg: error_msg2)
+        expect(process).to have_received(:update_error).with(error_msg: error_msg2)
       end
     end
 
@@ -64,10 +57,7 @@ RSpec.describe AuditReporters::AuditWorkflowReporter do
                                           results: [result1, result2])
         error_msg = 'FooCheck (actual location: fixture_sr1; actual version: 6) does not match PreservedObject current_version ' \
                     '&& actual version (6) has unexpected relationship to db version'
-        expect(client).to have_received(:update_error_status).with(druid: "druid:#{druid}",
-                                                                   workflow: 'preservationAuditWF',
-                                                                   process: 'preservation-audit',
-                                                                   error_msg: error_msg)
+        expect(process).to have_received(:update_error).with(error_msg: error_msg)
       end
     end
 
@@ -76,21 +66,18 @@ RSpec.describe AuditReporters::AuditWorkflowReporter do
 
       before do
         call_count = 0
-        allow(client).to receive(:update_error_status) do
+        allow(process).to receive(:update_error) do
           call_count += 1
-          call_count == 1 ? raise(Dor::MissingWorkflowException) : nil
+          call_count == 1 ? raise(Dor::Services::Client::NotFoundResponse) : nil
         end
-        allow(client).to receive(:create_workflow_by_name)
+        allow(object_workflow).to receive(:create)
       end
 
       it 'creates the workflow and retries' do
         described_class.new.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result])
         error_msg = 'FooCheck (actual location: fixture_sr1; actual version: 6) does not match PreservedObject current_version'
-        expect(client).to have_received(:update_error_status).with(druid: "druid:#{druid}",
-                                                                   workflow: 'preservationAuditWF',
-                                                                   process: 'preservation-audit',
-                                                                   error_msg: error_msg).twice
-        expect(client).to have_received(:create_workflow_by_name).with("druid:#{druid}", 'preservationAuditWF', version: 6)
+        expect(process).to have_received(:update_error).with(error_msg: error_msg).twice
+        expect(object_workflow).to have_received(:create).with(version: 6)
       end
     end
 
@@ -99,7 +86,7 @@ RSpec.describe AuditReporters::AuditWorkflowReporter do
 
       it 'does not update workflow' do
         described_class.new.report_errors(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, results: [result])
-        expect(client).not_to have_received(:update_error_status)
+        expect(process).not_to have_received(:update_error)
       end
     end
   end
@@ -110,39 +97,24 @@ RSpec.describe AuditReporters::AuditWorkflowReporter do
     it 'updates workflow' do
       described_class.new.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
 
-      expect(client).to have_received(:update_status).with(druid: "druid:#{druid}",
-                                                           workflow: 'preservationAuditWF',
-                                                           process: 'preservation-audit',
-                                                           status: 'completed')
-      expect(client).to have_received(:update_status).with(druid: "druid:#{druid}",
-                                                           workflow: 'preservationAuditWF',
-                                                           process: 'moab-valid',
-                                                           status: 'completed')
+      expect(process).to have_received(:update).with(status: 'completed').twice
     end
 
     context 'when workflow does not exist' do
       before do
         call_count = 0
-        allow(client).to receive(:update_status) do
+        allow(process).to receive(:update) do
           call_count += 1
-          call_count == 1 ? raise(Dor::MissingWorkflowException) : nil
+          call_count == 1 ? raise(Dor::Services::Client::NotFoundResponse) : nil
         end
-        allow(client).to receive(:create_workflow_by_name)
+        allow(object_workflow).to receive(:create)
       end
 
       it 'creates the workflow and retries' do
         described_class.new.report_completed(druid: druid, version: actual_version, storage_area: ms_root, check_name: check_name, result: result)
 
-        expect(client).to have_received(:update_status).with(druid: "druid:#{druid}",
-                                                             workflow: 'preservationAuditWF',
-                                                             process: 'preservation-audit',
-                                                             status: 'completed').once
-        expect(client).to have_received(:update_status).with(druid: "druid:#{druid}",
-                                                             workflow: 'preservationAuditWF',
-                                                             process: 'moab-valid',
-                                                             status: 'completed').twice
-
-        expect(client).to have_received(:create_workflow_by_name).with("druid:#{druid}", 'preservationAuditWF', version: 6)
+        expect(process).to have_received(:update).with(status: 'completed').exactly(3).times
+        expect(object_workflow).to have_received(:create).with(version: 6)
       end
     end
   end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #2442 


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



