### PR TITLE
Stop running AWS S3 "live" specs in CI

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --require spec_helper
 --color
+--tag ~@live_s3

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ To run the tests:
 bundle exec rspec
 ```
 
+**NOTE**: This does not run tests which access AWS S3 resources on the fly, which are flaky and based on IP addresses. To run these, use `bundle exec rspec --tag live_s3`.)
+
 ### Run the App
 
 If you've chosen to install Ruby dependencies you can run the app locally with:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,6 @@ end
 require 'webmock/rspec'
 
 RSpec.configure do |config|
-  config.filter_run_excluding(:live_s3) unless ENV['CI'] == 'true' # default exclude unless on CI
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
# Why was this change made?

To allow the test suite to pass in CI, now that the AWS S3 resources in question are not configured to allow access from CI servers.

Instead, exclude these tests via `.rspec`, and document in the README how to run them interactively.

# How was this change tested?

CI
