### PR TITLE
Remove workflow vestiges.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -583,6 +583,7 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -107,10 +107,6 @@ OkComputer::Registry.register 'ruby_version', OkComputer::RubyVersionCheck.new
 #   - at individual moab_storage_root, HTTP response code reflects the actual result
 #   - in /status/all, these checks will display their result text, but will not affect HTTP response code
 
-# Audit Checks (only) report errors to workflow service so they appear in Argo
-workflows_url = "#{Settings.workflow_services_url}/objects/druid:oo000oo0000/workflows"
-OkComputer::Registry.register 'external-workflow-services-url', OkComputer::HttpCheck.new(workflows_url)
-
 # For each deployed environment (qa, stage, prod), the "web" host, by convention, does not
 # mount the zip-transfers directory, so this check will always fail on those hosts. Instead
 # of failing a check on these hosts, only register the check on non-web hosts.
@@ -121,6 +117,6 @@ end
 
 # TODO: do we want anything about s3 credentials here?
 
-optional_checks = %w[external-workflow-services-url]
+optional_checks = []
 optional_checks << 'feature-zip_storage_dir' if worker_host?
 OkComputer.make_optional optional_checks

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -22,7 +22,6 @@ zip_endpoints:
     audit_class: 'Audit::ReplicationToAws'
     access_key_id: 'foo'
     secret_access_key: 'bar'
-workflow_services_url: 'https://sul-lyberservices-test.stanford.edu/workflow/'
 
 slow_queries:
   enable: true


### PR DESCRIPTION
# Why was this change made? 🤔




# How was this change tested? 🤨

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



