### PR TITLE
Update zip_parts_debug_info to return a keyed hash for use in the UI

### DIFF
--- a/app/services/audit/replication_support.rb
+++ b/app/services/audit/replication_support.rb
@@ -59,23 +59,23 @@ module Audit
                bucket = zip_part.zip_endpoint.delivery_class.constantize.new.bucket
                s3_part = bucket.object(zip_part.s3_key)
                s3_part_exists = s3_part.exists?
-               [
-                 zip_part.preserved_object.druid,
-                 zip_part.preserved_object.current_version,
-                 zip_part.zipped_moab_version.version,
-                 zip_part.zip_endpoint.endpoint_name,
-                 zip_part.status,
-                 zip_part.suffix,
-                 zip_part.parts_count,
-                 zip_part.size,
-                 zip_part.md5,
-                 zip_part.id,
-                 zip_part.created_at,
-                 zip_part.updated_at,
-                 zip_part.s3_key,
-                 s3_part_exists ? 'found at endpoint' : 'not found at endpoint',
-                 s3_part_exists ? s3_part.metadata['checksum_md5'] : nil
-               ]
+               {
+                 druid: zip_part.preserved_object.druid,
+                 preserved_object_version: zip_part.preserved_object.current_version,
+                 zipped_moab_version: zip_part.zipped_moab_version.version,
+                 endpoint_name: zip_part.zip_endpoint.endpoint_name,
+                 status: zip_part.status,
+                 suffix: zip_part.suffix,
+                 parts_count: zip_part.parts_count,
+                 size: zip_part.size,
+                 md5: zip_part.md5,
+                 id: zip_part.id,
+                 created_at: zip_part.created_at,
+                 updated_at: zip_part.updated_at,
+                 s3_key: zip_part.s3_key,
+                 found_at_endpoint: s3_part_exists ? 'found at endpoint' : 'not found at endpoint',
+                 checksum_md5: s3_part_exists ? s3_part.metadata['checksum_md5'] : nil
+               }
       end
     end
   end

--- a/lib/tasks/prescat.rake
+++ b/lib/tasks/prescat.rake
@@ -10,7 +10,7 @@ namespace :prescat do
               'zip part md5', 'zip part id',
               'zip part created at', 'zip part updated at', 'zip part s3 key', 'zip part endpoint status',
               'zip part endpoint md5']
-      debug_infos.each { |debug_info| csv << debug_info }
+      debug_infos.each { |debug_info| csv << debug_info.values }
     end
   end
 


### PR DESCRIPTION
# Why was this change made? 🤔

This is a small change to the `zipped_part_debug_info` method of `Audit::ReplicationSupport` to return a keyed hash for better usability in the UI when added to the druid show page. This should not have any impact on the output created when used from the `prescat:diagnose_replication` rake task.