### PR TITLE
Adds endpoint for check object status.

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -4,10 +4,15 @@
 # ObjectsController allows consumers to interact with preserved objects
 #  (Note: methods will eventually be ported from sdr-services-app)
 class ObjectsController < ApiController
+  before_action :set_preserved_object, only: %i[show ok]
   # return the PreservedObject model for the druid (supplied *without* `druid:` prefix)
   # GET /v1/objects/:id.json
   def show
-    render json: PreservedObject.find_by!(druid: druid).to_json
+    render json: @preserved_object.to_json
+  end
+
+  def ok
+    render json: @preserved_object.moab_record.ok?.to_json
   end
 
   # queue a ValidateMoab job for a specific druid, typically called by a preservationIngestWF robot.
@@ -106,5 +111,9 @@ class ObjectsController < ApiController
     content_group.path_hash.map do |file, signature|
       { filename: file, md5: signature.md5, sha1: signature.sha1, sha256: signature.sha256, filesize: signature.size }
     end
+  end
+
+  def set_preserved_object
+    @preserved_object = PreservedObject.find_by!(druid:)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
 
     resources :objects, only: %i[show] do
       member do
+        get 'ok'
         get 'checksum'
         get 'validate_moab'
         get 'file', format: false # no need to add extension to url

--- a/openapi.yml
+++ b/openapi.yml
@@ -124,6 +124,27 @@ paths:
           example: 'druid:bc123df4567.json'
           schema:
             $ref: '#/components/schemas/DruidWithOptionalFormat'
+  /v1/objects/{id}/ok:
+    get:
+      tags:
+        - objects
+      summary: Returns true if the object (MoabRecord) is not in an error state
+      responses:
+        '200':
+          description: Preserved object found
+          content:
+            application/json:
+              schema:
+                type: boolean
+        '404':
+          description: Preserved object not found
+      parameters:
+        - name: id
+          in: path
+          required: true
+          example: 'druid:bc123df4567'
+          schema:
+            $ref: '#/components/schemas/Druid'
   /v1/objects/{id}/validate_moab:
     get:
       tags:

--- a/spec/requests/objects_controller_ok_spec.rb
+++ b/spec/requests/objects_controller_ok_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe ObjectsController do
+  let(:preserved_object) do
+    create(:preserved_object).tap do |preserved_object|
+      create(:moab_record, preserved_object:, status:)
+    end
+  end
+
+  let(:status) { 'ok' }
+
+  describe 'GET #ok' do
+    context 'when object is ok' do
+      it 'returns true' do
+        get ok_object_url("druid:#{preserved_object.druid}"), headers: valid_auth_header
+        expect(JSON.parse(response.body)).to be true
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when object is not ok' do
+      let(:status) { 'invalid_moab' }
+
+      it 'returns false' do
+        get ok_object_url(preserved_object.druid), headers: valid_auth_header
+        expect(JSON.parse(response.body)).to be false
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when object not found' do
+      it 'returns a 404' do
+        get ok_object_url('druid:bc123df4567'), headers: valid_auth_header
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #2534

# Why was this change made? 🤔
So that DSA can check if an object is in a pres error state before opening it.



# How was this change tested? 🤨
Unit

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



