### PR TITLE
Switch to using Aws transfer manager.

### DIFF
--- a/app/models/zip_endpoint.rb
+++ b/app/models/zip_endpoint.rb
@@ -18,6 +18,8 @@ class ZipEndpoint < ApplicationRecord
   # TODO: after switching to string, validate that input resolves to class which #is_a class of the right type?
   validates :delivery_class, presence: true
 
+  delegate :bucket, :bucket_name, to: :provider
+
   # iterates over the zip endpoints enumerated in settings, creating a ZipEndpoint for each if one doesn't
   # already exist.
   # @return [Array<ZipEndpoint>] the ZipEndpoint list for the zip endpoints defined in the config (all
@@ -42,9 +44,8 @@ class ZipEndpoint < ApplicationRecord
     end
   end
 
-  # @return [Aws::S3::Bucket] S3 bucket object for this zip endpoint
-  def bucket
-    @bucket ||= Replication::ProviderFactory.create(zip_endpoint: self).bucket
+  def provider
+    @provider ||= Replication::ProviderFactory.create(zip_endpoint: self)
   end
 
   def to_s

--- a/app/services/replication/replicate_zip_part_service.rb
+++ b/app/services/replication/replicate_zip_part_service.rb
@@ -21,7 +21,9 @@ module Replication
       return if already_replicated?
       check_existing_part_file_on_endpoint
 
-      s3_part.upload_file(druid_version_zip_part.file_path, metadata:)
+      transfer_manager.upload_file(druid_version_zip_part.file_path,
+                                   bucket: zip_part.zip_endpoint.bucket_name,
+                                   key: zip_part.s3_key, metadata:)
     end
 
     private
@@ -60,6 +62,12 @@ module Replication
 
     def check_existing_part_file_on_endpoint
       raise DifferentPartFileFoundError if zip_part_file_exists_on_endpoint? && !zip_part_md5s_match?
+    end
+
+    def transfer_manager
+      @transfer_manager ||= Aws::S3::TransferManager.new(
+        client: zip_part.zip_endpoint.provider.client
+      )
     end
   end
 end

--- a/spec/services/replication/replicate_zip_part_service_spec.rb
+++ b/spec/services/replication/replicate_zip_part_service_spec.rb
@@ -9,18 +9,28 @@ RSpec.describe Replication::ReplicateZipPartService do
   let(:druid_version_zip_part) { instance_double(Replication::DruidVersionZipPart, file_path: '/path/to/file', read_md5: md5, size: 2048) }
   let(:s3_part) { instance_double(Aws::S3::Object) }
   let(:md5) { '00236a2ae558018ed13b5222ef1bd977' }
+  let(:transfer_manager) { instance_double(Aws::S3::TransferManager) }
+  let(:bucket_name) { 'sul-sdr-aws-us-west-2-test' }
+  let(:provider) { instance_double(Replication::AwsProvider, client:, bucket_name:) }
+  let(:client) { instance_double(Aws::S3::Client) }
 
   before do
     allow(zip_part).to receive_messages(s3_part: s3_part, druid_version_zip_part: druid_version_zip_part)
 
     allow(s3_part).to receive(:exists?).and_return(false)
-    allow(s3_part).to receive(:upload_file)
+    allow(Aws::S3::TransferManager).to receive(:new).with(client:).and_return(transfer_manager)
+    allow(transfer_manager).to receive(:upload_file)
+    allow(Replication::ProviderFactory).to receive(:create).and_return(provider)
   end
 
   context 'when the zip part does not exist on the endpoint' do
     it 'uploads the zip part file to the endpoint' do
       subject.call
-      expect(s3_part).to have_received(:upload_file).with('/path/to/file', metadata: { checksum_md5: md5, size: '2048' })
+      expect(transfer_manager).to have_received(:upload_file)
+        .with('/path/to/file',
+              bucket: bucket_name,
+              key: zip_part.s3_key,
+              metadata: { checksum_md5: md5, size: '2048' })
     end
   end
 
@@ -31,7 +41,7 @@ RSpec.describe Replication::ReplicateZipPartService do
 
     it 'does not re-upload the zip part file' do
       subject.call
-      expect(s3_part).not_to have_received(:upload_file)
+      expect(transfer_manager).not_to have_received(:upload_file)
     end
   end
 
@@ -42,7 +52,7 @@ RSpec.describe Replication::ReplicateZipPartService do
 
     it 'raises' do
       expect { subject.call }.to raise_error(Replication::ReplicateZipPartService::DifferentPartFileFoundError)
-      expect(s3_part).not_to have_received(:upload_file)
+      expect(transfer_manager).not_to have_received(:upload_file)
     end
   end
 end


### PR DESCRIPTION
# Why was this change made? 🤔
The current upload method is deprecated.



# How was this change tested? 🤨
QA

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



