### PR TITLE
Refactors replication.

### DIFF
--- a/app/jobs/audit/replication_audit_job.rb
+++ b/app/jobs/audit/replication_audit_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Audit
+  # Job to audit replication for a PreservedObject
+  class ReplicationAuditJob < ApplicationJob
+    queue_as :moab_replication_audit
+    delegate :logger, to: Audit::ReplicationSupport
+
+    include UniqueJob
+
+    def perform(preserved_object)
+      @preserved_object = preserved_object
+
+      preserved_object.populate_zipped_moab_versions!
+
+      ::Replication::AuditService.call(preserved_object: preserved_object).each do |audit_results|
+        AuditResultsReporter.report_results(audit_results: audit_results, logger: logger)
+      end
+
+      preserved_object.update!(last_archive_audit: Time.current)
+
+      start_replication
+    end
+
+    attr_reader :preserved_object
+
+    def start_replication
+      return unless preserved_object.zipped_moab_versions.created.exists? || preserved_object.zipped_moab_versions.incomplete.exists?
+      ::ReplicationJob.perform_later(preserved_object)
+    end
+  end
+end

--- a/app/jobs/replication_job.rb
+++ b/app/jobs/replication_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Job to replicate a PreservedObject to cloud endpoints
+class ReplicationJob < ApplicationJob
+  queue_as :replication
+  include UniqueJob
+
+  def perform(preserved_object)
+    preserved_object.populate_zipped_moab_versions!
+
+    ::Replication::AuditService.call(preserved_object: preserved_object)
+
+    (1..preserved_object.current_version).each do |version|
+      Replication::ReplicateVersionService.call(preserved_object:, version:)
+    end
+  end
+end

--- a/app/models/moab_record.rb
+++ b/app/models/moab_record.rb
@@ -14,11 +14,6 @@ class MoabRecord < ApplicationRecord
     'validity_unknown' => 6
   }
 
-  after_create :create_zipped_moab_versions!
-  # hook for creating archive zips is here and on PreservedObject, because version and current_version must be in sync, and
-  # even though both fields will usually be updated together in a single transaction, one has to be updated first.  latter
-  # of the two updates will actually trigger replication.
-  after_update :create_zipped_moab_versions!, if: :saved_change_to_version? # an ActiveRecord dynamic method
   after_save :validate_checksums!, if: proc { |moab_record| moab_record.saved_change_to_status? && moab_record.validity_unknown? }
 
   # NOTE: Since Rails 5.0, belongs_to adds the presence validator automatically, and explicit presence validation

--- a/app/models/replication/druid_version_zip_part.rb
+++ b/app/models/replication/druid_version_zip_part.rb
@@ -73,5 +73,10 @@ module Replication
     def read_md5
       File.read(md5_path)
     end
+
+    # @return [Boolean] whether the md5 from the md5 sidecar file matches the computed md5
+    def md5_match?
+      read_md5 == hexdigest
+    end
   end
 end

--- a/app/models/zip_endpoint.rb
+++ b/app/models/zip_endpoint.rb
@@ -63,6 +63,11 @@ class ZipEndpoint < ApplicationRecord
     raise "Failed to return audit class based on setting for #{endpoint_name}.  Check setting string for accuracy."
   end
 
+  # @return [Aws::S3::Bucket] S3 bucket object for this zip endpoint
+  def bucket
+    @bucket ||= Replication::ProviderFactory.create(zip_endpoint: self).bucket
+  end
+
   def to_s
     endpoint_name
   end

--- a/app/models/zip_part.rb
+++ b/app/models/zip_part.rb
@@ -5,7 +5,7 @@
 # This model's data is populated by Replication::DeliveryDispatcherJob.
 class ZipPart < ApplicationRecord
   belongs_to :zipped_moab_version, inverse_of: :zip_parts
-  delegate :zip_endpoint, :preserved_object, to: :zipped_moab_version
+  delegate :zip_endpoint, :preserved_object, :druid_version_zip, to: :zipped_moab_version
 
   # @note Hash values cannot be modified without migrating any associated persisted data.
   # @see [enum docs] http://api.rubyonrails.org/classes/ActiveRecord/Enum.html
@@ -37,11 +37,15 @@ class ZipPart < ApplicationRecord
     druid_version_zip.expected_part_keys(parts_count).map { |key| File.extname(key) }
   end
 
-  def druid_version_zip
-    @druid_version_zip ||= Replication::DruidVersionZip.new(preserved_object.druid, zipped_moab_version.version)
+  def druid_version_zip_part
+    @druid_version_zip_part ||= Replication::DruidVersionZipPart.new(druid_version_zip, s3_key)
   end
 
   def s3_key
     druid_version_zip.s3_key(suffix)
+  end
+
+  def s3_part
+    @s3_part ||= zip_endpoint.bucket.object(s3_key)
   end
 end

--- a/app/services/audit/replication_support.rb
+++ b/app/services/audit/replication_support.rb
@@ -41,7 +41,7 @@ module Audit
       if unreplicated_parts.any?
         results.add_result(
           Audit::Results::ZIP_PARTS_NOT_ALL_REPLICATED,
-          base_hash.merge(unreplicated_parts_list: unreplicated_parts.to_a)
+          base_hash
         )
       end
 

--- a/app/services/audit/results.rb
+++ b/app/services/audit/results.rb
@@ -81,7 +81,7 @@ module Audit
                                       'Sum of ZippedMoabVersion child part sizes (%{total_part_size}) is less than what is in ' \
                                       'the Moab: %{moab_version_size}',
       ZIP_PARTS_NOT_ALL_REPLICATED => '%{version} on %{endpoint_name}: not all ' \
-                                      'ZippedMoabVersion parts are replicated yet: %{unreplicated_parts_list}',
+                                      'ZippedMoabVersion parts are replicated yet',
       ZIP_PARTS_NOT_CREATED => '%{version} on %{endpoint_name}: no zip_parts exist yet for this ZippedMoabVersion'
     }.freeze
 

--- a/app/services/moab_record_service/check_existence.rb
+++ b/app/services/moab_record_service/check_existence.rb
@@ -19,6 +19,7 @@ module MoabRecordService
         else
           create_missing_moab_record
         end
+        ReplicationJob.perform_later(preserved_object) if perform_replication?
       end
     end
 
@@ -31,6 +32,8 @@ module MoabRecordService
         moab_record.upd_audstamps_version_size(moab_on_storage_validator.ran_moab_validation?, incoming_version, incoming_size)
         preserved_object.current_version = incoming_version
         preserved_object.save!
+
+        @perform_replication = true
       end
     end
 
@@ -62,6 +65,10 @@ module MoabRecordService
         moab_record.update_audit_timestamps(moab_on_storage_validator.ran_moab_validation?, true)
         moab_record.save!
       end
+    end
+
+    def perform_replication?
+      @perform_replication ||= false
     end
   end
 end

--- a/app/services/replication/audit_service.rb
+++ b/app/services/replication/audit_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Replication
+  # Service for auditing a PreservedObject's replication status.
+  # The service returns audit results, as well as updating the ZippedMoabVersion statuses.
+  class AuditService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(preserved_object:)
+      @preserved_object = preserved_object
+    end
+
+    # @return [Array<AuditResult>] audit results for each zip endpoint
+    def call
+      ZipEndpoint.all.to_a.map do |zip_endpoint|
+        new_audit_results(zip_endpoint).tap do |audit_results|
+          preserved_object.zipped_moab_versions.where(zip_endpoint: zip_endpoint).find_each do |zipped_moab_version|
+            Replication::ZippedMoabVersionAuditService.call(zipped_moab_version:, audit_results:)
+          end
+        end
+      end
+    end
+
+    private
+
+    attr_reader :preserved_object
+
+    def new_audit_results(zip_endpoint)
+      Audit::Results.new(druid: preserved_object.druid, moab_storage_root: zip_endpoint, check_name: 'ReplicationAudit')
+    end
+  end
+end

