### PR TITLE
Adds status_details to ZippedMoabVersion

### DIFF
--- a/app/models/zipped_moab_version.rb
+++ b/app/models/zipped_moab_version.rb
@@ -29,6 +29,7 @@ class ZippedMoabVersion < ApplicationRecord
   }
 
   before_save :update_status_updated_at
+  before_save :update_status_details
 
   def total_part_size
     zip_parts.sum(&:size)
@@ -36,6 +37,11 @@ class ZippedMoabVersion < ApplicationRecord
 
   def update_status_updated_at
     self.status_updated_at = Time.current if status_changed?
+  end
+
+  def update_status_details
+    # Clear status_details if status changed but status_details did not
+    self.status_details = nil if status_changed? && !status_details_changed?
   end
 
   def druid_version_zip

--- a/app/services/replication/zip_parts_to_zip_files_audit_service.rb
+++ b/app/services/replication/zip_parts_to_zip_files_audit_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Replication
+  # Compare the md5s of ZipParts against zip files on disk
+  class ZipPartsToZipFilesAuditService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(zipped_moab_version:)
+      @zipped_moab_version = zipped_moab_version
+    end
+
+    def call
+      zipped_moab_version.zip_parts.each do |zip_part|
+        next if zip_part.md5 == (local_md5 = zip_part.druid_version_zip_part.read_md5)
+
+        results.add_result(Results::ZIP_PART_CHECKSUM_FILE_MISMATCH, s3_key: zip_part.s3_key,
+                                                                     md5: zip_part.md5,
+                                                                     local_md5:)
+      end
+
+      results
+    end
+
+    private
+
+    attr_reader :zipped_moab_version
+
+    def results
+      @results ||= Results.new(druid: zipped_moab_version.preserved_object.druid,
+                               moab_storage_root: zipped_moab_version.zip_endpoint,
+                               check_name: 'ZipPartsToZipFilesAudit')
+    end
+  end
+end

--- a/app/services/replication/zipped_moab_version_audit_service.rb
+++ b/app/services/replication/zipped_moab_version_audit_service.rb
@@ -145,7 +145,7 @@ module Replication
 
     def update_status_to(new_status)
       # Setting status_updated_at to now to indicate that the status was checked, even if not changed.
-      zipped_moab_version.update!(status: new_status, status_updated_at: Time.zone.now)
+      zipped_moab_version.update!(status: new_status, status_updated_at: Time.zone.now, status_details: results.to_s)
     end
   end
 end

--- a/app/services/results.rb
+++ b/app/services/results.rb
@@ -44,6 +44,8 @@ class Results # rubocop:disable Metrics/ClassLength
   # When MoabRecord version does not match moab on disk
   UNEXPECTED_VERSION = :unexpected_version
   VERSION_MATCHES = :version_matches
+  # When ZipPart md5 does not match local zip part file md5
+  ZIP_PART_CHECKSUM_FILE_MISMATCH = :zip_part_checksum_file_mismatch
   # When ZipPart md5 does not match zip part file md5 on endpoint
   ZIP_PART_CHECKSUM_MISMATCH = :zip_part_checksum_mismatch
   # When expected zip part file not found on endpoint
@@ -86,6 +88,8 @@ class Results # rubocop:disable Metrics/ClassLength
     UNEXPECTED_VERSION => 'actual version (%{actual_version}) has unexpected ' \
                           'relationship to %{db_obj_name} db version (%{db_obj_version}); ERROR!',
     VERSION_MATCHES => 'actual version (%{actual_version}) matches %{addl} db version',
+    ZIP_PART_CHECKSUM_FILE_MISMATCH => "%{s3_key} catalog md5 (%{md5}) doesn't match the local zip file md5 " \
+                                       '(%{local_md5})',
     ZIP_PART_CHECKSUM_MISMATCH => 'replicated md5 mismatch on %{endpoint_name}: ' \
                                   "%{s3_key} catalog md5 (%{md5}) doesn't match the replicated md5 " \
                                   '(%{replicated_checksum}) on %{bucket_name}',

