### PR TITLE
temporarily disable weekly and monthly audit cron jobs

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -16,21 +16,25 @@ job_type :runner_hb, 'cd :path && bin/rails runner -e :environment ":task" :outp
 # Overriding default runner job_type to remove invoking bundle exec.
 job_type :runner, 'cd :path && bin/rails runner -e :environment ":task" :output'
 
-# 11 am on the 1st of every month
-# If changing schedule, also change for HB checkin
-every :month, at: '11:00', roles: [:queue_populator] do
-  set :output, standard: nil, error: 'log/m2c-err.log'
-  set :check_in, Settings.honeybadger_checkins.moab_to_catalog
-  runner_hb 'MoabStorageRoot.find_each(&:m2c_check!)'
-end
+# TODO: re-enable this cron job, which will queue the entire catalog, to reduce the chance of
+# disrupting a very deep zipmaker queue.  See https://github.com/sul-dlss/preservation_catalog/issues/2477
+# # 11 am on the 1st of every month
+# # If changing schedule, also change for HB checkin
+# every :month, at: '11:00', roles: [:queue_populator] do
+#   set :output, standard: nil, error: 'log/m2c-err.log'
+#   set :check_in, Settings.honeybadger_checkins.moab_to_catalog
+#   runner_hb 'MoabStorageRoot.find_each(&:m2c_check!)'
+# end
 
-# 11 am on the 15th of every month - the 'whenever' syntax for this is awkward and needs an ignored month
-# for the day to get parsed, so just use raw cron syntax
-every '0 11 15 * *', roles: [:queue_populator] do
-  set :output, standard: nil, error: 'log/c2m-err.log'
-  set :check_in, Settings.honeybadger_checkins.catalog_to_moab
-  runner_hb 'MoabStorageRoot.find_each(&:c2m_check!)'
-end
+# TODO: re-enable this cron job, which will queue the entire catalog, to reduce the chance of
+# disrupting a very deep zipmaker queue.  See https://github.com/sul-dlss/preservation_catalog/issues/2477
+# # 11 am on the 15th of every month - the 'whenever' syntax for this is awkward and needs an ignored month
+# # for the day to get parsed, so just use raw cron syntax
+# every '0 11 15 * *', roles: [:queue_populator] do
+#   set :output, standard: nil, error: 'log/c2m-err.log'
+#   set :check_in, Settings.honeybadger_checkins.catalog_to_moab
+#   runner_hb 'MoabStorageRoot.find_each(&:c2m_check!)'
+# end
 
 # Proactively spread out replication audit TTL to keep replication audit queue from having a huge backlog due to similar TTL values.
 # Any that are not validated but hit fixity TTL will be validated by weekly audit below.
@@ -39,11 +43,13 @@ every :day, at: '8pm', roles: [:queue_populator] do
   runner 'PreservedObject.order(last_archive_audit: :asc).limit(PreservedObject.daily_check_count).find_each(&:audit_moab_version_replication!)'
 end
 
-every :wednesday, roles: [:queue_populator] do
-  set :output, standard: nil, error: 'log/c2a-err.log'
-  set :check_in, Settings.honeybadger_checkins.audit_replication
-  runner_hb 'PreservedObject.archive_check_expired.find_each(&:audit_moab_version_replication!)'
-end
+# TODO: re-enable this cron job, which will queue the entire catalog, to reduce the chance of
+# disrupting a very deep zipmaker queue.  See https://github.com/sul-dlss/preservation_catalog/issues/2477
+# every :wednesday, roles: [:queue_populator] do
+#   set :output, standard: nil, error: 'log/c2a-err.log'
+#   set :check_in, Settings.honeybadger_checkins.audit_replication
+#   runner_hb 'PreservedObject.archive_check_expired.find_each(&:audit_moab_version_replication!)'
+# end
 
 # Proactively spread out checksum validation TTL to keep validate_checksum audit queue from having a huge backlog due to similar TTL values.
 # Any that are not validated but hit fixity TTL will be validated by weekly validation below.
@@ -52,11 +58,13 @@ every :day, at: '10pm', roles: [:queue_populator] do
   runner 'MoabRecord.order(last_checksum_validation: :asc).limit(MoabRecord.daily_check_count).find_each(&:validate_checksums!)'
 end
 