--- a/app/services/replication/provider_factory.rb
+++ b/app/services/replication/provider_factory.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Replication
+  # Factory for replication provider instances based on ZipEndpoint configuration.
+  class ProviderFactory
+    def self.create(...)
+      new(...).create
+    end
+
+    def initialize(zip_endpoint:)
+      @zip_endpoint = zip_endpoint
+    end
+
+    # @return [Replication::AwsProvider, Replication::IbmProvider, Replication::GcpProvider]
+    def create
+      raise 'Unknown endpoint configuration' unless endpoint_settings&.provider_class
+
+      provider_class.new(
+        region: endpoint_settings.region,
+        access_key_id: endpoint_settings.access_key_id,
+        secret_access_key: endpoint_settings.secret_access_key
+      )
+    end
+
+    private
+
+    attr_reader :zip_endpoint
+
+    def endpoint_settings
+      @endpoint_settings ||= Settings.zip_endpoints[zip_endpoint.endpoint_name]
+    end
+
+    def provider_class
+      endpoint_settings.provider_class.constantize
+    end
+  end
+end

--- a/app/services/replication/replicate_version_service.rb
+++ b/app/services/replication/replicate_version_service.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module Replication
+  # Performs replication of a specific version of a PreservedObject
+  class ReplicateVersionService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(preserved_object:, version:)
+      @preserved_object = preserved_object
+      @version = version
+      Honeybadger.context(druid:, version: version)
+    end
+
+    def call # rubocop:disable Metrics/AbcSize
+      # Skip if there are no created or incomplete ZippedMoabVersion for the version
+      return unless zipped_moab_versions.created.exists? || zipped_moab_versions.incomplete.exists?
+
+      # If there is a zip, makes sure it is complete.
+      # If it is not complete or not present, creates it.
+      create_zip_if_necessary
+
+      zipped_moab_versions.incomplete.each do |zipped_moab_version|
+        reset_to_created!(zipped_moab_version) if no_zip_parts_on_endpoint?(zipped_moab_version)
+        # Check that the md5s for the local zip part files match those recorded in the db
+        zipped_moab_version.failed! if md5_mismatch_for_md5_sidecar?(zipped_moab_version)
+      end
+
+      zipped_moab_versions.created.each do |zipped_moab_version|
+        populate_zip_parts!(zipped_moab_version)
+      end
+
+      replicate_incomplete_zipped_moab_versions
+
+      # Delete the local zip part files
+      druid_version_zip.cleanup_zip_parts!
+    end
+
+    private
+
+    attr_reader :preserved_object, :version
+
+    delegate :druid, to: :preserved_object
+
+    def zipped_moab_versions
+      preserved_object.zipped_moab_versions.where(version:)
+    end
+
+    def druid_version_zip
+      @druid_version_zip ||= zipped_moab_versions.first.druid_version_zip
+    end
+
+    def create_zip_if_necessary
+      return if druid_version_zip.complete?
+
+      druid_version_zip.cleanup_zip_parts!
+      druid_version_zip.create_zip!
+    end
+
+    def reset_to_created!(zipped_moab_version)
+      ZippedMoabVersion.transaction do
+        zipped_moab_version.zip_parts.destroy_all
+        zipped_moab_version.created!
+      end
+    end
+
+    # @return [Boolean] true if there are no zip part files on the endpoint for the ZippedMoabVersion
+    def no_zip_parts_on_endpoint?(zipped_moab_version)
+      zipped_moab_version.zip_parts.none? { |zip_part| zip_part.s3_part.exists? }
+    end
+
+    # @return [Boolean] true if the md5 from any md5 sidecar file does not match the ZipPart md5 field
+    def md5_mismatch_for_md5_sidecar?(zipped_moab_version)
+      zipped_moab_version.zip_parts.any? do |zip_part|
+        zip_part.md5 != zip_part.druid_version_zip_part.read_md5
+      end
+    end
+
+    def populate_zip_parts!(zipped_moab_version)
+      ZippedMoabVersion.transaction do
+        druid_version_zip.druid_version_zip_parts.each do |druid_version_zip_part|
+          zipped_moab_version.zip_parts.create!(
+            suffix: druid_version_zip_part.extname,
+            size: druid_version_zip_part.size,
+            md5: druid_version_zip_part.read_md5,
+            # The following will be dropped and these are bogus values to satisfy validations
+            create_info: 'not provided',
+            parts_count: 1
+          )
+        end
+        zipped_moab_version.update!(zip_parts_count: zipped_moab_version.zip_parts.count)
+        zipped_moab_version.incomplete!
+      end
+    end
+
+    def replicate_incomplete_zipped_moab_versions
+      zipped_moab_versions.incomplete.each do |zipped_moab_version|
+        zipped_moab_version.zip_parts.each do |zip_part|
+          Replication::ReplicateZipPartService.call(zip_part:)
+        end
+        zipped_moab_version.ok!
+        send_dsa_event(zipped_moab_version)
+      rescue Replication::ReplicateZipPartService::DifferentPartFileFoundError
+        zipped_moab_version.failed!
+        Honeybadger.notify('Replication failure')
+      end
+    end
+
+    def send_dsa_event(zipped_moab_version)
+      parts_info = zipped_moab_version.zip_parts.order(:suffix).map do |part|
+        { s3_key: part.s3_key, size: part.size, md5: part.md5 }
+      end
+
+      Dor::Event::Client.create(
+        druid: "druid:#{druid}",
+        type: 'druid_version_replicated',
+        data: {
+          host: Socket.gethostname,
+          invoked_by: 'preservation-catalog',
+          version: zipped_moab_version.version,
+          endpoint_name: zipped_moab_version.zip_endpoint.endpoint_name,
+          parts_info:
+        }
+      )
+    end
+  end
+end

--- a/app/services/replication/replicate_zip_part_service.rb
+++ b/app/services/replication/replicate_zip_part_service.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Replication
+  # Service to replicate a single zip part to cloud endpoint
+  class ReplicateZipPartService
+    # Raised when a part file is found at the endpoint and there is an md5 mismatch
+    class DifferentPartFileFoundError < StandardError; end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(zip_part:)
+      @zip_part = zip_part
+    end
+
+    # @raise [DifferentPartFileFoundError] if a different part file is found at the endpoint
+    def call
+      set_hb_context
+
+      return if already_replicated?
+      check_existing_part_file_on_endpoint
+
+      s3_part.upload_file(druid_version_zip_part.file_path, metadata:)
+    end
+
+    private
+
+    attr_reader :zip_part
+
+    delegate :s3_part, :druid_version_zip_part, to: :zip_part
+
+    def zip_part_file_exists_on_endpoint?
+      s3_part.exists?
+    end
+
+    def zip_part_md5s_match?
+      s3_part.metadata['checksum_md5'] == zip_part.md5
+    end
+
+    def already_replicated?
+      zip_part_file_exists_on_endpoint? && zip_part_md5s_match?
+    end
+
+    def set_hb_context
+      Honeybadger.context(
+        druid: zip_part.preserved_object.druid,
+        version: zip_part.zipped_moab_version.version,
+        endpoint: zip_part.zip_endpoint.endpoint_name,
+        zip_part_id: zip_part.id
+      )
+    end
+
+    def metadata
+      {
+        checksum_md5: druid_version_zip_part.read_md5,
+        size: druid_version_zip_part.size.to_s # S3 metadata values must be strings
+      }
+    end
+
+    def check_existing_part_file_on_endpoint
+      raise DifferentPartFileFoundError if zip_part_file_exists_on_endpoint? && !zip_part_md5s_match?
+    end
+  end
+end

