### PR TITLE
bin/fixity_check_replicated_moabs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,3 +17,8 @@ workflows:
           api-only: true
           db-prepare-command: db:reset
           executor: ruby-rails/ruby-postgres-redis
+          before-test:
+            - run: sudo apt-get update -y
+            - run: sudo apt-get install -y 7zip
+            - run: cd /home/circleci/.local/bin && ln -s `which 7zz` 7z && ls -lah
+            - run: 7z -h # just some debugging output in case the installation went awry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Project Guidelines
+
+preservation_catalog (aka prescat or pres cat) is a Rails application that does the following for Stanford Digital Repository (SDR) objects:
+* catalogs the existence, version, and last known preservation fixity status for each preserved copy of an accessioned SDR object.
+* replicates copies to the cloud, from on prem copies that have passed fixity checking.
+* audits on prem and cloud copies of archival artifacts for presence and data integrity.
+  * As of May 2026, all on prem copies are regularly checked in full for fixity.  Cloud copies are checked for presence and expected minimum size, and there are plans to introduce fixity checking as part of future enhancement work.
+
+## Architecture
+
+Prefer putting complex domain logic in service classes. As much as is possible, model classes, job classes, and rake tasks should be thin wrappers for service class code that is well tested.
+
+For command line tasks that require complex argument handling, prefer scripts in the bin directory that use OptionParser, instead of Rake tasks.
+
+## Conventions
+
+In the database, use foreign key constraints and unique indexes where possible.
+
+Similarly, also use Rails ActiveRecord validations where possible to provide informative error messages, and _only_ where needed, to implement validation that cannot be adequately expressed as relational database constraints.
+
+## Testing Notes
+
+* When creating multiple, unique druids for the same spec, vary at least the first 2 characters and the last 2 characters.
+* Prefer instance_doubles instead of doubles.
+* For mocking, place allow statements in a before block and expect statements after the action is performed. Prefer testing argument (with) in expect; do not test in both allow and expect.
+* Place "let" statements before "before "blocks.
+
+
+## SDR object identifiers
+
+Each object is identified by a unique "druid" (Digital Repository Unique Identifier).
+
+Druids are stored **without** the `druid:` prefix in the database. The pattern is enforced with an ActiveRecord format validator. The `druid-tools` gem provides `DruidTools::Druid` for validation and path generation based on other app configuration.
+
+Druids should match the pattern "^[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$", e.g., "bc123df4567".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ The *prescat* application has several modes of operation, that are either self-m
 
 2. *prescat* has an internal schedule of cron jobs which perform periodic [audits](https://github.com/sul-dlss/preservation_catalog/wiki/Validations-for-Moabs) that compare the Moabs that are on disk, with what is in the database (and vice-versa), and also verify that data has been replicated to the cloud. These audits ensure that files are present with the expected content (fixity). When these audits succeed or fail they generate events using the [DOR Services API](https://sul-dlss.github.io/dor-services-app/#operation/events#create), and (if they fail) Honey Badger alerts.
 
-3. Both [Argo](https://github.com/sul-dlss/argo) and [HappyHeron](https://github.com/sul-dlss/happy-heron) allow users to fetch preserved files using the *prescat* REST API.
+3. Both [Argo](https://github.com/sul-dlss/argo) and [H3](https://github.com/sul-dlss/hungry-hungry-hippo/) allow users to fetch preserved files using the *prescat* REST API.
 
 4. [DOR Services](https://github.com/sul-dlss/dor-services-app) uses the *prescat* REST API in order to determine what files are in need of replication during shelving to [Stacks](https://github.com/sul-dlss/stacks).
 
 ```mermaid
 flowchart LR;
-  H2 --> PresCat;
+  H3 --> PresCat;
   Argo --> PresCat;
   DSA <--> PresCat;
   PresRobots --> PresCat;
@@ -46,6 +46,28 @@ Here are the steps you need to follow to get a working development instance of *
 First get the Ruby dependencies:
 ```sh
 bundle install
+```
+
+Then, install `yarn` if you haven't already.  E.g., if using NVM to manage Node versions, something like:
+```sh
+nvm install 20 --latest-npm
+nvm use 20
+npm install -g yarn
+```
+
+Then, install 7zip.
+
+This is required because it works on multi-part zip files reliably, which pres cat generates for large objects, and
+which the default `unzip` CLI tool does not fully support; and because the test suite tests cloud archive fixity checking, and
+only mocks the download:
+```sh
+# E.g. on Mac, use Homebrew like so, see https://formulae.brew.sh/formula/sevenzip
+brew install sevenzip
+
+# By default, the Mac/Homebrew 7zip binary is called 7zz, but in Linux envs, like the VMs were pres cat is deployed,
+# it's 7z.  You can create a 7z symlink on your path.  E.g., if ~/.local/bin/ is on your path, you could do something like:
+cd /Users/$USER/.local/bin/
+ln -s /opt/homebrew/bin/7zz 7z
 ```
 
 The credentials for SideKiq Pro must be provided (e.g., in `.bash_profile`): `export BUNDLE_GEMS__CONTRIBSYS__COM=xxxx:xxxx` (available from shared_configs).

--- a/app/services/audit/replicated_moab_checksum_validator.rb
+++ b/app/services/audit/replicated_moab_checksum_validator.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+module Audit
+  # This service class provides tools for retrieving and fixity checking
+  # archived Moabs (stored as zipped moab versions in S3 buckets, possibly
+  # with multi-part zip files for larger Moab versions).
+  class ReplicatedMoabChecksumValidator # rubocop:disable Metrics/ClassLength
+    include ActionView::Helpers::NumberHelper
+
+    attr_accessor :fixity_check_base_location
+
+    def initialize(fixity_check_base_location:, dry_run:, force_part_md5_comparison:, additional_logger: nil)
+      @fixity_check_base_location = fixity_check_base_location
+      @dry_run = dry_run
+      @force_part_md5_comparison = force_part_md5_comparison
+      @transfer_managers = {}
+      logger.broadcast_to(additional_logger) if additional_logger
+    end
+
+    def logger
+      @logger ||= ActiveSupport::BroadcastLogger.new(
+        Audit::ReplicationSupport.logger
+      )
+    end
+
+    def validate_replicated_moab_checksums!(endpoints_to_audit:, druids:)
+      logger.info('======= DRY RUN =======') if dry_run?
+
+      logger.info("druids to check: #{druids}")
+
+      zip_part_relation =
+        ZipPart.joins(
+          zipped_moab_version: %i[preserved_object zip_endpoint]
+        ).where(
+          preserved_object: { druid: druids },
+          zip_endpoint: { endpoint_name: endpoints_to_audit }
+        ).order(:endpoint_name, :druid, :version, :suffix)
+
+      download_zip_parts(fixity_check_base_location:, zip_part_relation:)
+      unzip_downloaded_zip_parts(zip_part_relation:)
+      fixity_check_unzipped_moabs(endpoints_to_audit:, druids:)
+    end
+
+    def self.druids_having_single_part_versions(sample_count, logger: nil)
+      logger ||= Audit::ReplicationSupport.logger
+
+      # look for druids with nothing but single part zips, one part per replicated version
+      having_clause = 'COUNT(DISTINCT(zip_parts.id)) = COUNT(DISTINCT(zipped_moab_versions.id))'
+
+      po_list = preserved_object_sample_query(sample_count:, having_clause:).pluck(
+        :druid, :current_version, 'COUNT(DISTINCT(zipped_moab_versions.id))',
+        'COUNT(DISTINCT(zip_parts.id))', 'PG_SIZE_PRETTY(SUM(zip_parts.size))',
+        'SUM(zip_parts.size)'
+      )
+
+      total_size = number_to_human_size(po_list.map(&:last).sum)
+      logger.info("query results: preserved_objects with only single-part zips: (#{total_size} total): #{po_list}")
+      po_list.map(&:first).uniq
+    end
+
+    def self.druids_having_a_multi_part_version(sample_count, logger: nil)
+      logger ||= Audit::ReplicationSupport.logger
+
+      # look for druids with at least one multi-part zip, i.e. more parts than replicated versions
+      having_clause = 'COUNT(DISTINCT(zip_parts.id)) > COUNT(DISTINCT(zipped_moab_versions.id))'
+
+      po_list = preserved_object_sample_query(sample_count:, having_clause:).pluck(
+        :druid, :current_version, 'COUNT(DISTINCT(zipped_moab_versions.id))',
+        'COUNT(DISTINCT(zip_parts.id))', 'PG_SIZE_PRETTY(SUM(zip_parts.size))',
+        'SUM(zip_parts.size)'
+      )
+
+      total_size = number_to_human_size(po_list.map(&:last).sum)
+      logger.info("query results: preserved_objects with at least one multi-part zip: (#{total_size} total): #{po_list}")
+      po_list.map(&:first).uniq
+    end
+
+    private
+
+    private_class_method def self.preserved_object_sample_query(sample_count:, having_clause:)
+      PreservedObject.joins(
+        zipped_moab_versions: [:zip_parts]
+      ).group(
+        'preserved_objects.id'
+      ).having(
+        having_clause
+      ).order(
+        'RANDOM()'
+      ).limit(
+        sample_count
+      )
+    end
+
+    def force_part_md5_comparison?
+      @force_part_md5_comparison
+    end
+
+    def dry_run?
+      @dry_run
+    end
+
+    def transfer_manager(zip_endpoint:)
+      @transfer_managers[zip_endpoint.endpoint_name] ||= Aws::S3::TransferManager.new(
+        client: zip_endpoint.provider.client
+      )
+    end
+
+    # @param [Pathname] download_path
+    # @param [ZipPart] zip_part
+    def download_zip_part(download_path:, zip_part:) # rubocop:disable Metrics/AbcSize
+      endpoint_name = zip_part.zip_endpoint.endpoint_name
+      db_md5 = zip_part.md5
+      db_size = zip_part.size
+      s3_key = zip_part.s3_key
+
+      FileUtils.mkdir_p(download_path.dirname) unless download_path.dirname.exist?
+      just_downloaded = false
+      if download_path.exist?
+        logger.info("skipping download of #{s3_key} from #{endpoint_name}, already downloaded")
+      else
+        zip_endpoint = zip_part.zip_endpoint
+        transfer_manager = transfer_manager(zip_endpoint:)
+        logger.info("downloading #{s3_key} from #{endpoint_name} (#{number_to_human_size(db_size)} expected)")
+        transfer_manager.download_file(download_path, bucket: zip_endpoint.bucket.name, key: s3_key)
+        logger.info("downloaded #{s3_key} from #{endpoint_name} (#{number_to_human_size(File.size(download_path.to_s))} retrieved)")
+        just_downloaded = true
+      end
+
+      if just_downloaded || force_part_md5_comparison?
+        logger.info("comparing fresh MD5 calculation to DB value for #{download_path}")
+        fresh_md5 = Digest::MD5.file(download_path)
+        logger.info("fresh_md5.hexdigest=#{fresh_md5.hexdigest}")
+        logger.info("fresh_md5.hexdigest==db_md5: #{fresh_md5.hexdigest == db_md5 ? '✅' : '🚨'}")
+      else
+        logger.info("skipping comparing fresh MD5 calculation to DB value for #{download_path} (already downloaded, comparison not forced)")
+      end
+    end
+
+    def download_zip_parts(fixity_check_base_location:, zip_part_relation:) # rubocop:disable Metrics/AbcSize
+      zip_part_relation.find_each do |zip_part|
+        endpoint_name = zip_part.zip_endpoint.endpoint_name
+        db_md5 = zip_part.md5
+        db_size = zip_part.size
+        s3_key = zip_part.s3_key
+        download_path = Pathname(fixity_check_base_location.join(endpoint_name, s3_key))
+        s3_object = zip_part.s3_part
+
+        logger.info("=== retrieve #{s3_key} from #{endpoint_name}")
+        logger.debug("download_path=#{download_path}")
+        logger.debug("download_path.exist?=#{download_path.exist?}")
+        logger.debug("download_path.dirname=#{download_path.dirname}")
+        logger.debug("download_path.dirname.exist?=#{download_path.dirname.exist?}")
+        logger.debug("s3_key=#{s3_key}")
+        logger.debug("s3_object.exists?=#{s3_object.exists?}")
+        logger.debug("db_md5=#{db_md5}")
+        logger.debug("db_size=#{db_size}")
+        logger.debug("s3_object.metadata=#{s3_object.metadata}")
+
+        if dry_run?
+          logger.info("DRY RUN: skipping download and fresh MD5 computation of #{s3_key} from #{endpoint_name}")
+        else
+          download_zip_part(download_path:, zip_part:)
+        end
+      end
+    end
+
+    # @param [Pathname] download_path
+    def unzip_zipped_moab_version_from_zip_parts(download_path:)
+      unzip_filename = download_path.basename
+
+      logger.info("unzipping #{unzip_filename} in #{download_path.dirname}")
+      logger.debug(Open3.capture2e("7z x #{unzip_filename}", chdir: download_path.dirname))
+    end
+
+    def unzip_downloaded_zip_parts(zip_part_relation:) # rubocop:disable Metrics/AbcSize
+      zip_part_relation.where(suffix: '.zip').find_each do |zip_part|
+        endpoint_name = zip_part.zip_endpoint.endpoint_name
+        druid = zip_part.preserved_object.druid
+        version = zip_part.zipped_moab_version.version
+        s3_key = zip_part.s3_key
+
+        logger.info("=== unzip #{druid} #{version} from #{endpoint_name}")
+        download_path = Pathname(fixity_check_base_location.join(endpoint_name, s3_key))
+        if dry_run?
+          logger.info("DRY RUN, skipping unzipping #{download_path.basename} in #{download_path.dirname}")
+        else
+          unzip_zipped_moab_version_from_zip_parts(download_path:)
+        end
+      end
+    end
+
+    def fixity_check_unzipped_moabs(endpoints_to_audit:, druids:) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+      results_objects = []
+
+      endpoints_to_audit.each do |endpoint_name|
+        druids.each do |druid|
+          logger.info("=== fixity check unzipped Moab for #{druid} from #{endpoint_name}")
+          storage_location = fixity_check_base_location.join(endpoint_name)
+          unless ZippedMoabVersion.joins(:zip_endpoint, :preserved_object).exists?(preserved_object: { druid: },
+                                                                                   zip_endpoint: { endpoint_name: })
+            logger.info("#{endpoint_name} doesn't have any ZMVs for #{druid}, skipping fixity check")
+            next
+          end
+
+          if dry_run?
+            logger.info("DRY RUN, skipping checksum validation for #{druid} in #{storage_location}")
+          else
+            logger.info "Starting checksum validation for #{druid} in #{storage_location} (NOTE: this may take some time!)"
+            checksum_validator = Audit::ChecksumValidator.new(
+              logger:,
+              moab_storage_object: MoabOnStorage.moab(storage_location:, druid:),
+              emit_results: true
+            )
+            checksum_validator.validate
+            results_objects << checksum_validator.results
+          end
+        end
+      end
+
+      results_objects
+    end
+  end
+end

--- a/app/services/audit/replicated_moab_checksum_validator.rb
+++ b/app/services/audit/replicated_moab_checksum_validator.rb
@@ -6,6 +6,7 @@ module Audit
   # with multi-part zip files for larger Moab versions).
   class ReplicatedMoabChecksumValidator # rubocop:disable Metrics/ClassLength
     include ActionView::Helpers::NumberHelper
+    extend ActionView::Helpers::NumberHelper
 
     attr_accessor :fixity_check_base_location
 

--- a/app/services/audit/replicated_moab_checksum_validator.rb
+++ b/app/services/audit/replicated_moab_checksum_validator.rb
@@ -4,12 +4,32 @@ module Audit
   # This service class provides tools for retrieving and fixity checking
   # archived Moabs (stored as zipped moab versions in S3 buckets, possibly
   # with multi-part zip files for larger Moab versions).
+  #
+  # USAGE NOTES:
+  #   * Look at the logs to tell you how the run went!
+  #   * This code works synchronously. It downloads and checksum validates arbitrarily
+  #     large SDR objects. For anything long running, run via screen or ActiveJob.
+  #   * In practice, as of May 2026, this won't be able to retrieve most of our
+  #     content on AWS endpoints, because that content gets moved to Glacier after
+  #     upload, and a request must be made to restore it to a temp S3 bucket for
+  #     retrieval. GCP-stored content should not have that issue, and should be immediately
+  #     retrievable from the location to which it was initially uploaded.
+  #     See https://docs.aws.amazon.com/AmazonS3/latest/userguide/restoring-objects.html
+  #   * A further possible manual check, and an opportunity to add functionality to this class: compare
+  #     the hash of each manifestInventory.xml with corresponding file in on prem Moab.  This file contains
+  #     checksums for each manifest file in the version, including signatureCatalog.xml, which contains checksums
+  #     for each SDR content and metadata file for its version.
   class ReplicatedMoabChecksumValidator # rubocop:disable Metrics/ClassLength
     include ActionView::Helpers::NumberHelper
     extend ActionView::Helpers::NumberHelper
 
     attr_accessor :fixity_check_base_location
 
+    # @param [Pathname] fixity_check_base_location target directory for downloading cloud archived Moabs
+    # @param [Boolean] dry_run if true, do not actually download or checksum validate
+    # @param [Boolean] force_part_md5_comparison Even if the zip parts are not downloaded on this run, compare
+    #  the previously downloaded MD5 results to what is in the DB
+    # @param [Logger] additional_logger an additional logger for this object to broadcast to
     def initialize(fixity_check_base_location:, dry_run:, force_part_md5_comparison:, additional_logger: nil)
       @fixity_check_base_location = fixity_check_base_location
       @dry_run = dry_run
@@ -24,6 +44,8 @@ module Audit
       )
     end
 
+    # @param [Array<String>] endpoints_to_audit
+    # @param [Array<String>] druids
     def validate_replicated_moab_checksums!(endpoints_to_audit:, druids:)
       logger.info('======= DRY RUN =======') if dry_run?
 
@@ -42,6 +64,8 @@ module Audit
       fixity_check_unzipped_moabs(endpoints_to_audit:, druids:)
     end
 
+    # obtain a random sampling of druids for which each ZippedMoabVersion row
+    # has only one ZipPart
     def self.druids_having_single_part_versions(sample_count, logger: nil)
       logger ||= Audit::ReplicationSupport.logger
 
@@ -59,6 +83,9 @@ module Audit
       po_list.map(&:first).uniq
     end
 
+    # obtain a random sampling of druids where at least one of each druid's
+    # ZippedMoabVersion rows has more than one ZipPart (i.e. each druid has at
+    # least one archive zip split into multiple parts)
     def self.druids_having_a_multi_part_version(sample_count, logger: nil)
       logger ||= Audit::ReplicationSupport.logger
 
@@ -137,6 +164,9 @@ module Audit
       end
     end
 
+    # @param [Pathname] fixity_check_base_location
+    # @param [ActiveRecord::Relation] zip_part_relation The zip parts that will be downloaded and inflated into
+    #  Moab directories
     def download_zip_parts(fixity_check_base_location:, zip_part_relation:) # rubocop:disable Metrics/AbcSize
       zip_part_relation.find_each do |zip_part|
         endpoint_name = zip_part.zip_endpoint.endpoint_name
@@ -165,7 +195,7 @@ module Audit
       end
     end
 
-    # @param [Pathname] download_path
+    # @param [Pathname] download_path the path to which the .zip file was downloaded
     def unzip_zipped_moab_version_from_zip_parts(download_path:)
       unzip_filename = download_path.basename
 
@@ -173,6 +203,8 @@ module Audit
       logger.debug(Open3.capture2e("7z x #{unzip_filename}", chdir: download_path.dirname))
     end
 
+    # @param [ActiveRecord::Relation] zip_part_relation The zip parts that will be downloaded and inflated into
+    #  Moab directories
     def unzip_downloaded_zip_parts(zip_part_relation:) # rubocop:disable Metrics/AbcSize
       zip_part_relation.where(suffix: '.zip').find_each do |zip_part|
         endpoint_name = zip_part.zip_endpoint.endpoint_name
@@ -190,6 +222,8 @@ module Audit
       end
     end
 
+    # @param [Array<String>] endpoints_to_audit
+    # @param [Array<String>] druids
     def fixity_check_unzipped_moabs(endpoints_to_audit:, druids:) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       results_objects = []
 

--- a/app/services/audit/replication_support.rb
+++ b/app/services/audit/replication_support.rb
@@ -3,8 +3,6 @@
 module Audit
   # Methods to support auditing replication.
   class ReplicationSupport
-    include ActionView::Helpers::NumberHelper
-
     def self.logger
       @logger ||= Logger.new(Rails.root.join('log', 'c2a.log'))
     end
@@ -37,56 +35,6 @@ module Audit
           checksum_md5: s3_part_exists ? s3_part.metadata['checksum_md5'] : nil
         }
       end
-    end
-
-    # @param [Pathname] download_path
-    # @param [String] s3_key
-    # @param [Aws::S3::Object] s3_object
-    # @param [String] endpoint_name
-    # @param [Integer] db_size
-    # @param [String] db_md5
-    # @param [Boolean] force_part_md5_comparison
-    # @param [ActiveSupport::BroadcastLogger] download_logger
-    # TODO: could start by taking in s3_key and s3_object for simplicity of refactor,
-    #   but should switch to taking in bucket and making a TransferManager, or taking a
-    #   ZipPart and using ReplicateZipPartService to get a transfer manager
-    #   see https://github.com/sul-dlss/preservation_catalog/pull/2526/changes and
-    #   https://www.rubydoc.info/gems/aws-sdk-s3/1.208.0/Aws/S3/TransferManager:download_file
-    def self.download_zip_part(download_path:, s3_key:, s3_object:, endpoint_name:, db_size:, db_md5:, force_part_md5_comparison:, download_logger: nil) # rubocop:disable Metrics/PerceivedComplexity,Metrics/ParameterLists,Layout/LineLength
-      download_logger ||= ActiveSupport::BroadcastLogger.new
-      download_logger.broadcast_to(logger)
-
-      FileUtils.mkdir_p(download_path.dirname) unless download_path.dirname.exist?
-      just_downloaded = false
-      if download_path.exist?
-        download_logger.info("skipping download of #{s3_key} from #{endpoint_name}, already downloaded")
-      else
-        download_logger.info("downloading #{s3_key} from #{endpoint_name} (#{number_to_human_size(db_size)} expected)")
-        s3_object.download_file(download_path)
-        download_logger.info("downloaded #{s3_key} from #{endpoint_name} (#{number_to_human_size(File.size(download_path.to_s))} retrieved)")
-        just_downloaded = true
-      end
-
-      if just_downloaded || force_part_md5_comparison
-        download_logger.info("comparing fresh MD5 calculation to DB value for #{download_path}")
-        fresh_md5 = Digest::MD5.file(download_path)
-        download_logger.info("fresh_md5.hexdigest=#{fresh_md5.hexdigest}")
-        download_logger.info("fresh_md5.hexdigest==db_md5: #{fresh_md5.hexdigest == db_md5 ? '✅' : '🚨'}")
-      else
-        download_logger.info("skipping comparing fresh MD5 calculation to DB value for #{download_path} (already downloaded, comparison not forced)")
-      end
-    end
-
-    # @param [Pathname] download_path
-    # @param [ActiveSupport::BroadcastLogger] unzip_logger
-    def self.unzip_zipped_moab_version_from_zip_parts(download_path:, unzip_logger:)
-      unzip_logger ||= ActiveSupport::BroadcastLogger.new
-      unzip_logger.broadcast_to(logger)
-
-      unzip_filename = download_path.basename
-
-      unzip_logger.info("unzipping #{unzip_filename} in #{download_path.dirname}")
-      unzip_logger.debug(Open3.capture2e("7z x #{unzip_filename}", chdir: download_path.dirname))
     end
   end
 end

--- a/app/services/audit/replication_support.rb
+++ b/app/services/audit/replication_support.rb
@@ -83,22 +83,10 @@ module Audit
       unzip_logger ||= ActiveSupport::BroadcastLogger.new
       unzip_logger.broadcast_to(logger)
 
-      unzip_filename =
-        if Dir.glob("#{download_path.to_s.chomp('zip')}*").size > 1
-          "#{download_path.basename.to_s.chomp('zip')}combined.zip".tap do |combined_filename|
-            unzip_logger.info("multi-part zip, combining into one file (#{combined_filename}) so unzip can handle it")
-            if File.exist?("#{download_path.dirname}/#{combined_filename}")
-              unzip_logger.info("#{download_path.dirname}/#{combined_filename} exists, skipping combining")
-            else
-              # https://unix.stackexchange.com/questions/40480/how-to-unzip-a-multipart-spanned-zip-on-linux
-              unzip_logger.info(Open3.capture2e("zip -s 0 #{download_path.basename} --out #{combined_filename}", chdir: download_path.dirname))
-            end
-          end
-        else
-          download_path.basename
-        end
+      unzip_filename = download_path.basename
+
       unzip_logger.info("unzipping #{unzip_filename} in #{download_path.dirname}")
-      unzip_logger.debug(Open3.capture2e("unzip #{unzip_filename}", chdir: download_path.dirname))
+      unzip_logger.debug(Open3.capture2e("7z x #{unzip_filename}", chdir: download_path.dirname))
     end
   end
 end

--- a/app/services/audit/replication_support.rb
+++ b/app/services/audit/replication_support.rb
@@ -3,6 +3,8 @@
 module Audit
   # Methods to support auditing replication.
   class ReplicationSupport
+    include ActionView::Helpers::NumberHelper
+
     def self.logger
       @logger ||= Logger.new(Rails.root.join('log', 'c2a.log'))
     end
@@ -35,6 +37,68 @@ module Audit
           checksum_md5: s3_part_exists ? s3_part.metadata['checksum_md5'] : nil
         }
       end
+    end
+
+    # @param [Pathname] download_path
+    # @param [String] s3_key
+    # @param [Aws::S3::Object] s3_object
+    # @param [String] endpoint_name
+    # @param [Integer] db_size
+    # @param [String] db_md5
+    # @param [Boolean] force_part_md5_comparison
+    # @param [ActiveSupport::BroadcastLogger] download_logger
+    # TODO: could start by taking in s3_key and s3_object for simplicity of refactor,
+    #   but should switch to taking in bucket and making a TransferManager, or taking a
+    #   ZipPart and using ReplicateZipPartService to get a transfer manager
+    #   see https://github.com/sul-dlss/preservation_catalog/pull/2526/changes and
+    #   https://www.rubydoc.info/gems/aws-sdk-s3/1.208.0/Aws/S3/TransferManager:download_file
+    def self.download_zip_part(download_path:, s3_key:, s3_object:, endpoint_name:, db_size:, db_md5:, force_part_md5_comparison:, download_logger: nil) # rubocop:disable Metrics/PerceivedComplexity,Metrics/ParameterLists,Layout/LineLength
+      download_logger ||= ActiveSupport::BroadcastLogger.new
+      download_logger.broadcast_to(logger)
+
+      FileUtils.mkdir_p(download_path.dirname) unless download_path.dirname.exist?
+      just_downloaded = false
+      if download_path.exist?
+        download_logger.info("skipping download of #{s3_key} from #{endpoint_name}, already downloaded")
+      else
+        download_logger.info("downloading #{s3_key} from #{endpoint_name} (#{number_to_human_size(db_size)} expected)")
+        s3_object.download_file(download_path)
+        download_logger.info("downloaded #{s3_key} from #{endpoint_name} (#{number_to_human_size(File.size(download_path.to_s))} retrieved)")
+        just_downloaded = true
+      end
+
+      if just_downloaded || force_part_md5_comparison
+        download_logger.info("comparing fresh MD5 calculation to DB value for #{download_path}")
+        fresh_md5 = Digest::MD5.file(download_path)
+        download_logger.info("fresh_md5.hexdigest=#{fresh_md5.hexdigest}")
+        download_logger.info("fresh_md5.hexdigest==db_md5: #{fresh_md5.hexdigest == db_md5 ? '✅' : '🚨'}")
+      else
+        download_logger.info("skipping comparing fresh MD5 calculation to DB value for #{download_path} (already downloaded, comparison not forced)")
+      end
+    end
+
+    # @param [Pathname] download_path
+    # @param [ActiveSupport::BroadcastLogger] unzip_logger
+    def self.unzip_zipped_moab_version_from_zip_parts(download_path:, unzip_logger:)
+      unzip_logger ||= ActiveSupport::BroadcastLogger.new
+      unzip_logger.broadcast_to(logger)
+
+      unzip_filename =
+        if Dir.glob("#{download_path.to_s.chomp('zip')}*").size > 1
+          "#{download_path.basename.to_s.chomp('zip')}combined.zip".tap do |combined_filename|
+            unzip_logger.info("multi-part zip, combining into one file (#{combined_filename}) so unzip can handle it")
+            if File.exist?("#{download_path.dirname}/#{combined_filename}")
+              unzip_logger.info("#{download_path.dirname}/#{combined_filename} exists, skipping combining")
+            else
+              # https://unix.stackexchange.com/questions/40480/how-to-unzip-a-multipart-spanned-zip-on-linux
+              unzip_logger.info(Open3.capture2e("zip -s 0 #{download_path.basename} --out #{combined_filename}", chdir: download_path.dirname))
+            end
+          end
+        else
+          download_path.basename
+        end
+      unzip_logger.info("unzipping #{unzip_filename} in #{download_path.dirname}")
+      unzip_logger.debug(Open3.capture2e("unzip #{unzip_filename}", chdir: download_path.dirname))
     end
   end
 end

--- a/bin/fixity_check_replicated_moabs
+++ b/bin/fixity_check_replicated_moabs
@@ -1,0 +1,197 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This script will pull objects from the preservation cloud archives, and fixity check
+# them, using the preservation_catalog Audit::ChecksumValidator class.  It will report
+# any errors that are found.  The list of druids to retrieve is specified by any combo
+# of druids listed in a file (one bare druid per line with no druid: prefix), random
+# sampling of Moabs smaller than the zip segmenting threshold, and random sampling of
+# Moabs larger than the zip segmenting threshold.
+#
+# WARNING: this does some naive things that assume that the druid lists won't be more than
+# a few hundred long, or possibly a few thousand, since druid lists will be plucked from query
+# results and held in memory, parsed naively from file and held in memory, made unique with
+# Ruby Array#uniq, etc.
+
+# Set default environment if not already set by the command line
+ENV["RAILS_ENV"] ||= "production"
+
+require_relative '../config/environment'
+require 'optparse'
+
+include ActionView::Helpers::NumberHelper
+
+options = {
+  druid_list: '',
+  druid_list_file: nil,
+  single_part_druid_sample_count: 0,
+  multipart_druid_sample_count: 0,
+  fixity_check_base_location: "/tmp/#{ENV['USER']}/archive_fixity_checking/",
+  endpoints_to_audit: 'aws_s3_west_2,aws_s3_east_1,gcp_s3_south_1,ibm_us_south',
+  force_part_md5_comparison: false,
+  dry_run: false,
+  quiet: false
+}
+
+parser = OptionParser.new do |option_parser|
+  option_parser.banner = "Usage: #{$PROGRAM_NAME} [options]"
+  option_parser.on('--druid_list DRUID_LIST',
+                   'comma-separated (no spaces) list of bare druids (no prefixes)')
+  option_parser.on('--druid_list_file DRUID_LIST_FILE',
+                   'file with a list of provided druids, e.g. from integration tests, manual tests, your own queries, etc')
+  option_parser.on('--fixity_check_base_location FIXITY_CHECK_BASE_LOCATION',
+                   'target directory for downloading cloud archived Moabs, where they will be inflated and fixity checked.  ensure sufficient free space.')
+  option_parser.on('--single_part_druid_sample_count SINGLE_PART_DRUID_SAMPLE_COUNT', Integer,
+                   'number of < 10 GB Moabs to query for and retrieve (default: 0)')
+  option_parser.on('--multipart_druid_sample_count MULTIPART_DRUID_SAMPLE_COUNT', Integer,
+                   'number of > 10 GB Moabs to query for and retrieve (default: 0)')
+  option_parser.on('--endpoints_to_audit ENDPOINTS_TO_AUDIT',
+                   'list of cloud endpoints to audit (comma-separated, no spaces, names from config)')
+  option_parser.on('--[no-]force_part_md5_comparison', 'Even if the zip parts are not downloaded on this run, compare the previously downloaded MD5 results to what is in the DB')
+  option_parser.on('--[no-]dry_run',
+                   'Simulate download and fixity check for druid list (defaults to false)')
+  option_parser.on('--[no-]quiet', 'Do not output progress information (defaults to false)')
+  option_parser.on('-h', '--help', 'Displays help.') do
+    $stdout.puts option_parser
+    exit
+  end
+end
+
+parser.parse!(into: options)
+
+exit_code = 0 # we can update if/when we hit problems
+
+
+logger = ActiveSupport::BroadcastLogger.new(
+  Logger.new(Rails.root.join('log', 'audit_archive_zip_checksum_validation.log'))
+)
+logger.broadcast_to(Logger.new($stdout)) unless options[:quiet]
+
+logger.info('======= FIXITY CHECKING RUN WITH OPTIONS =======')
+logger.info("#{options}")
+logger.info('======= ******************************** =======')
+
+endpoints_to_audit = options[:endpoints_to_audit].split(',')
+fixity_check_base_location = Pathname(options[:fixity_check_base_location])
+
+
+druids = options[:druid_list].split(',')
+
+if options[:druid_list_file].present? && File.file?(options[:druid_list_file])
+  druids += File.readlines(options[:druid_list_file], chomp: true)
+end
+
+if options[:single_part_druid_sample_count].positive?
+  po_list =
+    PreservedObject.joins(
+      zipped_moab_versions: [:zip_parts]
+    ).group(
+      'preserved_objects.id'
+    ).having(
+      # look for druids with nothing but single part zips, one part per replicated version
+      'COUNT(DISTINCT(zip_parts.id)) = COUNT(DISTINCT(zipped_moab_versions.id))'
+    ).order(
+      'RANDOM()'
+    ).limit(
+      options[:single_part_druid_sample_count]
+    ).pluck(
+      :druid, :current_version, 'COUNT(DISTINCT(zipped_moab_versions.id))', 'COUNT(DISTINCT(zip_parts.id))', 'PG_SIZE_PRETTY(SUM(zip_parts.size))', 'SUM(zip_parts.size)'
+    )
+
+  total_size = number_to_human_size(po_list.map { |row| row.last }.sum)
+  logger.info("query results: preserved_objects with only single-part zips: (#{total_size} total): #{po_list}")
+  druids += po_list.map { |row| row.first }.uniq
+end
+
+if options[:multipart_druid_sample_count].positive?
+  multipart_zip_po_list =
+    PreservedObject.joins(
+      zipped_moab_versions: [:zip_parts]
+    ).group(
+      'preserved_objects.id'
+    ).having(
+      # look for druids with at least one multi-part zip, i.e. more parts than replicated versions
+      'COUNT(DISTINCT(zip_parts.id)) > COUNT(DISTINCT(zipped_moab_versions.id))'
+    ).order(
+      'RANDOM()'
+    ).limit(
+      options[:multipart_druid_sample_count]
+    ).pluck(
+      :druid, :current_version, 'COUNT(DISTINCT(zipped_moab_versions.id))', 'COUNT(DISTINCT(zip_parts.id))', 'PG_SIZE_PRETTY(SUM(zip_parts.size))', 'SUM(zip_parts.size)'
+    )
+
+  total_size = number_to_human_size(multipart_zip_po_list.map { |row| row.last }.sum)
+  logger.info("query results: preserved_objects with at least one multi-part zip: (#{total_size} total): #{multipart_zip_po_list}")
+  druids += multipart_zip_po_list.map { |row| row.first }.uniq
+end
+
+if options[:dry_run]
+  logger.info("======= DRY RUN =======")
+end
+
+logger.info("druids to check: #{druids}")
+
+zp_relation = ZipPart.joins(
+  zipped_moab_version: [:preserved_object, :zip_endpoint]
+).where(
+  preserved_object: { druid: druids },
+  zip_endpoint: { endpoint_name: endpoints_to_audit }
+).order(:endpoint_name, :druid, :version, :suffix)
+
+zp_relation.pluck(:endpoint_name, :druid, :version, :suffix, :md5, :size).each do |endpoint_name, druid, version, suffix, db_md5, db_size|
+  s3_key = Replication::DruidVersionZip.new(druid, version).s3_key(suffix)
+  download_path = Pathname(fixity_check_base_location.join(endpoint_name, s3_key))
+  s3_object = ZipEndpoint.find_by!(endpoint_name:).bucket.object(s3_key)
+  logger.info("=== retrieve #{s3_key} from #{endpoint_name}")
+  logger.debug("download_path=#{download_path}")
+  logger.debug("download_path.exist?=#{download_path.exist?}")
+  logger.debug("download_path.dirname=#{download_path.dirname}")
+  logger.debug("download_path.dirname.exist?=#{download_path.dirname.exist?}")
+  logger.debug("s3_key=#{s3_key}")
+  logger.debug("s3_object.exists?=#{s3_object.exists?}")
+  logger.debug("db_md5=#{db_md5}")
+  logger.debug("db_size=#{db_size}")
+  logger.debug("s3_object.metadata=#{s3_object.metadata}")
+  if options[:dry_run]
+    logger.info("DRY RUN: skipping download and fresh MD5 computation of #{s3_key} from #{endpoint_name}")
+  else
+    Audit::ReplicationSupport.download_zip_part(download_path:, s3_key:, s3_object:, endpoint_name:, db_size:, db_md5:, force_part_md5_comparison: options[:force_part_md5_comparison], download_logger: logger)
+  end
+end
+
+zp_relation.where(suffix: '.zip').pluck(:endpoint_name, :druid, :version, :suffix).each do |endpoint_name, druid, version, suffix|
+  logger.info("=== unzip #{druid} #{version} from #{endpoint_name}")
+  s3_key = Replication::DruidVersionZip.new(druid, version).s3_key(suffix)
+  download_path = Pathname(fixity_check_base_location.join(endpoint_name, s3_key))
+  if options[:dry_run]
+    logger.info("DRY RUN, skipping unzipping #{download_path.basename} in #{download_path.dirname}")
+  else
+    Audit::ReplicationSupport.unzip_zipped_moab_version_from_zip_parts(download_path:, unzip_logger: logger)
+  end
+end
+
+endpoints_to_audit.each do |endpoint_name|
+  druids.each do |druid|
+    logger.info("=== fixity check unzipped Moab for #{druid} from #{endpoint_name}")
+    storage_location = fixity_check_base_location.join(endpoint_name)
+    unless ZippedMoabVersion.joins(:zip_endpoint, :preserved_object).where(preserved_object: { druid: }, zip_endpoint: { endpoint_name: }).exists?
+      logger.info("#{endpoint_name} doesn't have any ZMVs for #{druid}, skipping fixity check")
+      next
+    end
+
+    if options[:dry_run]
+      logger.info("DRY RUN, skipping checksum validation for #{druid} in #{storage_location}")
+    else
+      logger.info "Starting checksum validation for #{druid} in #{storage_location} (NOTE: this may take some time!)"
+      checksum_validator = Audit::ChecksumValidator.new(
+        logger:,
+        moab_storage_object: MoabOnStorage.moab(storage_location:, druid:),
+        emit_results: true
+      )
+      checksum_validator.validate
+      exit_code = 1 if checksum_validator.results.error_results.present?
+    end
+  end
+end
+
+exit exit_code

--- a/bin/fixity_check_replicated_moabs
+++ b/bin/fixity_check_replicated_moabs
@@ -26,8 +26,9 @@ options = {
   druid_list_file: nil,
   single_part_druid_sample_count: 0,
   multipart_druid_sample_count: 0,
-  fixity_check_base_location: "/tmp/#{ENV['USER']}/archive_fixity_checking/",
-  endpoints_to_audit: 'aws_s3_west_2,aws_s3_east_1,gcp_s3_south_1,ibm_us_south',
+  # in deployed envs, Settings.zip_storage is a mount with ample free space
+  fixity_check_base_location: "#{Settings.zip_storage}/archive_fixity_checking/#{ENV['USER']}/",
+  endpoints_to_audit: 'aws_s3_west_2,aws_s3_east_1,gcp_s3_south_1',
   force_part_md5_comparison: false,
   dry_run: false,
   quiet: false
@@ -82,116 +83,17 @@ if options[:druid_list_file].present? && File.file?(options[:druid_list_file])
 end
 
 if options[:single_part_druid_sample_count].positive?
-  po_list =
-    PreservedObject.joins(
-      zipped_moab_versions: [:zip_parts]
-    ).group(
-      'preserved_objects.id'
-    ).having(
-      # look for druids with nothing but single part zips, one part per replicated version
-      'COUNT(DISTINCT(zip_parts.id)) = COUNT(DISTINCT(zipped_moab_versions.id))'
-    ).order(
-      'RANDOM()'
-    ).limit(
-      options[:single_part_druid_sample_count]
-    ).pluck(
-      :druid, :current_version, 'COUNT(DISTINCT(zipped_moab_versions.id))', 'COUNT(DISTINCT(zip_parts.id))', 'PG_SIZE_PRETTY(SUM(zip_parts.size))', 'SUM(zip_parts.size)'
-    )
-
-  total_size = number_to_human_size(po_list.map { |row| row.last }.sum)
-  logger.info("query results: preserved_objects with only single-part zips: (#{total_size} total): #{po_list}")
-  druids += po_list.map { |row| row.first }.uniq
+  druids += Audit::ReplicatedMoabChecksumValidator.druids_having_single_part_versions(options[:single_part_druid_sample_count], logger:)
 end
 
 if options[:multipart_druid_sample_count].positive?
-  multipart_zip_po_list =
-    PreservedObject.joins(
-      zipped_moab_versions: [:zip_parts]
-    ).group(
-      'preserved_objects.id'
-    ).having(
-      # look for druids with at least one multi-part zip, i.e. more parts than replicated versions
-      'COUNT(DISTINCT(zip_parts.id)) > COUNT(DISTINCT(zipped_moab_versions.id))'
-    ).order(
-      'RANDOM()'
-    ).limit(
-      options[:multipart_druid_sample_count]
-    ).pluck(
-      :druid, :current_version, 'COUNT(DISTINCT(zipped_moab_versions.id))', 'COUNT(DISTINCT(zip_parts.id))', 'PG_SIZE_PRETTY(SUM(zip_parts.size))', 'SUM(zip_parts.size)'
-    )
-
-  total_size = number_to_human_size(multipart_zip_po_list.map { |row| row.last }.sum)
-  logger.info("query results: preserved_objects with at least one multi-part zip: (#{total_size} total): #{multipart_zip_po_list}")
-  druids += multipart_zip_po_list.map { |row| row.first }.uniq
+  druids += Audit::ReplicatedMoabChecksumValidator.druids_having_a_multi_part_version(options[:multipart_druid_sample_count], logger:)
 end
 
-if options[:dry_run]
-  logger.info("======= DRY RUN =======")
-end
+validator = Audit::ReplicatedMoabChecksumValidator.new(
+  fixity_check_base_location:, force_part_md5_comparison: options[:force_part_md5_comparison], dry_run: options[:dry_run], additional_logger: logger
+)
+fixity_check_results_objects = validator.validate_replicated_moab_checksums!(endpoints_to_audit:, druids:)
 
-logger.info("druids to check: #{druids}")
-
-zp_relation = ZipPart.joins(
-  zipped_moab_version: [:preserved_object, :zip_endpoint]
-).where(
-  preserved_object: { druid: druids },
-  zip_endpoint: { endpoint_name: endpoints_to_audit }
-).order(:endpoint_name, :druid, :version, :suffix)
-
-zp_relation.pluck(:endpoint_name, :druid, :version, :suffix, :md5, :size).each do |endpoint_name, druid, version, suffix, db_md5, db_size|
-  s3_key = Replication::DruidVersionZip.new(druid, version).s3_key(suffix)
-  download_path = Pathname(fixity_check_base_location.join(endpoint_name, s3_key))
-  s3_object = ZipEndpoint.find_by!(endpoint_name:).bucket.object(s3_key)
-  logger.info("=== retrieve #{s3_key} from #{endpoint_name}")
-  logger.debug("download_path=#{download_path}")
-  logger.debug("download_path.exist?=#{download_path.exist?}")
-  logger.debug("download_path.dirname=#{download_path.dirname}")
-  logger.debug("download_path.dirname.exist?=#{download_path.dirname.exist?}")
-  logger.debug("s3_key=#{s3_key}")
-  logger.debug("s3_object.exists?=#{s3_object.exists?}")
-  logger.debug("db_md5=#{db_md5}")
-  logger.debug("db_size=#{db_size}")
-  logger.debug("s3_object.metadata=#{s3_object.metadata}")
-  if options[:dry_run]
-    logger.info("DRY RUN: skipping download and fresh MD5 computation of #{s3_key} from #{endpoint_name}")
-  else
-    Audit::ReplicationSupport.download_zip_part(download_path:, s3_key:, s3_object:, endpoint_name:, db_size:, db_md5:, force_part_md5_comparison: options[:force_part_md5_comparison], download_logger: logger)
-  end
-end
-
-zp_relation.where(suffix: '.zip').pluck(:endpoint_name, :druid, :version, :suffix).each do |endpoint_name, druid, version, suffix|
-  logger.info("=== unzip #{druid} #{version} from #{endpoint_name}")
-  s3_key = Replication::DruidVersionZip.new(druid, version).s3_key(suffix)
-  download_path = Pathname(fixity_check_base_location.join(endpoint_name, s3_key))
-  if options[:dry_run]
-    logger.info("DRY RUN, skipping unzipping #{download_path.basename} in #{download_path.dirname}")
-  else
-    Audit::ReplicationSupport.unzip_zipped_moab_version_from_zip_parts(download_path:, unzip_logger: logger)
-  end
-end
-
-endpoints_to_audit.each do |endpoint_name|
-  druids.each do |druid|
-    logger.info("=== fixity check unzipped Moab for #{druid} from #{endpoint_name}")
-    storage_location = fixity_check_base_location.join(endpoint_name)
-    unless ZippedMoabVersion.joins(:zip_endpoint, :preserved_object).where(preserved_object: { druid: }, zip_endpoint: { endpoint_name: }).exists?
-      logger.info("#{endpoint_name} doesn't have any ZMVs for #{druid}, skipping fixity check")
-      next
-    end
-
-    if options[:dry_run]
-      logger.info("DRY RUN, skipping checksum validation for #{druid} in #{storage_location}")
-    else
-      logger.info "Starting checksum validation for #{druid} in #{storage_location} (NOTE: this may take some time!)"
-      checksum_validator = Audit::ChecksumValidator.new(
-        logger:,
-        moab_storage_object: MoabOnStorage.moab(storage_location:, druid:),
-        emit_results: true
-      )
-      checksum_validator.validate
-      exit_code = 1 if checksum_validator.results.error_results.present?
-    end
-  end
-end
-
+exit_code = 1 if fixity_check_results_objects.any? { |results| results.error_results.present? }
 exit exit_code

--- a/bin/fixity_check_replicated_moabs
+++ b/bin/fixity_check_replicated_moabs
@@ -8,6 +8,8 @@
 # sampling of Moabs smaller than the zip segmenting threshold, and random sampling of
 # Moabs larger than the zip segmenting threshold.
 #
+# SEE ALSO: usage notes in Audit::ReplicatedMoabChecksumValidator
+#
 # WARNING: this does some naive things that assume that the druid lists won't be more than
 # a few hundred long, or possibly a few thousand, since druid lists will be plucked from query
 # results and held in memory, parsed naively from file and held in memory, made unique with

--- a/spec/services/audit/replicated_moab_checksum_validator_spec.rb
+++ b/spec/services/audit/replicated_moab_checksum_validator_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::ReplicatedMoabChecksumValidator do
+  # single-part: 1 ZMV with 1 ZipPart → part count equals ZMV count
+  let!(:single_part_po) { create(:preserved_object, druid: 'bc123df4567') }
+  let!(:single_part_zmv) { create(:zipped_moab_version, preserved_object: single_part_po) }
+  let!(:single_part_zip_part) { create(:zip_part, zipped_moab_version: single_part_zmv, suffix: '.zip') }
+
+  # multi-part: 1 ZMV with 2 ZipParts → part count exceeds ZMV count
+  let!(:multi_part_po) { create(:preserved_object, druid: 'gh456jk8901') }
+  let!(:multi_part_zmv) { create(:zipped_moab_version, preserved_object: multi_part_po) }
+  let!(:multi_part_zip_part1) { create(:zip_part, zipped_moab_version: multi_part_zmv, suffix: '.zip') }
+  let!(:multi_part_zip_part2) { create(:zip_part, zipped_moab_version: multi_part_zmv, suffix: '.z01') }
+
+  describe '.druids_having_single_part_versions' do
+    it 'returns druids whose every ZMV has exactly one zip part, not druids with any multi-part ZMV' do
+      result = described_class.druids_having_single_part_versions(10)
+      expect(result).to include(single_part_po.druid)
+      expect(result).not_to include(multi_part_po.druid)
+    end
+  end
+
+  describe '.druids_having_a_multi_part_version' do
+    it 'returns druids with at least one multi-part ZMV, not druids where all ZMVs are single-part' do
+      result = described_class.druids_having_a_multi_part_version(10)
+      expect(result).to include(multi_part_po.druid)
+      expect(result).not_to include(single_part_po.druid)
+    end
+  end
+end

--- a/spec/services/audit/replicated_moab_checksum_validator_spec.rb
+++ b/spec/services/audit/replicated_moab_checksum_validator_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe Audit::ReplicatedMoabChecksumValidator do
   # single-part: 1 ZMV with 1 ZipPart → part count equals ZMV count
   let!(:single_part_po) { create(:preserved_object, druid: 'bc123df4567') }
   let!(:single_part_zmv) { create(:zipped_moab_version, preserved_object: single_part_po) }
-  let!(:single_part_zip_part) { create(:zip_part, zipped_moab_version: single_part_zmv, suffix: '.zip') }
+  let!(:single_part_zip_part) { create(:zip_part, zipped_moab_version: single_part_zmv, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
 
   # multi-part: 1 ZMV with 2 ZipParts → part count exceeds ZMV count
   let!(:multi_part_po) { create(:preserved_object, druid: 'gh456jk8901') }
   let!(:multi_part_zmv) { create(:zipped_moab_version, preserved_object: multi_part_po) }
-  let!(:multi_part_zip_part1) { create(:zip_part, zipped_moab_version: multi_part_zmv, suffix: '.zip') }
-  let!(:multi_part_zip_part2) { create(:zip_part, zipped_moab_version: multi_part_zmv, suffix: '.z01') }
+  let!(:multi_part_zip_part1) { create(:zip_part, zipped_moab_version: multi_part_zmv, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
+  let!(:multi_part_zip_part2) { create(:zip_part, zipped_moab_version: multi_part_zmv, suffix: '.z01') } # rubocop:disable RSpec/LetSetup
 
   describe '.druids_having_single_part_versions' do
     it 'returns druids whose every ZMV has exactly one zip part, not druids with any multi-part ZMV' do
@@ -31,6 +31,7 @@ RSpec.describe Audit::ReplicatedMoabChecksumValidator do
   end
 
   describe '#validate_replicated_moab_checksums!' do
+    # rubocop:disable RSpec/BeforeAfterAll, RSpec/InstanceVariable
     before(:all) do
       @tmp_fixity_dir = Pathname(Dir.mktmpdir)
       target_dir = @tmp_fixity_dir.join('aws_s3_west_2', 'bz/514/sm/9647')
@@ -45,23 +46,23 @@ RSpec.describe Audit::ReplicatedMoabChecksumValidator do
     after(:all) { FileUtils.rm_rf(@tmp_fixity_dir) }
 
     let(:endpoint) { ZipEndpoint.find_by!(endpoint_name: 'aws_s3_west_2') }
-    let!(:po)       { create(:preserved_object, druid: 'bz514sm9647', current_version: 3) }
-    let!(:zmv1)     { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 1) }
-    let!(:zmv2)     { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 2) }
-    let!(:zmv3)     { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 3) }
-    let!(:zp1)      { create(:zip_part, zipped_moab_version: zmv1, suffix: '.zip') }
-    let!(:zp2)      { create(:zip_part, zipped_moab_version: zmv2, suffix: '.zip') }
-    let!(:zp3)      { create(:zip_part, zipped_moab_version: zmv3, suffix: '.zip') }
+    let!(:po)    { create(:preserved_object, druid: 'bz514sm9647', current_version: 3) }
+    let!(:zmv1)  { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 1) }
+    let!(:zmv2)  { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 2) }
+    let!(:zmv3)  { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 3) }
+    let!(:zp1)   { create(:zip_part, zipped_moab_version: zmv1, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
+    let!(:zp2)   { create(:zip_part, zipped_moab_version: zmv2, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
+    let!(:zp3)   { create(:zip_part, zipped_moab_version: zmv3, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
 
     let(:mock_s3_object) { instance_double(Aws::S3::Object, exists?: true, metadata: {}) }
     let(:mock_bucket)    { instance_double(Aws::S3::Bucket, object: mock_s3_object, name: 'test-bucket') }
     let(:mock_provider)  { instance_double(Replication::CloudProvider, bucket: mock_bucket) }
-
-    before { allow(Replication::ProviderFactory).to receive(:create).and_return(mock_provider) }
-
     let(:validator) do
       described_class.new(fixity_check_base_location: @tmp_fixity_dir, dry_run: false, force_part_md5_comparison: false)
     end
+    # rubocop:enable RSpec/BeforeAfterAll, RSpec/InstanceVariable
+
+    before { allow(Replication::ProviderFactory).to receive(:create).and_return(mock_provider) }
 
     it 'returns results with no errors for a valid moab' do
       results = validator.validate_replicated_moab_checksums!(

--- a/spec/services/audit/replicated_moab_checksum_validator_spec.rb
+++ b/spec/services/audit/replicated_moab_checksum_validator_spec.rb
@@ -3,12 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Audit::ReplicatedMoabChecksumValidator do
-  # single-part: 1 ZMV with 1 ZipPart → part count equals ZMV count
   let!(:single_part_po) { create(:preserved_object, druid: 'bc123df4567') }
   let!(:single_part_zmv) { create(:zipped_moab_version, preserved_object: single_part_po) }
   let!(:single_part_zip_part) { create(:zip_part, zipped_moab_version: single_part_zmv, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
 
-  # multi-part: 1 ZMV with 2 ZipParts → part count exceeds ZMV count
   let!(:multi_part_po) { create(:preserved_object, druid: 'gh456jk8901') }
   let!(:multi_part_zmv) { create(:zipped_moab_version, preserved_object: multi_part_po) }
   let!(:multi_part_zip_part1) { create(:zip_part, zipped_moab_version: multi_part_zmv, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
@@ -30,47 +28,170 @@ RSpec.describe Audit::ReplicatedMoabChecksumValidator do
     end
   end
 
-  describe '#validate_replicated_moab_checksums!' do
-    # rubocop:disable RSpec/BeforeAfterAll, RSpec/InstanceVariable
-    before(:all) do
-      @tmp_fixity_dir = Pathname(Dir.mktmpdir)
-      target_dir = @tmp_fixity_dir.join('aws_s3_west_2', 'bz/514/sm/9647')
-      FileUtils.mkdir_p(target_dir)
-      fixture_dir = Rails.root.join('spec/fixtures/storage_root01/sdr2objects/bz/514/sm/9647')
-      [1, 2, 3].each do |v|
-        vstr = format('v%04d', v)
-        system("cd #{fixture_dir} && zip -r #{target_dir}/bz514sm9647.#{vstr}.zip bz514sm9647/#{vstr} > /dev/null", exception: true)
-      end
-    end
-
-    after(:all) { FileUtils.rm_rf(@tmp_fixity_dir) }
-
-    let(:endpoint) { ZipEndpoint.find_by!(endpoint_name: 'aws_s3_west_2') }
-    let!(:po)    { create(:preserved_object, druid: 'bz514sm9647', current_version: 3) }
-    let!(:zmv1)  { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 1) }
-    let!(:zmv2)  { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 2) }
-    let!(:zmv3)  { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 3) }
-    let!(:zp1)   { create(:zip_part, zipped_moab_version: zmv1, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
-    let!(:zp2)   { create(:zip_part, zipped_moab_version: zmv2, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
-    let!(:zp3)   { create(:zip_part, zipped_moab_version: zmv3, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
+  describe '#validate_replicated_moab_checksums!' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    let(:fixture_dir) { Rails.root.join('spec/fixtures/storage_root01/sdr2objects/bz/514/sm/9647') }
+    let(:fixity_check_base_location) { Pathname(Dir.mktmpdir) }
+    let(:zip_endpoint) { ZipEndpoint.find_by!(endpoint_name: 'aws_s3_west_2') }
+    let!(:po) { create(:preserved_object, druid: 'bz514sm9647', current_version: 3) }
+    let!(:zmv1) { create(:zipped_moab_version, preserved_object: po, zip_endpoint:, version: 1) }
+    let!(:zmv2) { create(:zipped_moab_version, preserved_object: po, zip_endpoint:, version: 2) }
+    let!(:zmv3) { create(:zipped_moab_version, preserved_object: po, zip_endpoint:, version: 3) }
+    let!(:zp1) { create(:zip_part, zipped_moab_version: zmv1, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
+    let!(:zp2) { create(:zip_part, zipped_moab_version: zmv2, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
+    let!(:zp3) { create(:zip_part, zipped_moab_version: zmv3, suffix: '.zip') } # rubocop:disable RSpec/LetSetup
 
     let(:mock_s3_object) { instance_double(Aws::S3::Object, exists?: true, metadata: {}) }
     let(:mock_bucket)    { instance_double(Aws::S3::Bucket, object: mock_s3_object, name: 'test-bucket') }
-    let(:mock_provider)  { instance_double(Replication::CloudProvider, bucket: mock_bucket) }
+    let(:mock_provider)  { instance_double(Replication::CloudProvider, bucket: mock_bucket, client: instance_double(Aws::S3::Client)) }
+    let(:mock_transfer_manager) { instance_double(Aws::S3::TransferManager, download_file: nil) }
+
+    let(:zip_endpoint_dir) { fixity_check_base_location.join('aws_s3_west_2') }
+    let(:druid_zip_download_dir) { zip_endpoint_dir.join('bz/514/sm/9647') }
+
+    let(:dry_run) { false }
+    let(:additional_logger) { Logger.new('log/test.log') }
     let(:validator) do
-      described_class.new(fixity_check_base_location: @tmp_fixity_dir, dry_run: false, force_part_md5_comparison: false)
+      described_class.new(fixity_check_base_location:, dry_run:, force_part_md5_comparison: false, additional_logger:)
     end
-    # rubocop:enable RSpec/BeforeAfterAll, RSpec/InstanceVariable
 
-    before { allow(Replication::ProviderFactory).to receive(:create).and_return(mock_provider) }
+    before do
+      FileUtils.mkdir_p(fixity_check_base_location)
+      allow(Replication::ProviderFactory).to receive(:create).and_return(mock_provider)
+      allow(Aws::S3::TransferManager).to receive(:new).with(client: zip_endpoint.provider.client).and_return(mock_transfer_manager)
+      allow(additional_logger).to receive(:info).and_call_original
+    end
 
-    it 'returns results with no errors for a valid moab' do
-      results = validator.validate_replicated_moab_checksums!(
-        endpoints_to_audit: ['aws_s3_west_2'],
-        druids: ['bz514sm9647']
-      )
-      expect(results).not_to be_empty
-      expect(results.flat_map(&:error_results)).to be_empty
+    after { FileUtils.rm_rf(fixity_check_base_location) }
+
+    context 'the zip files were retrieved on a prior run' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      # create the zip files in their expected retrieval locations before the test, as if they were already downloaded
+      # NOTE: we're not bothering to update the expected sizes or MD5 values on the zip part for this test, so the logs
+      # will show errors for them.  we exercise that check in the download test.
+      before do
+        FileUtils.mkdir_p(druid_zip_download_dir)
+        [1, 2, 3].each do |v|
+          vstr = format('v%04d', v)
+          zip_filename = "#{druid_zip_download_dir}/bz514sm9647.#{vstr}.zip"
+          system("cd #{fixture_dir} && zip -r #{zip_filename} bz514sm9647/#{vstr} > /dev/null", exception: true)
+        end
+      end
+
+      it 'returns results with no errors for a valid moab' do
+        results = validator.validate_replicated_moab_checksums!(
+          endpoints_to_audit: ['aws_s3_west_2'],
+          druids: ['bz514sm9647']
+        )
+        expect(results).not_to be_empty
+        expect(results.flat_map(&:error_results)).to be_empty
+        expect(Aws::S3::TransferManager).not_to have_received(:new)
+        expect(mock_transfer_manager).not_to have_received(:download_file)
+        expect(additional_logger).to have_received(:info).with(/skipping download of.*already downloaded/).thrice
+      end
+
+      context 'the cloud archive zip is corrupted or incomplete' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+        # the before block from the parent context will set up the zip file fixtures.  this before block will corrupt them by
+        # removing a couple of the files.
+        before do
+          zip_filename = "#{druid_zip_download_dir}/bz514sm9647.v0001.zip"
+          internal_filepath_to_delete = 'bz514sm9647/v0001/data/content/SC1258_FUR_032a.jpg'
+          system("cd #{fixture_dir} && zip -d #{zip_filename} #{internal_filepath_to_delete} > /dev/null", exception: true)
+
+          zip_filename = "#{druid_zip_download_dir}/bz514sm9647.v0003.zip"
+          internal_filepath_to_delete = 'bz514sm9647/v0003/manifests/manifestInventory.xml'
+          system("cd #{fixture_dir} && zip -d #{zip_filename} #{internal_filepath_to_delete} > /dev/null", exception: true)
+        end
+
+        it 'returns and logs error results for an invalid moab' do
+          results = validator.validate_replicated_moab_checksums!(
+            endpoints_to_audit: ['aws_s3_west_2'],
+            druids: ['bz514sm9647']
+          )
+          expect(additional_logger).to have_received(:info).with(
+            %r{fixity check failed, investigate errors - validate_checksums - bz514sm9647 - actual location: .*/aws_s3_west_2/; actual version: 3}
+          )
+          expect(additional_logger).to have_received(:info).with(
+            %r{manifest_not_in_moab: .*bz514sm9647/v0003/manifests/manifestInventory.xml not found in Moab}
+          )
+          expect(additional_logger).to have_received(:info).with(
+            %r{file_not_in_moab: "#{fixity_check_base_location}/aws_s3_west_2/bz/514/sm/9647/bz514sm9647/v0003/manifests/signatureCatalog.xml refers to file \(#{fixity_check_base_location}/aws_s3_west_2/bz/514/sm/9647/bz514sm9647/v0001/data/content/SC1258_FUR_032a.jpg\) not found in Moab} # rubocop:disable Layout/LineLength
+          )
+          expect(additional_logger).to have_received(:info).with(
+            /invalid_moab: "Invalid Moab, validation errors: \[\\"Version v0001: No files present in content dir\\", \\"Version v0003: Missing manifestInventory.xml\\"\]"/ # rubocop:disable Layout/LineLength
+          )
+
+          expect(results.first.error_results).to include(
+            { manifest_not_in_moab: "#{fixity_check_base_location}/aws_s3_west_2/bz/514/sm/9647/bz514sm9647/v0003/manifests/manifestInventory.xml not found in Moab" }, # rubocop:disable Layout/LineLength
+            { file_not_in_moab: "#{fixity_check_base_location}/aws_s3_west_2/bz/514/sm/9647/bz514sm9647/v0003/manifests/signatureCatalog.xml refers to file (#{fixity_check_base_location}/aws_s3_west_2/bz/514/sm/9647/bz514sm9647/v0001/data/content/SC1258_FUR_032a.jpg) not found in Moab" }, # rubocop:disable Layout/LineLength
+            { invalid_moab: 'Invalid Moab, validation errors: ["Version v0001: No files present in content dir", "Version v0003: Missing manifestInventory.xml"]' } # rubocop:disable Layout/LineLength
+          )
+        end
+      end
+    end
+
+    context 'the zip files have yet to be retrieved from endpoints' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      # * create the zip files in the root of the fixity_check_base_location, since they'll be looked
+      #   for in a druid tree for the endpoint under that base location.
+      # * update the zip part size and md5 info in the DB so that we can confirm those checks work.
+      # * mock the download by symlinking from the expected druid tree location to the real zip file.
+      before do
+        FileUtils.mkdir_p(zip_endpoint_dir)
+
+        [1, 2, 3].each do |v|
+          vstr = format('v%04d', v)
+          zip_filename = "bz514sm9647.#{vstr}.zip"
+          concrete_zip_filepath_str = "#{fixity_check_base_location}/#{zip_filename}"
+
+          zp = ZipPart.find_by!(zipped_moab_version: ZippedMoabVersion.where(preserved_object: po, version: v))
+          system("cd #{fixture_dir} && zip -r #{concrete_zip_filepath_str} bz514sm9647/#{vstr} > /dev/null", exception: true)
+          zp.update!(
+            md5: Digest::MD5.file(concrete_zip_filepath_str).hexdigest,
+            size: File.size(concrete_zip_filepath_str)
+          )
+          download_path = Pathname(druid_zip_download_dir.join(zip_filename))
+          allow(mock_transfer_manager).to receive(:download_file).with(download_path, bucket: mock_bucket.name, key: zp.s3_key) do
+            FileUtils.ln_s(concrete_zip_filepath_str, druid_zip_download_dir)
+          end
+        end
+      end
+
+      it 'returns results with no errors for a valid moab' do
+        results = validator.validate_replicated_moab_checksums!(
+          endpoints_to_audit: ['aws_s3_west_2'],
+          druids: ['bz514sm9647']
+        )
+        expect(results).not_to be_empty
+        expect(results.flat_map(&:error_results)).to be_empty
+        expect(additional_logger).to have_received(:info).with(
+          %r{downloading bz/514/sm/9647/bz514sm9647.v0003.zip from aws_s3_west_2 \(12.5 KB expected\)}
+        )
+        expect(additional_logger).to have_received(:info).with(
+          %r{downloaded bz/514/sm/9647/bz514sm9647.v0003.zip from aws_s3_west_2 \(12.5 KB retrieved\)}
+        )
+        expect(additional_logger).to have_received(:info).with(
+          /fresh_md5.hexdigest==db_md5: ✅/
+        ).thrice
+        expect(additional_logger).not_to have_received(:info).with(/already downloaded/)
+        expect(additional_logger).to have_received(:info).with(
+          %r{fixity check passed - validate_checksums - bz514sm9647 - actual location: #{fixity_check_base_location}/aws_s3_west_2/; actual version: 3} # rubocop:disable Layout/LineLength
+        )
+      end
+
+      context 'executing a dry run' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+        let(:dry_run) { true }
+
+        it 'does not attempt to download or compare, and indicates in logs that it is a dry run' do
+          results = validator.validate_replicated_moab_checksums!(
+            endpoints_to_audit: ['aws_s3_west_2'],
+            druids: ['bz514sm9647']
+          )
+          expect(results).to be_empty
+          expect(additional_logger).to have_received(:info).with(/=== DRY RUN ==/)
+          expect(additional_logger).to have_received(:info).with(/skipping unzipping bz514sm9647.v0001.zip/)
+          expect(additional_logger).to have_received(:info).with(/skipping download and fresh MD5 .*bz514sm9647.v0003.zip from aws_s3_west_2/)
+          expect(Aws::S3::TransferManager).not_to have_received(:new)
+          expect(mock_transfer_manager).not_to have_received(:download_file)
+        end
+      end
     end
   end
 end

--- a/spec/services/audit/replicated_moab_checksum_validator_spec.rb
+++ b/spec/services/audit/replicated_moab_checksum_validator_spec.rb
@@ -29,4 +29,47 @@ RSpec.describe Audit::ReplicatedMoabChecksumValidator do
       expect(result).not_to include(single_part_po.druid)
     end
   end
+
+  describe '#validate_replicated_moab_checksums!' do
+    before(:all) do
+      @tmp_fixity_dir = Pathname(Dir.mktmpdir)
+      target_dir = @tmp_fixity_dir.join('aws_s3_west_2', 'bz/514/sm/9647')
+      FileUtils.mkdir_p(target_dir)
+      fixture_dir = Rails.root.join('spec/fixtures/storage_root01/sdr2objects/bz/514/sm/9647')
+      [1, 2, 3].each do |v|
+        vstr = format('v%04d', v)
+        system("cd #{fixture_dir} && zip -r #{target_dir}/bz514sm9647.#{vstr}.zip bz514sm9647/#{vstr} > /dev/null", exception: true)
+      end
+    end
+
+    after(:all) { FileUtils.rm_rf(@tmp_fixity_dir) }
+
+    let(:endpoint) { ZipEndpoint.find_by!(endpoint_name: 'aws_s3_west_2') }
+    let!(:po)       { create(:preserved_object, druid: 'bz514sm9647', current_version: 3) }
+    let!(:zmv1)     { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 1) }
+    let!(:zmv2)     { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 2) }
+    let!(:zmv3)     { create(:zipped_moab_version, preserved_object: po, zip_endpoint: endpoint, version: 3) }
+    let!(:zp1)      { create(:zip_part, zipped_moab_version: zmv1, suffix: '.zip') }
+    let!(:zp2)      { create(:zip_part, zipped_moab_version: zmv2, suffix: '.zip') }
+    let!(:zp3)      { create(:zip_part, zipped_moab_version: zmv3, suffix: '.zip') }
+
+    let(:mock_s3_object) { instance_double(Aws::S3::Object, exists?: true, metadata: {}) }
+    let(:mock_bucket)    { instance_double(Aws::S3::Bucket, object: mock_s3_object, name: 'test-bucket') }
+    let(:mock_provider)  { instance_double(Replication::CloudProvider, bucket: mock_bucket) }
+
+    before { allow(Replication::ProviderFactory).to receive(:create).and_return(mock_provider) }
+
+    let(:validator) do
+      described_class.new(fixity_check_base_location: @tmp_fixity_dir, dry_run: false, force_part_md5_comparison: false)
+    end
+
+    it 'returns results with no errors for a valid moab' do
+      results = validator.validate_replicated_moab_checksums!(
+        endpoints_to_audit: ['aws_s3_west_2'],
+        druids: ['bz514sm9647']
+      )
+      expect(results).not_to be_empty
+      expect(results.flat_map(&:error_results)).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

This is a script for pulling down and fixity checking content we've archived to cloud buckets.  It's been shaped up from what was essentially [ruby console notes to myself](https://github.com/sul-dlss/preservation_catalog/issues/2417#issuecomment-2900018412) for this sort of check, into something that is runnable as a script by anyone.  The machinery here could also form a starting point for #1076 (performing spot fixity checks of cloud archived zipped moabs).

It has been useful for spot checking GCP replication on prod (as we did with its predecessor against stage and QA).  See #2426 and #2518.

## Usage

```
Usage: bin/fixity_check_replicated_moabs [options]
        --druid_list DRUID_LIST      comma-separated (no spaces) list of bare druids (no prefixes)
        --druid_list_file DRUID_LIST_FILE
                                     file with a list of provided druids, e.g. from integration tests, manual tests, your own queries, etc
        --fixity_check_base_location FIXITY_CHECK_BASE_LOCATION
                                     target directory for downloading cloud archived Moabs, where they will be inflated and fixity checked.  ensure sufficient free space.
        --single_part_druid_sample_count SINGLE_PART_DRUID_SAMPLE_COUNT
                                     number of < 10 GB Moabs to query for and retrieve (default: 0)
        --multipart_druid_sample_count MULTIPART_DRUID_SAMPLE_COUNT
                                     number of > 10 GB Moabs to query for and retrieve (default: 0)
        --endpoints_to_audit ENDPOINTS_TO_AUDIT
                                     list of cloud endpoints to audit (comma-separated, no spaces, names from config)
        --[no-]force_part_md5_comparison
                                     Even if the zip parts are not downloaded on this run, compare the previously downloaded MD5 results to what is in the DB
        --[no-]dry_run               Simulate download and fixity check for druid list (defaults to false)
        --[no-]quiet                 Do not output progress information (defaults to false)
    -h, --help                       Displays help.
```

# How was this change tested? 🤨

- [x] initial testing of early iteration: it was used to fixity check the test objects listed in #2518.  when an earlier pass at the script failed to properly re-assemble multi-part zips it had downloaded, the missing moab manifest files were detected (they were indeed missing from that first zip extraction attempt; but were present in the multi-part zip, retrieved when the script was updated to re-assemble the zip successfully, and led to the moabs in question passing fixity check once the zip re-assembly was fixed).  this was a convenient natural experiment with a corrupted zip extraction that was resolved by fixing the extraction approach.
- [x] integration-y unit tests in this PR
- [x] tested on stage and QA.  downloaded archive zips passed fixity checks (single and multi-part).  when i deleted files from within an already downloaded zip from a successful run, deleted up the extracted Moab, and re-ran the fixity check script on the druid so that it used the cached zip files, the fixity check of the Moab at the end exited with a non-zero value and logged descriptive messages for the missing files (a `manifestInventory.xml` and a `.tiff` content file, both in v1 of km859rc8802 on QA).  see logs from `audit_archive_zip_checksum_validation.log` files from 2026-05-28 on `preservation-catalog-worker-qa-01` for more detail.