--- a/db/migrate/20260115121204_add_status_details_to_zipped_moab_version.rb
+++ b/db/migrate/20260115121204_add_status_details_to_zipped_moab_version.rb
@@ -1,0 +1,7 @@
+class AddStatusDetailsToZippedMoabVersion < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :zipped_moab_versions, :status_details, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_13_114437) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_15_121204) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -90,6 +90,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_13_114437) do
     t.integer "status", default: 2, null: false
     t.datetime "status_updated_at", precision: nil
     t.integer "zip_parts_count"
+    t.string "status_details"
     t.index ["preserved_object_id", "zip_endpoint_id", "version"], name: "index_unique_on_zipped_moab_versions", unique: true
     t.index ["preserved_object_id"], name: "index_zipped_moab_versions_on_preserved_object_id"
     t.index ["status"], name: "index_zipped_moab_versions_on_status"

--- a/spec/models/zipped_moab_version_spec.rb
+++ b/spec/models/zipped_moab_version_spec.rb
@@ -67,4 +67,23 @@ RSpec.describe ZippedMoabVersion do
       expect { zmv.update!(zip_parts_count: 2) }.not_to(change(zmv, :status_updated_at))
     end
   end
+
+  describe '#update_status_details before save' do
+    before do
+      zmv.update!(status_details: 'some details')
+    end
+
+    it 'clears status_details if status has changed but status_details has not changed' do
+      expect { zmv.ok! }.to(change(zmv, :status_details).from('some details').to(nil))
+    end
+
+    it 'does not change status_details if status_details has changed' do
+      expect { zmv.update(status: 'ok', status_details: 'new details') }
+        .to(change(zmv, :status_details).from('some details').to('new details'))
+    end
+
+    it 'does not change status_details if status has not changed' do
+      expect { zmv.update!(zip_parts_count: 2) }.not_to(change(zmv, :status_details))
+    end
+  end
 end

--- a/spec/services/replication/zip_parts_to_zip_files_audit_service_spec.rb
+++ b/spec/services/replication/zip_parts_to_zip_files_audit_service_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Replication::ZipPartsToZipFilesAuditService do
+  subject(:results) { described_class.call(zipped_moab_version:) }
+
+  let(:preserved_object) { create(:preserved_object_fixture, druid: 'bj102hs9687') }
+
+  let(:zipped_moab_version) do
+    create(:zipped_moab_version, preserved_object:)
+  end
+
+  let!(:zip_part) { create(:zip_part, zipped_moab_version:) }
+  let!(:mismatched_zip_part) { create(:zip_part, zipped_moab_version:) }
+
+  before do
+    allow(zip_part.druid_version_zip_part).to receive(:read_md5).and_return(zip_part.md5)
+    allow(mismatched_zip_part.druid_version_zip_part).to receive(:read_md5).and_return('different_md5_value')
+  end
+
+  it 'returns results for zip parts with md5 mismatches' do
+    expect(results.size).to eq 1
+    expect(results.to_s).to match(%r{bj/102/hs/9687/bj102hs9687\.v0001\.z.. catalog md5 \(00236a2ae558018ed13b5222ef1bd977\) doesn't match the local zip file md5 \(different_md5_value\)}) # rubocop:disable Layout/LineLength
+  end
+end

--- a/spec/services/replication/zipped_moab_version_audit_service_spec.rb
+++ b/spec/services/replication/zipped_moab_version_audit_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Replication::ZippedMoabVersionAuditService do
     instance_double(Aws::S3::Object, exists?: true, metadata: { 'checksum_md5' => 'incorrect_checksum' }, bucket_name: 'test-bucket')
   end
 
-  let(:results) { instance_double(Results, add_result: nil) }
+  let(:results) { instance_double(Results, add_result: nil, to_s: 'new status details') }
 
   before do
     allow(Replication::ProviderFactory).to receive(:create).and_return(provider)
@@ -36,7 +36,8 @@ RSpec.describe Replication::ZippedMoabVersionAuditService do
     it 'sets zip_parts_count to actual count' do
       expect { described_class.call(zipped_moab_version:, results:) }
         .to change { zipped_moab_version.reload.zip_parts_count }.from(nil).to(3)
-        .and change { zipped_moab_version.reload.status }.to('ok')
+        .and change(zipped_moab_version, :status).to('ok')
+        .and change(zipped_moab_version, :status_details).from(nil).to('new status details')
     end
   end
 


### PR DESCRIPTION
closes #2539

# Why was this change made? 🤔
To align with `status_details` in MoabRecord.



# How was this change tested? 🤨

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