--- a/app/services/replication/zipped_moab_version_audit_service.rb
+++ b/app/services/replication/zipped_moab_version_audit_service.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+module Replication
+  # Service for auditing a ZippedMoabVersion's replication status
+  class ZippedMoabVersionAuditService # rubocop:disable Metrics/ClassLength
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(zipped_moab_version:, audit_results:)
+      @zipped_moab_version = zipped_moab_version
+      @audit_results = audit_results
+    end
+
+    def call
+      remediate_zip_part_count!
+
+      status = check_zip_parts_created
+      return update_status_to(status) if status
+
+      status ||= check_zip_part_size_consistency
+      status ||= check_zip_part_count_consistency
+      status ||= check_zip_part_checksums
+      status ||= check_zip_part_found
+      status ||= :ok
+
+      update_status_to(status)
+    end
+
+    private
+
+    attr_reader :zipped_moab_version, :audit_results
+
+    delegate :zip_parts, :preserved_object, to: :zipped_moab_version
+
+    def remediate_zip_part_count!
+      # When the zip_part_count field was added, it was set to nil for existing ZippedMoabVersions.
+      # Set it to the actual count of associated ZipParts if nil.
+      return unless zipped_moab_version.zip_parts_count.nil?
+
+      actual_count = zipped_moab_version.zip_parts.count
+      zipped_moab_version.update!(zip_parts_count: actual_count) if actual_count.positive?
+    end
+
+    # @return [Boolean] true if the ZipPart count matches the zip_parts_count field
+    def zip_part_count_mismatch?
+      expected_count = zipped_moab_version.zip_parts_count
+      actual_count = zipped_moab_version.zip_parts.count
+
+      expected_count != actual_count
+    end
+
+    def check_zip_part_checksums
+      checksum_mismatch_zip_parts = zip_parts_with_status(:checksum_mismatch)
+      return if checksum_mismatch_zip_parts.empty?
+
+      checksum_mismatch_zip_parts.each do |zip_part|
+        add_result(Audit::Results::ZIP_PART_CHECKSUM_MISMATCH,
+                   endpoint_name: zip_part.zipped_moab_version.zip_endpoint.endpoint_name,
+                   s3_key: zip_part.s3_key,
+                   md5: zip_part.md5,
+                   replicated_checksum: zip_part.s3_part.metadata['checksum_md5'],
+                   bucket_name: zip_part.s3_part.bucket_name)
+      end
+      :failed
+    end
+
+    def check_zip_part_found
+      not_found_zip_parts = zip_parts_with_status(:not_found)
+      return if not_found_zip_parts.empty?
+
+      # If the status is currently :incomplete, report as ZIP_PARTS_NOT_ALL_REPLICATED
+      # This state is expected; reporting doesn't indicate a problem.
+      # If the status is something else, report as ZIP_PART_NOT_FOUND.
+      if zipped_moab_version.incomplete?
+        add_result(Audit::Results::ZIP_PARTS_NOT_ALL_REPLICATED)
+      else
+        not_found_zip_parts.each do |zip_part|
+          add_result(Audit::Results::ZIP_PART_NOT_FOUND,
+                     endpoint_name: zip_part.zipped_moab_version.zip_endpoint.endpoint_name,
+                     s3_key: zip_part.s3_key,
+                     bucket_name: zip_part.s3_part.bucket_name)
+        end
+      end
+      :incomplete
+    end
+
+    def zip_parts_with_status(status)
+      @zip_part_status_map ||= zip_parts.index_with do |zip_part|
+        if !zip_part.s3_part.exists?
+          :not_found
+        elsif zip_part.s3_part.metadata['checksum_md5'] != zip_part.md5
+          :checksum_mismatch
+        else
+          :ok
+        end
+      end
+      zip_parts.select { |zip_part| @zip_part_status_map[zip_part] == status }
+    end
+
+    def add_result(code, **details)
+      audit_results.add_result(
+        code,
+        details.merge(
+          version: zipped_moab_version.version,
+          endpoint_name: zipped_moab_version.zip_endpoint.endpoint_name
+        )
+      )
+    end
+
+    # @return [Symbol, nil] returns status symbol if inconsistency found, else nil
+    def check_zip_part_size_consistency
+      total_part_size = zipped_moab_version.total_part_size
+      moab_version_size = zipped_moab_version.druid_version_zip.moab_version_size
+      return unless total_part_size < moab_version_size
+      add_result(
+        Audit::Results::ZIP_PARTS_SIZE_INCONSISTENCY,
+        total_part_size: total_part_size, moab_version_size: moab_version_size
+      )
+      :failed
+    end
+
+    # @return [Symbol, nil] returns status symbol if inconsistency found, else nil
+    def check_zip_part_count_consistency
+      db_count = zipped_moab_version.zip_parts_count
+      actual_count = zipped_moab_version.zip_parts.count
+      return if db_count == actual_count
+      add_result(
+        Audit::Results::ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL,
+        db_count:, actual_count:
+      )
+      :failed
+    end
+
+    # @return [Symbol, nil] returns status symbol if zip parts were not created, else nil
+    def check_zip_parts_created
+      # If zip_parts_count is present, this is a zip part count consistency issue so not reporting here.
+      return unless zip_parts.empty? && zipped_moab_version.zip_parts_count.nil?
+
+      # If the current status is :created, this state is expected; reporting doesn't indicate a problem.
+      # If the status is something else, this is unexpected.
+      add_result(Audit::Results::ZIP_PARTS_NOT_CREATED)
+      :created # ZippedMoabVersion has been created, but no ZipParts yet.
+    end
+
+    def update_status_to(new_status)
+      # Setting status_updated_at to now to indicate that the status was checked, even if not changed.
+      zipped_moab_version.update!(status: new_status, status_updated_at: Time.zone.now)
+    end
+  end
+end

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -23,6 +23,7 @@ zip_endpoints:
     audit_class: 'Audit::ReplicationToAws'
     access_key_id: 'overridden-by-env-var-in-ci'
     secret_access_key: 'overridden-by-env-var-in-ci'
+    provider_class: 'Replication::AwsProvider'
   ibm_us_south:
     region: 'us-south'
     endpoint_node: 'https://s3.us-south.cloud-object-storage.appdomain.cloud'
@@ -31,6 +32,7 @@ zip_endpoints:
     audit_class: 'Audit::ReplicationToIbm'
     access_key_id: 'overridden-by-env-var-in-ci'
     secret_access_key: 'overridden-by-env-var-in-ci'
+    provider_class: 'Replication::IbmProvider'
   gcp_s3_south_1:
     region: 'us-south1'
     endpoint_node: 'https://storage.googleapis.com'
@@ -39,3 +41,4 @@ zip_endpoints:
     audit_class: 'Audit::ReplicationToGcp'
     access_key_id: 'overridden-by-env-var-in-ci'
     secret_access_key: 'overridden-by-env-var-in-ci'
+    provider_class: 'Replication::GcpProvider'

