### PR TITLE
various maintenance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,15 +5,18 @@
 
 # How was this change tested? 🤨
 
-⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.
+⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.
 
-The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡
+The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).
 
+⚠ Run any integration tests that exercise other services impacted by the change, if any.
+
+⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.
 
 
 # Does your change introduce accessibility violations? 🩺
 
-⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡
+⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.
 
 
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -724,3 +724,18 @@ Capybara/FindAllFirst: # new in 2.22
   Enabled: true
 Capybara/NegationMatcherAfterVisit: # new in 2.22
   Enabled: true
+
+Gemspec/AttributeAssignment: # new in 1.77
+  Enabled: true
+Layout/EmptyLinesAfterModuleInclusion: # new in 1.79
+  Enabled: true
+Lint/UselessDefaultValueArgument: # new in 1.76
+  Enabled: true
+Lint/UselessOr: # new in 1.76
+  Enabled: true
+Naming/PredicateMethod: # new in 1.76
+  Enabled: false # for better or worse, pres cat has a lot of methods that aren't exactly predicate methods, but which return a boolean status
+Style/EmptyStringInsideInterpolation: # new in 1.76
+  Enabled: true
+Style/RedundantArrayFlatten: # new in 1.76
+  Enabled: true

--- a/app/components/dashboard/audit_information_component.html.erb
+++ b/app/components/dashboard/audit_information_component.html.erb
@@ -60,7 +60,7 @@ Note also:
       </tr>
       <tr>
         <td><strong>Catalog to Archive</strong><br>Confirm a PreservedObject has all versions/parts replicated for each of its target endpoints and attempts to backfill missing ones</td>
-        <td>moab_replication_audit<br>part_audit_aws_s3_east_1<br>part_audit_aws_s3_west_2<br>part_audit_ibm_us_south</td>
+        <td>moab_replication_audit</td>
         <td><strong>Weekly</strong>: 12am on Wednesday<br><em>for PreservedObjects with expired checks</em></td>
         <td><strong>subset</strong>:<br>expired archive checks for PreservedObjects and their associated ZipParts are queued</td>
         <td class="text-end<%= ' table-warning' if replication_audits_older_than_threshold? %>">PreservedObject replication audits older than <%= replication_audit_age_threshold %>:<hr><%= num_replication_audits_older_than_threshold %></td>

--- a/app/models/replication/druid_version_zip.rb
+++ b/app/models/replication/druid_version_zip.rb
@@ -161,6 +161,9 @@ module Replication
       @zip_storage ||= Pathname.new(Settings.zip_storage)
     end
 
+    # This assumes that the zip file will be at least as large as the Moab version being zipped. Why? Because
+    # we don't enable compression (see zip_command). Why no compression? We thought it might make extraction
+    # from zips more reliable in the distant future. For further explanation, see https://github.com/sul-dlss/preservation_catalog/wiki/Zip-Creation
     def zip_size_ok?
       total_part_size > moab_version_size
     end

--- a/app/services/audit/replication.rb
+++ b/app/services/audit/replication.rb
@@ -51,7 +51,7 @@ module Audit
     end
 
     def new_audit_results(zip_endpoint)
-      Audit::Results.new(druid: preserved_object.druid, moab_storage_root: zip_endpoint, check_name: 'PartReplicationAuditJob')
+      Audit::Results.new(druid: preserved_object.druid, moab_storage_root: zip_endpoint, check_name: 'MoabReplicationAuditJob')
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,7 +42,6 @@ zip_storage: '/tmp' # override in #{RAILS_ENV}.yml
 replication:
   audit_should_backfill: false
 
-total_worker_count: 117 # for okcomputer endpoint
 minimum_subfolder_count: 1 # for okcomputer pres-cat mount check, verifies the storage_trunk has at least this many subfolders
                            # NOTE: when null, no minimum check is performed, and this can be overriden per environment as needed
 worker_hostnames: # used for OK computer checks

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -59,6 +59,10 @@ namespace :prescat do
                  Replication::IbmProvider.new(region: Settings.zip_endpoints.ibm_us_south.region,
                                               access_key_id: args[:access_key],
                                               secret_access_key: args[:secret_access_key])
+               when 'gcp_s3_south_1'
+                 Replication::GcpProvider.new(region: Settings.zip_endpoints.gcp_s3_south_1.region,
+                                              access_key_id: args[:access_key],
+                                              secret_access_key: args[:secret_access_key])
                else
                  raise ArgumentError, "Unknown endpoint_name: #{args[:endpoint_name]}"
                end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 # A very simple job class that extends ApplicationJob to allow testing of basic queue locking behavior
 class RegularParameterJob < ApplicationJob
   include UniqueJob
+
   def self.lock_timeout
     1
   end

--- a/spec/models/zip_endpoint_spec.rb
+++ b/spec/models/zip_endpoint_spec.rb
@@ -130,6 +130,10 @@ RSpec.describe ZipEndpoint do
   end
 
   context 'ZippedMoabVersion presence on ZipEndpoint' do
+    # The tests in this section basically start with no druid versions for our test data existing on any of the endpoints.  As specific
+    # druid versions are progressively created on different endpoints, expectations on the queries spot check that they return appropriate
+    # results for various druid/version pairs for various endpoints.  The expectations are not exhaustive, they just spot check the different
+    # dimensions along which a buggy query might return bad info.
     let(:version) { 3 }
     let(:other_druid) { 'zy098xw7654' }
     let!(:po) { create(:preserved_object, current_version: version, druid: druid) }


### PR DESCRIPTION
# Why was this change made? 🤔

* add GCP awareness to `purge_zips` rake task
* update old page text and check names to get rid of missed cruft from `PartReplicationAuditJob` to `MoabReplicationAuditJob` transition
* explain strategy for a moderately complicated set of query tests (because it took me a bit to figure it out again myself when i went to update for GCP endpoint addition, and i was the original author)
* add new rubocop rules (and make small change for one of them)
* explanatory comment on archive zip size check
* freshen PR template
* remove obsolete setting

# How was this change tested? 🤨


⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



