### PR TITLE
disable DDL transaction for latest migration

### DIFF
--- a/db/migrate/20260107124042_add_status_to_zipped_moab_versions.rb
+++ b/db/migrate/20260107124042_add_status_to_zipped_moab_versions.rb
@@ -1,4 +1,6 @@
 class AddStatusToZippedMoabVersions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
   def change
     add_column :zipped_moab_versions, :status, :integer, default: 2, null: false
     add_column :zipped_moab_versions, :status_updated_at, :datetime, precision: nil


### PR DESCRIPTION
i know going back and editing migrations is frowned upon, but...

# Why was this change made? 🤔

this hasn't been deployed to prod yet (i attempted to deploy, but killed it around the 1 hr 50 min mark, as the migration was taking forever; i confirmed that the long-running transaction did indeed work, as the new field was not added to zipped_moab_versions and the most recent migration was still 20221220212633, the one before the migration this PR touches).

follow on to https://github.com/sul-dlss/preservation_catalog/pull/2518



# How was this change tested? 🤨

will deploy to stage first to test (stage has also not had this migration applied).

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