--- a/db/migrate/20260107124042_add_status_to_zipped_moab_versions.rb
+++ b/db/migrate/20260107124042_add_status_to_zipped_moab_versions.rb
@@ -1,0 +1,16 @@
+class AddStatusToZippedMoabVersions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :zipped_moab_versions, :status, :integer, default: 2, null: false
+    add_column :zipped_moab_versions, :status_updated_at, :datetime, precision: nil
+    add_column :zipped_moab_versions, :zip_parts_count, :integer
+
+    add_index :zipped_moab_versions, :status
+    add_index :zipped_moab_versions, :status_updated_at
+
+    # Set status to 'ok'. Auditing will set this correctly later.
+    ZippedMoabVersion.update_all(status: 0)
+
+    # For ZippedMoabVersions without any ZipParts, set status to 'created'.
+    ZippedMoabVersion.where.missing(:zip_parts).update_all(status: 2, status_updated_at: Time.current)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_20_212633) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_07_124042) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "moab_records", force: :cascade do |t|
     t.integer "version", null: false
@@ -95,8 +95,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_20_212633) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "preserved_object_id", null: false
+    t.integer "status", default: 2, null: false
+    t.datetime "status_updated_at", precision: nil
+    t.integer "zip_parts_count"
     t.index ["preserved_object_id", "zip_endpoint_id", "version"], name: "index_unique_on_zipped_moab_versions", unique: true
     t.index ["preserved_object_id"], name: "index_zipped_moab_versions_on_preserved_object_id"
+    t.index ["status"], name: "index_zipped_moab_versions_on_status"
+    t.index ["status_updated_at"], name: "index_zipped_moab_versions_on_status_updated_at"
     t.index ["zip_endpoint_id"], name: "index_zipped_moab_versions_on_zip_endpoint_id"
   end
 

--- a/spec/factories/zip_parts.rb
+++ b/spec/factories/zip_parts.rb
@@ -2,12 +2,15 @@
 
 FactoryBot.define do
   factory :zip_part do
+    transient do
+      sequence(:index, 0)
+    end
     md5 { '00236a2ae558018ed13b5222ef1bd977' }
     create_info { { zip_cmd: 'zip some args', zip_version: '3.14' } }
     parts_count { 1 }
     size { 1234 }
     status { 'unreplicated' }
-    suffix { parts_count == 1 ? '.zip' : format('.z%02d', parts_count) }
+    suffix { index == 1 ? '.zip' : format('.z%02d', index) }
     zipped_moab_version
   end
 end

--- a/spec/jobs/audit/replication_audit_job_spec.rb
+++ b/spec/jobs/audit/replication_audit_job_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::ReplicationAuditJob do
+  let(:audit_results) { instance_double(Audit::Results) }
+
+  before do
+    allow(Replication::AuditService).to receive(:call).and_return(audit_results_list)
+    allow(ReplicationJob).to receive(:perform_later)
+    allow(AuditResultsReporter).to receive(:report_results)
+  end
+
+  context 'when no failures and no created/incomplete ZippedMoabVersions' do
+    let(:preserved_object) { create(:preserved_object, current_version: 1) }
+    let(:audit_results_list) { [] }
+
+    before do
+      ZipEndpoint.find_each do |zip_endpoint|
+        create(:zipped_moab_version, status: :ok, preserved_object:, zip_endpoint:, version: 1)
+      end
+    end
+
+    it 'performs audit and does not notify or start replication' do
+      expect { described_class.perform_now(preserved_object) }.to(change { preserved_object.reload.last_archive_audit })
+
+      expect(preserved_object.reload.zipped_moab_versions.count).to eq ZipEndpoint.count
+      expect(Replication::AuditService).to have_received(:call).with(preserved_object: preserved_object)
+      expect(AuditResultsReporter).not_to have_received(:report_results)
+      expect(ReplicationJob).not_to have_received(:perform_later)
+    end
+  end
+
+  context 'when not all ZippedMoabVersions exists' do
+    let(:preserved_object) { create(:preserved_object, current_version: 2) }
+    let(:audit_results_list) { [audit_results] }
+
+    before do
+      ZipEndpoint.find_each do |zip_endpoint|
+        create(:zipped_moab_version, status: :ok, preserved_object:, zip_endpoint:, version: 1)
+      end
+    end
+
+    it 'creates the ZippedMoabVersions, performs audit and starts replication' do
+      described_class.perform_now(preserved_object)
+
+      expect(preserved_object.reload.zipped_moab_versions.count).to eq ZipEndpoint.count * 2
+      expect(Replication::AuditService).to have_received(:call).with(preserved_object: preserved_object)
+      expect(ReplicationJob).to have_received(:perform_later).with(preserved_object)
+      expect(AuditResultsReporter).to have_received(:report_results).with(audit_results:, logger: anything)
+    end
+  end
+
+  context 'when some ZippedMoabVersions have failed' do
+    let(:preserved_object) { create(:preserved_object, current_version: 1) }
+    let(:audit_results_list) { [audit_results] }
+
+    before do
+      ZipEndpoint.find_each do |zip_endpoint|
+        create(:zipped_moab_version, status: :failed, preserved_object:, zip_endpoint:, version: 1)
+      end
+    end
+
+    it 'performs audit and notifies Honeybadger' do
+      described_class.perform_now(preserved_object)
+
+      expect(Replication::AuditService).to have_received(:call).with(preserved_object: preserved_object)
+      expect(ReplicationJob).not_to have_received(:perform_later)
+      expect(AuditResultsReporter).to have_received(:report_results).with(audit_results:, logger: anything)
+    end
+  end
+end

--- a/spec/jobs/replication/delivery_dispatcher_job_spec.rb
+++ b/spec/jobs/replication/delivery_dispatcher_job_spec.rb
@@ -63,7 +63,7 @@ describe Replication::DeliveryDispatcherJob do
 
     before do
       create(:zip_endpoint, delivery_class: 2) # new 3rd endpoint, preserved_object should 3 ZMVs
-      create(:moab_record, preserved_object: po, version: po.current_version)
+      po.populate_zipped_moab_versions!
     end
 
     it 'splits the message out to endpoints' do
@@ -126,7 +126,8 @@ describe Replication::DeliveryDispatcherJob do
       end
 
       it 'skips that zipped moab version' do
-        expect(po.zipped_moab_versions.first.zip_endpoint.delivery_class.constantize).not_to receive(:perform_later)
+        expect(po.zipped_moab_versions.first.zip_endpoint.delivery_class.constantize)
+          .not_to receive(:perform_later)
           .with(druid, version, s3_key, a_hash_including(:checksum_md5, :size, :zip_cmd, :zip_version))
         expect(po.zipped_moab_versions.second.zip_endpoint.delivery_class.constantize).to receive(:perform_later)
           .with(druid, version, s3_key, a_hash_including(:checksum_md5, :size, :zip_cmd, :zip_version))

--- a/spec/jobs/replication/results_recorder_job_spec.rb
+++ b/spec/jobs/replication/results_recorder_job_spec.rb
@@ -9,12 +9,11 @@ describe Replication::ResultsRecorderJob do
   let(:druid) { preserved_object.druid }
   let(:zip_endpoint) { zmv.zip_endpoint }
   let(:zip_endpoint2) { zmv2.zip_endpoint }
-  let(:zip_part_attributes) { [attributes_for(:zip_part)] }
+  let(:zip_part_attributes) { [attributes_for(:zip_part, index: 1)] }
   let(:druid_version_zip) { Replication::DruidVersionZip.new(druid, zmv.version) }
 
   before do
-    # creating the MoabRecord triggers associated ZippedMoabVersion creation via AR hooks
-    create(:moab_record, preserved_object: preserved_object, version: preserved_object.current_version)
+    preserved_object.populate_zipped_moab_versions!
     zmv.zip_parts.create(zip_part_attributes)
     zmv2.zip_parts.create(zip_part_attributes)
     allow(Dor::Event::Client).to receive(:create).and_return(true)

