### PR TITLE
Implement basic alert for dashboard based on config

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,3 +418,15 @@ purge_druid_from_all_could_providers!(test_druid, dry_run: false)
 # dry run on the first 10, to do for real add param `dry_run: false`
 druid_list.take(10).map { |druid_str| purge_druid_from_all_could_providers!(druid_str) }
 ```
+
+## Setting alert notices to appear on the dashboard
+
+In order to include a banner in the UI with a given bootstrap alert variant, see: https://getbootstrap.com/docs/4.0/components/alerts/ add a line to the appropriate environments settings.yml with the variant as key and the desired text as value.
+
+Valid variants are: primary, secondary, success, danger, warning, info, light, dark
+
+### Example:
+```
+notices:
+ warning: 'This is a Preservation Catalog instance running in the TEST environment.'
+ info: 'This is providing info <a href="http://example.com">with a link to document.</a>'

--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# A component for displaying alert messages
+class AlertComponent < ViewComponent::Base
+  def call
+    safe_join(notices.map do |notice|
+      next if notice.last.blank?
+
+      content_tag :div, class: "alert alert-#{notice.first}", role: 'alert' do
+        sanitize notice.last
+      end
+    end)
+  end
+
+  def render?
+    notices.present?
+  end
+
+  private
+
+  def notices
+    Settings.notices
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,17 +12,7 @@
   </head>
 
   <body>
-      <% if flash[:notice] %>
-        <div class="alert alert-primary" role="alert">
-          <%= flash[:notice] %>
-        </div>
-      <% end %>
-      <% if flash[:alert] %>
-        <div class="alert alert-warning" role="alert">
-          <%= flash[:alert] %>
-        </div>
-      <% end %>
-
+      <%= render AlertComponent.new %>
       <%= yield %>
   </body>
 </html>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -72,3 +72,10 @@ slow_queries:
   enable: false
   threshold: 500
 
+# In order to include a banner in the UI with a given bootstrap alert variant,
+# see: https://getbootstrap.com/docs/4.0/components/alerts/
+# add a line below with the variant as key and the desired text as value.
+# Valid variants are: primary, secondary, success, danger, warning, info, light, dark
+# Example:
+#  warning: 'This is a Preservation Catalog instance running in the TEST environment.'
+notices:

--- a/spec/components/alert_component_spec.rb
+++ b/spec/components/alert_component_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AlertComponent, type: :component do
+  context 'when there are no notices' do
+    it 'does not render alert content' do
+      render_inline(described_class.new)
+      expect(page).to have_no_css('.alert')
+    end
+  end
+
+  context 'when there are notices' do
+    before do
+      allow(Settings).to receive(:notices).and_return([
+                                                        ['warning', 'This is a test warning message.'],
+                                                        ['info', 'This is a test info warning'],
+                                                        ['alert', ''] # blank notices should not render
+                                                      ])
+    end
+
+    it 'does renders a warning alert content' do
+      render_inline(described_class.new)
+
+      expect(page).to have_css('div.alert.alert-warning', text: 'This is a test warning message.')
+      expect(page).to have_css('div.alert.alert-info', text: 'This is a test info warning')
+      expect(page).to have_no_css('div.alert.alert-alert')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2503 

This is a basic component that renders dashboard alerts based on notices configured in settings.

<img width="1005" height="436" alt="Screenshot 2026-01-13 at 9 41 43 AM" src="https://github.com/user-attachments/assets/55c238cf-65f0-445f-9601-a899c8339af3" />
