### PR TITLE
[WIP] enable Committee::Middleware::ResponseValidation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -63,11 +63,8 @@ module PreservationCatalog
       strict_reference_validation: true,
       parameter_overwrite_by_rails_rule: false
     )
-    # TODO: we can uncomment this at a later date to ensure we are passing back
-    #       valid responses. Currently, uncommenting this line causes 24 spec
-    #       failures. See https://github.com/sul-dlss/preservation_catalog/issues/1407
-    #
-    # config.middleware.use Committee::Middleware::ResponseValidation, schema_path: 'openapi.yml'
+
+    config.middleware.use Committee::Middleware::ResponseValidation, schema_path: 'openapi.yml'
 
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/openapi.yml
+++ b/openapi.yml
@@ -448,9 +448,6 @@ components:
       description: A preserved object instance
       type: object
       properties:
-        id:
-          type: integer
-          example: 123
         druid:
           $ref: '#/components/schemas/Druid'
         current_version:
@@ -465,7 +462,6 @@ components:
           format: date-time
           example: '2020-02-21T16:36:28.075Z'
       required:
-        - id
         - druid
         - current_version
         - created_at


### PR DESCRIPTION
# Why was this change made? 🤔

closes #1407

this probably has to stay WIP/draft until https://github.com/interagent/committee/issues/300 is fixed.

when revisiting this, also consider the suggestion from @justinlittman on the pres cat ticket: https://github.com/sul-dlss/preservation_catalog/issues/1407#issuecomment-1297371479

> For what it is worth, I believe that for other apps, we only do response validation during tests.
> See https://github.com/sul-dlss/dor-services-app/blob/fe8a3a024571092b2e0d8290a90f36f8aa69a285/config/application.rb#L61-L72


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