--- a/spec/jobs/replication_job_spec.rb
+++ b/spec/jobs/replication_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReplicationJob do
+  let(:preserved_object) { create(:preserved_object, current_version: 2) }
+
+  before do
+    allow(Replication::AuditService).to receive(:call)
+    allow(Replication::ReplicateVersionService).to receive(:call)
+  end
+
+  it 'audits and replicates each version' do
+    expect { described_class.perform_now(preserved_object) }.to change {
+      preserved_object.reload.zipped_moab_versions.count
+    }.from(0).to(ZipEndpoint.count * 2)
+    expect(Replication::AuditService).to have_received(:call).with(preserved_object:)
+    expect(Replication::ReplicateVersionService).to have_received(:call).twice
+    expect(Replication::ReplicateVersionService).to have_received(:call).with(preserved_object:, version: 1)
+    expect(Replication::ReplicateVersionService).to have_received(:call).with(preserved_object:, version: 2)
+  end
+end

--- a/spec/models/moab_record_spec.rb
+++ b/spec/models/moab_record_spec.rb
@@ -312,20 +312,6 @@ RSpec.describe MoabRecord do
     end
   end
 
-  describe '.after_update callback' do
-    it 'does not call create_zipped_moab_versions when version is unchanged' do
-      moab_record.size = 234
-      expect(moab_record).not_to receive(:create_zipped_moab_versions!)
-      moab_record.save!
-    end
-
-    it 'calls create_zipped_moab_versions when version was changed' do
-      moab_record.version = 55
-      expect(moab_record).to receive(:create_zipped_moab_versions!)
-      moab_record.save!
-    end
-  end
-
   describe '.after_save callback' do
     before { allow(Audit::ChecksumValidationJob).to receive(:perform_later).and_call_original } # undo rails_helper block
 

--- a/spec/models/replication/druid_version_zip_part_spec.rb
+++ b/spec/models/replication/druid_version_zip_part_spec.rb
@@ -94,5 +94,16 @@ describe Replication::DruidVersionZipPart do
         expect(part.size).to eq 3
       end
     end
+
+    describe '#md5_match?' do
+      it 'returns true when md5 matches' do
+        expect(part.md5_match?).to be true
+      end
+
+      it 'returns false when md5 does not match' do
+        allow(part).to receive(:read_md5).and_return('wrongmd5value')
+        expect(part.md5_match?).to be false
+      end
+    end
   end
 end

--- a/spec/models/zip_endpoint_spec.rb
+++ b/spec/models/zip_endpoint_spec.rb
@@ -61,6 +61,15 @@ RSpec.describe ZipEndpoint do
     end
   end
 
+  describe '#bucket' do
+    subject(:bucket) { described_class.find_by(endpoint_name: 'aws_s3_west_2').bucket }
+
+    it 'returns an Aws::S3::Bucket' do
+      expect(bucket).to be_a(Aws::S3::Bucket)
+      expect(bucket.name).to eq(Settings.zip_endpoints.aws_s3_west_2.storage_location)
+    end
+  end
+
   describe '.seed_from_config' do
     # NOTE: .seed_from_config has already been run or we wouldn't be able to run tests
 

--- a/spec/models/zip_part_spec.rb
+++ b/spec/models/zip_part_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ZipPart do
   let(:zmv) { build(:zipped_moab_version) }
-  let(:args) { attributes_for(:zip_part).merge(zipped_moab_version: zmv) }
+  let(:args) { attributes_for(:zip_part, index: 1).merge(zipped_moab_version: zmv) }
 
   it 'defines a status enum with the expected values' do
     is_expected.to define_enum_for(:status).with_values(

--- a/spec/models/zipped_moab_version_spec.rb
+++ b/spec/models/zipped_moab_version_spec.rb
@@ -154,4 +154,14 @@ RSpec.describe ZippedMoabVersion do
       end
     end
   end
+
+  describe '#update_status_updated_at before save' do
+    it 'sets status_updated_at if status has changed' do
+      expect { zmv.ok! }.to(change(zmv, :status_updated_at))
+    end
+
+    it 'does not change status_updated_at if status has not changed' do
+      expect { zmv.update!(zip_parts_count: 2) }.not_to(change(zmv, :status_updated_at))
+    end
+  end
 end

--- a/spec/services/audit/replication_spec.rb
+++ b/spec/services/audit/replication_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 describe Audit::Replication do
   let(:results) { described_class.results(preserved_object) }
 
-  let(:preserved_object) { create(:preserved_object, current_version: 2) }
+  let(:preserved_object) do
+    create(:preserved_object, current_version: 2).tap(&:populate_zipped_moab_versions!)
+  end
   let(:endpoints) { preserved_object.zipped_moab_versions.map(&:zip_endpoint).uniq }
   let(:endpoint) { endpoints.first }
   let(:endpoint2) { endpoints.second }

--- a/spec/services/audit/replication_support_spec.rb
+++ b/spec/services/audit/replication_support_spec.rb
@@ -124,9 +124,8 @@ RSpec.describe Audit::ReplicationSupport do
         )
       end
 
-      it 'logs the unreplicated parts' do
-        unreplicated_parts = zmv.zip_parts.where(suffix: ['.zip', '.z02'])
-        msg = "#{result_prefix}: not all ZippedMoabVersion parts are replicated yet: #{unreplicated_parts.to_a}"
+      it 'logs' do
+        msg = "#{result_prefix}: not all ZippedMoabVersion parts are replicated yet"
         described_class.check_child_zip_part_attributes(zmv, results)
         expect(results.results).to include(a_hash_including(Audit::Results::ZIP_PARTS_NOT_ALL_REPLICATED => msg))
       end

--- a/spec/services/moab_record_service/create_spec.rb
+++ b/spec/services/moab_record_service/create_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe MoabRecordService::Create do
     allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
     allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(ReplicationJob).to receive(:perform_later)
   end
 
   describe '#execute' do
@@ -33,6 +34,7 @@ RSpec.describe MoabRecordService::Create do
       expect(new_preserved_object.current_version).to eq incoming_version
       expect(new_moab_record.moab_storage_root).to eq moab_storage_root
       expect(new_moab_record.size).to eq incoming_size
+      expect(ReplicationJob).to have_received(:perform_later).with(new_preserved_object)
     end
 
     it 'creates the MoabRecord with "ok" status and validation timestamps if caller ran CV' do

--- a/spec/services/moab_record_service/update_version_spec.rb
+++ b/spec/services/moab_record_service/update_version_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe MoabRecordService::UpdateVersion do
     allow(AuditReporters::LoggerReporter).to receive(:new).and_return(logger_reporter)
     allow(AuditReporters::HoneybadgerReporter).to receive(:new).and_return(honeybadger_reporter)
     allow(AuditReporters::EventServiceReporter).to receive(:new).and_return(event_service_reporter)
+    allow(ReplicationJob).to receive(:perform_later)
   end
 
   describe '#execute' do
@@ -140,6 +141,7 @@ RSpec.describe MoabRecordService::UpdateVersion do
           it 'current_version becomes incoming version' do
             expect { moab_record_service.execute }.to change(moab_record_service.preserved_object, :current_version)
               .to(incoming_version)
+            expect(ReplicationJob).to have_received(:perform_later).with(preserved_object)
           end
         end
 