-every :sunday, at: '1am', roles: [:queue_populator] do
-  set :output, standard: nil, error: 'log/cv-err.log'
-  set :check_in, Settings.honeybadger_checkins.checksum_validation
-  runner_hb 'MoabStorageRoot.find_each(&:validate_expired_checksums!)'
-end
+# TODO: re-enable this cron job, which will queue the entire catalog, to reduce the chance of
+# disrupting a very deep zipmaker queue.  See https://github.com/sul-dlss/preservation_catalog/issues/2477
+# every :sunday, at: '1am', roles: [:queue_populator] do
+#   set :output, standard: nil, error: 'log/cv-err.log'
+#   set :check_in, Settings.honeybadger_checkins.checksum_validation
+#   runner_hb 'MoabStorageRoot.find_each(&:validate_expired_checksums!)'
+# end
 
 every :hour, roles: [:cache_cleaner] do
   set :output, standard: '/var/log/preservation_catalog/zip_cache_cleanup.log'


### PR DESCRIPTION
# Why was this change made? 🤔

They can queue a substantial portion (or possibly all) of the catalog, which would be trouble right now given Redis memory limits and current zipmaker queue depth.  See https://github.com/sul-dlss/preservation_catalog/issues/2477 (which intends to revert this as soon as possible)

# How was this change tested? 🤨

- [x] test on stage (confirm the cron jobs are active, deploy this branch to stage, confirm cron jobs this PR comments are no longer there).

`crontab -l` on the `queue_populator` box:

* before
```
# Begin Whenever generated tasks for: preservation_catalog_stage at: 2025-10-27 08:00:26 -0700
0 11 1 * * /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251027145946 && bin/rails runner -e production "MoabStorageRoot.find_each(&:m2c_check!)" >> /dev/null 2>> log/m2c-err.log && curl --silent https://api.honeybadger.io/v1/check_in/xoIP9m'

0 11 15 * * /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251027145946 && bin/rails runner -e production "MoabStorageRoot.find_each(&:c2m_check!)" >> /dev/null 2>> log/c2m-err.log && curl --silent https://api.honeybadger.io/v1/check_in/3DIqoN'

0 20 * * * /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251027145946 && bin/rails runner -e production "PreservedObject.order(last_archive_audit: :asc).limit(PreservedObject.daily_check_count).find_each(&:audit_moab_version_replication!)" >> /dev/null 2>> log/c2a-err.log'

0 22 * * * /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251027145946 && bin/rails runner -e production "MoabRecord.order(last_checksum_validation: :asc).limit(MoabRecord.daily_check_count).find_each(&:validate_checksums!)" >> /dev/null 2>> log/cv-err.log'

15 1 * * * /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251027145946 && RAILS_ENV=production bundle exec rake prescat:cache_cleaner:empty_directories --silent >> /var/log/preservation_catalog/zip_cache_cleanup.log'

0 0 * * 3 /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251027145946 && bin/rails runner -e production "PreservedObject.archive_check_expired.find_each(&:audit_moab_version_replication!)" >> /dev/null 2>> log/c2a-err.log && curl --silent https://api.honeybadger.io/v1/check_in/5mId5j'

0 1 * * 0 /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251027145946 && bin/rails runner -e production "MoabStorageRoot.find_each(&:validate_expired_checksums!)" >> /dev/null 2>> log/cv-err.log && curl --silent https://api.honeybadger.io/v1/check_in/wqInMG'

0 * * * * /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251027145946 && RAILS_ENV=production bundle exec rake prescat:cache_cleaner:stale_files --silent >> /var/log/preservation_catalog/zip_cache_cleanup.log'

# End Whenever generated tasks for: preservation_catalog_stage at: 2025-10-27 08:00:26 -0700
```

* after
```
# Begin Whenever generated tasks for: preservation_catalog_stage at: 2025-10-29 17:17:31 -0700
0 20 * * * /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251030001655 && bin/rails runner -e production "PreservedObject.order(last_archive_audit: :asc).limit(PreservedObject.daily_check_count).find_each(&:audit_moab_version_replication!)" >> /dev/null 2>> log/c2a-err.log'

0 22 * * * /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251030001655 && bin/rails runner -e production "MoabRecord.order(last_checksum_validation: :asc).limit(MoabRecord.daily_check_count).find_each(&:validate_checksums!)" >> /dev/null 2>> log/cv-err.log'

15 1 * * * /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251030001655 && RAILS_ENV=production bundle exec rake prescat:cache_cleaner:empty_directories --silent >> /var/log/preservation_catalog/zip_cache_cleanup.log'

0 * * * * /bin/bash -l -c 'cd /opt/app/pres/preservation_catalog/releases/20251030001655 && RAILS_ENV=production bundle exec rake prescat:cache_cleaner:stale_files --silent >> /var/log/preservation_catalog/zip_cache_cleanup.log'

# End Whenever generated tasks for: preservation_catalog_stage at: 2025-10-29 17:17:31 -0700
```


⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

n/a

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