--- a/spec/services/replication/audit_service_spec.rb
+++ b/spec/services/replication/audit_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Replication::AuditService do
+  subject(:results_list) { described_class.call(preserved_object:) }
+
+  let(:preserved_object) { create(:preserved_object) }
+
+  let(:zip_endpoint_east) { create(:zip_endpoint, endpoint_name: 's3-east') }
+  let(:zip_endpoint_west) { create(:zip_endpoint, endpoint_name: 's3-west') }
+  let!(:zipped_moab_version_east) { create(:zipped_moab_version, preserved_object:, zip_endpoint: zip_endpoint_east) }
+  let!(:zipped_moab_version_west) { create(:zipped_moab_version, preserved_object:, zip_endpoint: zip_endpoint_west) }
+
+  before do
+    allow(ZipEndpoint).to receive(:all).and_return([zip_endpoint_east, zip_endpoint_west])
+    allow(Replication::ZippedMoabVersionAuditService).to receive(:call)
+  end
+
+  it 'returns audit results for each zip endpoint' do
+    expect(results_list.length).to eq 2
+    endpoint_names = results_list.map { |result| result.moab_storage_root.endpoint_name }
+    expect(endpoint_names).to contain_exactly('s3-east', 's3-west')
+
+    expect(Replication::ZippedMoabVersionAuditService).to have_received(:call)
+      .with(zipped_moab_version: zipped_moab_version_east, audit_results: Audit::Results)
+    expect(Replication::ZippedMoabVersionAuditService).to have_received(:call)
+      .with(zipped_moab_version: zipped_moab_version_west, audit_results: Audit::Results)
+  end
+end

--- a/spec/services/replication/provider_factory_spec.rb
+++ b/spec/services/replication/provider_factory_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Replication::ProviderFactory do
+  subject(:provider) { described_class.create(zip_endpoint:) }
+
+  context 'when the endpoint configuration exists' do
+    let(:zip_endpoint) { instance_double(ZipEndpoint, endpoint_name: 'aws_s3_west_2') }
+
+    it 'creates an AwsProvider instance' do
+      expect(provider).to be_an_instance_of(Replication::AwsProvider)
+      expect(provider.bucket_name).to eq('sul-sdr-aws-us-west-2-test')
+    end
+  end
+
+  context 'when the endpoint configuration is missing' do
+    let(:zip_endpoint) { instance_double(ZipEndpoint, endpoint_name: 'non_existent_endpoint') }
+
+    it 'raises an error' do
+      expect { provider }.to raise_error('Unknown endpoint configuration')
+    end
+  end
+end

--- a/spec/services/replication/replicate_version_service_spec.rb
+++ b/spec/services/replication/replicate_version_service_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable RSpec/SubjectStub
+RSpec.describe Replication::ReplicateVersionService do
+  subject(:service) { described_class.new(preserved_object:, version:) }
+
+  let(:preserved_object) { create(:preserved_object, druid:) }
+  let(:version) { 2 }
+  let(:druid) { 'bj102hs9687' }
+  let(:s3_key) { 'bj/102/hs/9687/bj102hs9687.v0002.zip' }
+
+  let(:bucket) { instance_double(Aws::S3::Bucket, object: s3_part) }
+  let(:s3_part) { instance_double(Aws::S3::Object) }
+  let(:provider) { instance_double(Replication::AwsProvider, bucket:) }
+
+  let(:druid_version_zip) { instance_double(Replication::DruidVersionZip, s3_key:, complete?: true, cleanup_zip_parts!: nil) }
+  let(:druid_version_zip_part) { instance_double(Replication::DruidVersionZipPart) }
+
+  before do
+    allow(Replication::DruidVersionZip).to receive(:new).with(druid, version, nil).and_return(druid_version_zip)
+    allow(Replication::DruidVersionZipPart).to receive(:new).with(druid_version_zip, s3_key).and_return(druid_version_zip_part)
+
+    allow(Replication::ProviderFactory).to receive(:create).and_return(provider)
+  end
+
+  context 'when there are no created or incomplete ZippedMoabVersions' do
+    before do
+      create(:zipped_moab_version, status: :ok, preserved_object:, version:)
+      create(:zipped_moab_version, status: :failed, preserved_object:, version:)
+      allow(service).to receive(:create_zip_if_necessary) # rubocop:disable RSpec/SubjectStub
+    end
+
+    it 'does nothing' do
+      described_class.call(preserved_object:, version:)
+      expect(service).not_to have_received(:create_zip_if_necessary) # rubocop:disable RSpec/SubjectStub
+    end
+  end
+
+  context 'when zip parts files are not complete' do
+    let(:druid_version_zip) { instance_double(Replication::DruidVersionZip, complete?: false, cleanup_zip_parts!: nil, create_zip!: nil) }
+
+    before do
+      create(:zipped_moab_version, status: :incomplete, preserved_object:, version:)
+      # This stubs out the other parts that are not being tested here.
+      allow(subject).to receive_messages(no_zip_parts_on_endpoint?: false, md5_mismatch_for_md5_sidecar?: false)
+      allow(subject).to receive(:replicate_incomplete_zipped_moab_versions)
+
+      allow(Replication::DruidVersionZip).to receive(:new).and_return(druid_version_zip)
+    end
+
+    it 'creates the zip part files' do
+      service.call
+      expect(druid_version_zip).to have_received(:cleanup_zip_parts!).twice
+      expect(druid_version_zip).to have_received(:create_zip!)
+    end
+  end
+
+  context 'when no zip parts are found on the endpoint for an incomplete ZippedMoabVersion' do
+    let!(:zipped_moab_version) do
+      create(:zipped_moab_version, status: :incomplete, preserved_object:, version:).tap do |zipped_moab_version|
+        create(:zip_part, zipped_moab_version:)
+      end
+    end
+
+    before do
+      allow(subject).to receive(:md5_mismatch_for_md5_sidecar?).and_return(false)
+      allow(subject).to receive(:populate_zip_parts!)
+      allow(subject).to receive(:replicate_incomplete_zipped_moab_versions)
+
+      allow(s3_part).to receive(:exists?).and_return(false)
+    end
+
+    it 'resets the ZippedMoabVersion to created status and deletes any existing ZipParts' do
+      expect { service.call }
+        .to change { zipped_moab_version.reload.status }.from('incomplete').to('created')
+        .and change { zipped_moab_version.zip_parts.count }.from(1).to(0)
+    end
+  end
+
+  context 'when there is a md5 mismatch for a zip part sidecar file' do
+    let!(:zipped_moab_version) do
+      create(:zipped_moab_version, status: :incomplete, preserved_object:, version:).tap do |zipped_moab_version|
+        create(:zip_part, zipped_moab_version:)
+      end
+    end
+
+    before do
+      # This stubs out the other parts that are not being tested here.
+      allow(subject).to receive(:no_zip_parts_on_endpoint?).and_return(false)
+      allow(subject).to receive(:replicate_incomplete_zipped_moab_versions)
+
+      allow(druid_version_zip_part).to receive(:read_md5).and_return('differentmd5hashvalue1234')
+    end
+
+    it 'sets the ZippedMoabVersion status to failed' do
+      expect { service.call }
+        .to change { zipped_moab_version.reload.status }.from('incomplete').to('failed')
+    end
+  end
+
+  context 'when there are created ZippedMoabVersions' do
+    let!(:zipped_moab_version) do
+      create(:zipped_moab_version, status: :created, preserved_object:, version:)
+    end
+
+    let(:druid_version_zip_part1) { instance_double(Replication::DruidVersionZipPart, extname: '.zip', read_md5: '00236a2ae558018ed13b5222ef1bd977', size: 1234) }
+    let(:druid_version_zip_part2) { instance_double(Replication::DruidVersionZipPart, extname: '.z02', read_md5: '11236a2ae558018ed13b5222ef1bd988', size: 5678) }
+
+    before do
+      # This stubs out the other parts that are not being tested here.
+      allow(subject).to receive(:replicate_incomplete_zipped_moab_versions)
+
+      allow(druid_version_zip).to receive(:druid_version_zip_parts).and_return([druid_version_zip_part1, druid_version_zip_part2])
+    end
+
+    it 'populates the ZipParts for the ZippedMoabVersion' do
+      expect { service.call }
+        .to change { zipped_moab_version.zip_parts.count }.from(0).to(2)
+        .and change { zipped_moab_version.reload.status }.from('created').to('incomplete')
+        .and change(zipped_moab_version, :zip_parts_count).from(nil).to(2)
+      zip_part1 = zipped_moab_version.zip_parts.find_by(suffix: '.zip')
+      expect(zip_part1.size).to eq 1234
+      expect(zip_part1.md5).to eq '00236a2ae558018ed13b5222ef1bd977'
+      zip_part2 = zipped_moab_version.zip_parts.find_by(suffix: '.z02')
+      expect(zip_part2.size).to eq 5678
+      expect(zip_part2.md5).to eq '11236a2ae558018ed13b5222ef1bd988'
+    end
+  end
+
+  context 'when replication succeeds' do
+    let(:zipped_moab_version) do
+      create(:zipped_moab_version, status: :incomplete, preserved_object:, version:)
+    end
+    let!(:zip_part) { create(:zip_part, zipped_moab_version:) }
+
+    before do
+      # This stubs out the other parts that are not being tested here.
+      allow(subject).to receive(:create_zip_if_necessary)
+      allow(subject).to receive_messages(no_zip_parts_on_endpoint?: false, md5_mismatch_for_md5_sidecar?: false)
+
+      allow(Replication::ReplicateZipPartService).to receive(:call)
+      allow(Dor::Event::Client).to receive(:create)
+      allow(Socket).to receive(:gethostname).and_return('fakehost')
+    end
+
+    it 'sets the ZippedMoabVersion status to ok and sends a DSA event' do
+      expect { service.call }.to change { zipped_moab_version.reload.status }.from('incomplete').to('ok')
+      expect(Replication::ReplicateZipPartService).to have_received(:call).with(zip_part:).once
+
+      expect(Dor::Event::Client).to have_received(:create).with(
+        druid: "druid:#{druid}",
+        type: 'druid_version_replicated',
+        data: hash_including(
+          host: 'fakehost',
+          invoked_by: 'preservation-catalog',
+          version:,
+          endpoint_name: zipped_moab_version.zip_endpoint.endpoint_name,
+          parts_info: [{ s3_key:, size: 1234, md5: '00236a2ae558018ed13b5222ef1bd977' }]
+        )
+      )
+
+      expect(druid_version_zip).to have_received(:cleanup_zip_parts!)
+    end
+  end
+
+  context 'when replication raises DifferentPartFileFoundError' do
+    let!(:zipped_moab_version) do
+      create(:zipped_moab_version, status: :incomplete, preserved_object:, version:).tap do |zipped_moab_version|
+        create(:zip_part, zipped_moab_version:)
+      end
+    end
+
+    before do
+      # This stubs out the other parts that are not being tested here.
+      allow(subject).to receive(:create_zip_if_necessary)
+      allow(subject).to receive_messages(no_zip_parts_on_endpoint?: false, md5_mismatch_for_md5_sidecar?: false)
+
+      allow(Replication::ReplicateZipPartService).to receive(:call).and_raise(Replication::ReplicateZipPartService::DifferentPartFileFoundError)
+    end
+
+    it 'sets the ZippedMoabVersion status to failed and notifies' do
+      expect { service.call }.to change { zipped_moab_version.reload.status }.from('incomplete').to('failed')
+
+      expect(druid_version_zip).to have_received(:cleanup_zip_parts!)
+    end
+  end
+end
+# rubocop:enable RSpec/SubjectStub

--- a/spec/services/replication/replicate_zip_part_service_spec.rb
+++ b/spec/services/replication/replicate_zip_part_service_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Replication::ReplicateZipPartService do
+  subject { described_class.new(zip_part:) }
+
+  let(:zip_part) { create(:zip_part, md5:) }
+  let(:druid_version_zip_part) { instance_double(Replication::DruidVersionZipPart, file_path: '/path/to/file', read_md5: md5, size: 2048) }
+  let(:s3_part) { instance_double(Aws::S3::Object) }
+  let(:md5) { '00236a2ae558018ed13b5222ef1bd977' }
+
+  before do
+    allow(zip_part).to receive_messages(s3_part: s3_part, druid_version_zip_part: druid_version_zip_part)
+
+    allow(s3_part).to receive(:exists?).and_return(false)
+    allow(s3_part).to receive(:upload_file)
+  end
+
+  context 'when the zip part does not exist on the endpoint' do
+    it 'uploads the zip part file to the endpoint' do
+      subject.call
+      expect(s3_part).to have_received(:upload_file).with('/path/to/file', metadata: { checksum_md5: md5, size: '2048' })
+    end
+  end
+
+  context 'when the zip part already exists on the endpoint with matching md5' do
+    before do
+      allow(s3_part).to receive_messages(exists?: true, metadata: { 'checksum_md5' => md5 })
+    end
+
+    it 'does not re-upload the zip part file' do
+      subject.call
+      expect(s3_part).not_to have_received(:upload_file)
+    end
+  end
+
+  context 'when the zip part already exists on the endpoint with mismatched md5' do
+    before do
+      allow(s3_part).to receive_messages(exists?: true, metadata: { 'checksum_md5' => 'different_md5_value' })
+    end
+
+    it 'raises' do
+      expect { subject.call }.to raise_error(Replication::ReplicateZipPartService::DifferentPartFileFoundError)
+      expect(s3_part).not_to have_received(:upload_file)
+    end
+  end
+end

--- a/spec/services/replication/zipped_moab_version_audit_service_spec.rb
+++ b/spec/services/replication/zipped_moab_version_audit_service_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Replication::ZippedMoabVersionAuditService do
+  let(:preserved_object) { create(:preserved_object_fixture, druid: 'bj102hs9687') }
+  let(:md5_checksum) { '00236a2ae558018ed13b5222ef1bd977' }
+
+  let(:delivery_job) { instance_double(Replication::S3WestDeliveryJob, bucket:) }
+  let(:bucket) { instance_double(Aws::S3::Bucket, object: s3_object) }
+  let(:s3_object) { instance_double(Aws::S3::Object, exists?: true, metadata: { 'checksum_md5' => md5_checksum }) }
+  let(:provider) { instance_double(Replication::AwsProvider, bucket:) }
+
+  let(:missing_s3_object) { instance_double(Aws::S3::Object, exists?: false, bucket_name: 'test-bucket') }
+  let(:mismatch_s3_object) do
+    instance_double(Aws::S3::Object, exists?: true, metadata: { 'checksum_md5' => 'incorrect_checksum' }, bucket_name: 'test-bucket')
+  end
+
+  let(:audit_results) { instance_double(Audit::Results, add_result: nil) }
+
+  before do
+    allow(Replication::ProviderFactory).to receive(:create).and_return(provider)
+  end
+
+  context 'when a ZippedMoabVersion with nil zip_parts_count' do
+    let(:zipped_moab_version) do
+      create(:zipped_moab_version, zip_parts_count: nil, status: :failed, preserved_object: preserved_object).tap do |zipped_moab_version|
+        create_list(:zip_part, 3, zipped_moab_version:, md5: md5_checksum, size: 10_000_000)
+      end
+    end
+
+    before do
+      allow(bucket).to receive(:object).and_return(s3_object)
+    end
+
+    it 'sets zip_parts_count to actual count' do
+      expect { described_class.call(zipped_moab_version:, audit_results:) }
+        .to change { zipped_moab_version.reload.zip_parts_count }.from(nil).to(3)
+        .and change { zipped_moab_version.reload.status }.to('ok')
+    end
+  end
+
+  context 'when a ZippedMoabVersion with no issues' do
+    let(:zipped_moab_version) do
+      create(:zipped_moab_version, zip_parts_count: 3, status: :failed, preserved_object: preserved_object).tap do |zipped_moab_version|
+        create_list(:zip_part, 3, zipped_moab_version:, md5: md5_checksum, size: 10_000_000)
+      end
+    end
+
+    it 'changes status to ok and returns no audit results' do
+      expect { described_class.call(zipped_moab_version:, audit_results:) }
+        .to change { zipped_moab_version.reload.status }.to('ok')
+      expect(audit_results).not_to have_received(:add_result)
+    end
+  end
+
+  context 'when a ZippedMoabVersion with no ZipParts' do
+    let(:zipped_moab_version) do
+      create(:zipped_moab_version, status: :ok, preserved_object: preserved_object)
+    end
+
+    it 'adds an audit result and changes status to created' do
+      expect { described_class.call(zipped_moab_version:, audit_results:) }
+        .to change { zipped_moab_version.reload.status }.to('created')
+      expect(audit_results).to have_received(:add_result).with(
+        Audit::Results::ZIP_PARTS_NOT_CREATED,
+        hash_including(
+          version: zipped_moab_version.version,
+          endpoint_name: zipped_moab_version.zip_endpoint.endpoint_name
+        )
+      )
+    end
+  end
+
+  context 'when a created ZippedMoabVersion with no ZipParts' do
+    let(:zipped_moab_version) do
+      create(:zipped_moab_version, status: :created, preserved_object: preserved_object)
+    end
+
+    it 'adds an audit result and leaves status' do
+      expect { described_class.call(zipped_moab_version:, audit_results:) }
+        .not_to(change { zipped_moab_version.reload.status })
+      expect(audit_results).to have_received(:add_result).with(
+        Audit::Results::ZIP_PARTS_NOT_CREATED, Hash
+      )
+    end
+  end
+
+  context 'when a ZippedMoabVersion with inconsistent zip part sizes' do
+    let(:zipped_moab_version) do
+      create(:zipped_moab_version, zip_parts_count: 3, status: :ok, preserved_object: preserved_object).tap do |zipped_moab_version|
+        create_list(:zip_part, 3, zipped_moab_version:, md5: md5_checksum, size: 100)
+      end
+    end
+
+    it 'changes the status to failed and adds an audit result' do
+      expect { described_class.call(zipped_moab_version:, audit_results:) }
+        .to change { zipped_moab_version.reload.status }.to('failed')
+      expect(audit_results).to have_received(:add_result).with(
+        Audit::Results::ZIP_PARTS_SIZE_INCONSISTENCY,
+        hash_including(
+          total_part_size: 300,
+          moab_version_size: 1_928_387
+        )
+      )
+    end
+  end
+
+  context 'when a ZippedMoabVersion with inconsistent zip part counts' do
+    let(:zipped_moab_version) do
+      create(:zipped_moab_version, zip_parts_count: 3, status: :ok, preserved_object: preserved_object).tap do |zipped_moab_version|
+        create_list(:zip_part, 2, zipped_moab_version:, md5: md5_checksum, size: 10_000_000)
+      end
+    end
+
+    it 'changes the status to failed and adds an audit result' do
+      expect { described_class.call(zipped_moab_version:, audit_results:) }
+        .to change { zipped_moab_version.reload.status }.to('failed')
+      expect(audit_results).to have_received(:add_result).with(
+        Audit::Results::ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL,
+        hash_including(
+          db_count: 3,
+          actual_count: 2
+        )
+      )
+    end
+  end
+
+  context 'when a ZippedMoabVersion with checksum mismatches' do
+    let(:zipped_moab_version) do
+      create(:zipped_moab_version, zip_parts_count: 3, status: :ok, preserved_object: preserved_object).tap do |zipped_moab_version|
+        create_list(:zip_part, 3, zipped_moab_version:, md5: md5_checksum, size: 10_000_000)
+      end
+    end
+
+    before do
+      allow(bucket).to receive(:object).and_return(s3_object, mismatch_s3_object, s3_object)
+    end
+
+    it 'changes the status to failed and adds an audit result' do
+      expect { described_class.call(zipped_moab_version:, audit_results:) }
+        .to change { zipped_moab_version.reload.status }.to('failed')
+      expect(audit_results).to have_received(:add_result).with(
+        Audit::Results::ZIP_PART_CHECKSUM_MISMATCH,
+        hash_including(
+          bucket_name: 'test-bucket',
+          endpoint_name: zipped_moab_version.zip_endpoint.endpoint_name,
+          md5: '00236a2ae558018ed13b5222ef1bd977',
+          replicated_checksum: 'incorrect_checksum',
+          s3_key: zipped_moab_version.zip_parts.second.s3_key
+        )
+      )
+    end
+  end
+
+  context 'when a ZippedMoabVersion with missing zip parts' do
+    let(:zipped_moab_version) do
+      create(:zipped_moab_version, zip_parts_count: 3, status: :ok, preserved_object: preserved_object).tap do |zipped_moab_version|
+        create_list(:zip_part, 3, zipped_moab_version:, md5: md5_checksum, size: 10_000_000)
+      end
+    end
+
+    before do
+      allow(bucket).to receive(:object).and_return(s3_object, missing_s3_object, s3_object)
+    end
+
+    it 'changes the status to incomplete and adds an audit result' do
+      expect { described_class.call(zipped_moab_version:, audit_results:) }
+        .to change { zipped_moab_version.reload.status }.to('incomplete')
+      expect(audit_results).to have_received(:add_result).with(
+        Audit::Results::ZIP_PART_NOT_FOUND,
+        hash_including(
+          bucket_name: 'test-bucket',
+          endpoint_name: zipped_moab_version.zip_endpoint.endpoint_name,
+          s3_key: zipped_moab_version.zip_parts.second.s3_key
+        )
+      )
+    end
+  end
+
+  context 'when an incomplete ZippedMoabVersion with missing zip parts' do
+    let(:zipped_moab_version) do
+      create(:zipped_moab_version, zip_parts_count: 3, status: :incomplete, preserved_object: preserved_object).tap do |zipped_moab_version|
+        create_list(:zip_part, 3, zipped_moab_version:, md5: md5_checksum, size: 10_000_000)
+      end
+    end
+
+    before do
+      allow(bucket).to receive(:object).and_return(s3_object, missing_s3_object, s3_object)
+    end
+
+    it 'does not change status but adds an audit result' do
+      expect { described_class.call(zipped_moab_version:, audit_results:) }
+        .not_to(change { zipped_moab_version.reload.status })
+
+      expect(audit_results).to have_received(:add_result).with(
+        Audit::Results::ZIP_PARTS_NOT_ALL_REPLICATED, Hash
+      )
+    end
+  end
+end


### PR DESCRIPTION
# Why was this change made? 🤔
@jmartin-sul is not immortal, but the preservation system is.



# How was this change tested? 🤨

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



