### PR TITLE
Move hash building to ZipPart model

### DIFF
--- a/app/services/audit/replication_support.rb
+++ b/app/services/audit/replication_support.rb
@@ -55,28 +55,7 @@ module Audit
       ZipPart.joins(zipped_moab_version: %i[preserved_object zip_endpoint])
              .where(preserved_objects: { druid: druid })
              .order(:druid, :version, :endpoint_name, :suffix)
-             .map do |zip_part|
-               bucket = zip_part.zip_endpoint.delivery_class.constantize.new.bucket
-               s3_part = bucket.object(zip_part.s3_key)
-               s3_part_exists = s3_part.exists?
-               {
-                 druid: zip_part.preserved_object.druid,
-                 preserved_object_version: zip_part.preserved_object.current_version,
-                 zipped_moab_version: zip_part.zipped_moab_version.version,
-                 endpoint_name: zip_part.zip_endpoint.endpoint_name,
-                 status: zip_part.status,
-                 suffix: zip_part.suffix,
-                 parts_count: zip_part.parts_count,
-                 size: zip_part.size,
-                 md5: zip_part.md5,
-                 id: zip_part.id,
-                 created_at: zip_part.created_at,
-                 updated_at: zip_part.updated_at,
-                 s3_key: zip_part.s3_key,
-                 found_at_endpoint: s3_part_exists ? 'found at endpoint' : 'not found at endpoint',
-                 checksum_md5: s3_part_exists ? s3_part.metadata['checksum_md5'] : nil
-               }
-      end
+             .map(&:to_h)
     end
   end
 end

--- a/app/services/replication/replicate_zip_part_service.rb
+++ b/app/services/replication/replicate_zip_part_service.rb
@@ -16,7 +16,7 @@ module Replication
 
     # @raise [DifferentPartFileFoundError] if a different part file is found at the endpoint
     def call
-      set_hb_context
+      Honeybadger.context(zip_part:)
 
       return if already_replicated?
       check_existing_part_file_on_endpoint
@@ -40,15 +40,6 @@ module Replication
 
     def already_replicated?
       zip_part_file_exists_on_endpoint? && zip_part_md5s_match?
-    end
-
-    def set_hb_context
-      Honeybadger.context(
-        druid: zip_part.preserved_object.druid,
-        version: zip_part.zipped_moab_version.version,
-        endpoint: zip_part.zip_endpoint.endpoint_name,
-        zip_part_id: zip_part.id
-      )
     end
 
     def metadata

--- a/spec/services/audit/replication_support_spec.rb
+++ b/spec/services/audit/replication_support_spec.rb
@@ -3,116 +3,117 @@
 require 'rails_helper'
 
 RSpec.describe Audit::ReplicationSupport do
-  let(:zmv) { create(:zipped_moab_version, preserved_object: create(:preserved_object_fixture, druid: 'bz514sm9647')) }
+  let(:druid) { 'bz514sm9647' }
+  let(:zmv) { create(:zipped_moab_version, preserved_object: create(:preserved_object_fixture, druid:)) }
   let(:results) { Audit::Results.new(druid: zmv.preserved_object.druid, moab_storage_root: zmv.zip_endpoint, check_name: 'ReplicationSupportSpec') }
   let(:version) { zmv.version }
   let(:endpoint_name) { zmv.zip_endpoint.endpoint_name }
   let(:result_prefix) { "#{version} on #{endpoint_name}" }
 
-  context 'zip parts have not been created yet' do
-    it 'logs an error indicating that zip parts have not beeen created yet' do
-      described_class.check_child_zip_part_attributes(zmv, results)
-      expect(results.results).to include(
-        a_hash_including(
-          Audit::Results::ZIP_PARTS_NOT_CREATED => "#{result_prefix}: no zip_parts exist yet for this ZippedMoabVersion"
+  describe '.check_child_zip_part_attributes' do
+    context 'when zip parts have not been created yet' do
+      it 'logs an error indicating that zip parts have not beeen created yet' do
+        described_class.check_child_zip_part_attributes(zmv, results)
+        expect(results.results).to include(
+          a_hash_including(
+            Audit::Results::ZIP_PARTS_NOT_CREATED => "#{result_prefix}: no zip_parts exist yet for this ZippedMoabVersion"
+          )
         )
-      )
+      end
+
+      it 'returns false' do
+        expect(described_class.check_child_zip_part_attributes(zmv, results)).to be(false)
+      end
     end
 
-    it 'returns false' do
-      expect(described_class.check_child_zip_part_attributes(zmv, results)).to be(false)
-    end
-  end
+    context 'when different parts have different expected parts_count values' do
+      before do
+        args = attributes_for(:zip_part)
+        zmv.zip_parts.create!(
+          [
+            args.merge(status: 'ok', parts_count: 2, suffix: '.zip'),
+            args.merge(status: 'ok', parts_count: 2, suffix: '.z01'),
+            args.merge(status: 'ok', parts_count: 3, suffix: '.z02')
+          ]
+        )
+      end
 
-  context 'different parts have different expected parts_count values' do
-    before do
-      args = attributes_for(:zip_part)
-      zmv.zip_parts.create!(
-        [
-          args.merge(status: 'ok', parts_count: 2, suffix: '.zip'),
-          args.merge(status: 'ok', parts_count: 2, suffix: '.z01'),
-          args.merge(status: 'ok', parts_count: 3, suffix: '.z02')
-        ]
-      )
-    end
-
-    it 'logs the discrepancy' do
-      described_class.check_child_zip_part_attributes(zmv, results)
-      child_parts_counts = zmv.child_parts_counts
-      exp_err_msg = "#{result_prefix}: ZippedMoabVersion has variation in child parts_counts: #{child_parts_counts}"
-      expect(results.results).to include(
-        a_hash_including(Audit::Results::ZIP_PARTS_COUNT_INCONSISTENCY => exp_err_msg)
-      )
-    end
-  end
-
-  context 'parts_count is consistent across parts and with the actual number of zip parts' do
-    before do
-      args = attributes_for(:zip_part)
-      zmv.zip_parts.create!(
-        [
-          args.merge(status: 'ok', parts_count: 3, suffix: '.zip'),
-          args.merge(status: 'ok', parts_count: 3, suffix: '.z01'),
-          args.merge(status: 'ok', parts_count: 3, suffix: '.z02')
-        ]
-      )
+      it 'logs the discrepancy' do
+        described_class.check_child_zip_part_attributes(zmv, results)
+        child_parts_counts = zmv.child_parts_counts
+        exp_err_msg = "#{result_prefix}: ZippedMoabVersion has variation in child parts_counts: #{child_parts_counts}"
+        expect(results.results).to include(
+          a_hash_including(Audit::Results::ZIP_PARTS_COUNT_INCONSISTENCY => exp_err_msg)
+        )
+      end
     end
 
-    it "doesn't log parts_count errors" do
-      described_class.check_child_zip_part_attributes(zmv, results)
-      expect(results.results).not_to include(a_hash_including(Audit::Results::ZIP_PARTS_COUNT_INCONSISTENCY))
+    context 'when parts_count is consistent across parts with the actual number of zip parts' do
+      before do
+        args = attributes_for(:zip_part)
+        zmv.zip_parts.create!(
+          [
+            args.merge(status: 'ok', parts_count: 3, suffix: '.zip'),
+            args.merge(status: 'ok', parts_count: 3, suffix: '.z01'),
+            args.merge(status: 'ok', parts_count: 3, suffix: '.z02')
+          ]
+        )
+      end
+
+      it "doesn't log parts_count errors" do
+        described_class.check_child_zip_part_attributes(zmv, results)
+        expect(results.results).not_to include(a_hash_including(Audit::Results::ZIP_PARTS_COUNT_INCONSISTENCY))
+      end
+
+      it "doesn't log an error about parts_count mismatching number of zip_parts" do
+        described_class.check_child_zip_part_attributes(zmv, results)
+        expect(results.results).not_to include(a_hash_including(Audit::Results::ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL))
+      end
     end
 
-    it "doesn't log an error about parts_count mismatching number of zip_parts" do
-      described_class.check_child_zip_part_attributes(zmv, results)
-      expect(results.results).not_to include(a_hash_including(Audit::Results::ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL))
-    end
-  end
+    context "when parts_count is consistent across parts, but doesn't match the actual number of child parts" do
+      before do
+        args = attributes_for(:zip_part)
+        zmv.zip_parts.create!(
+          [
+            args.merge(status: 'ok', parts_count: 3, suffix: '.zip'),
+            args.merge(status: 'ok', parts_count: 3, suffix: '.z01')
+          ]
+        )
+      end
 
-  context "parts_count is consistent across parts, but doesn't match the actual number of child parts" do
-    before do
-      args = attributes_for(:zip_part)
-      zmv.zip_parts.create!(
-        [
-          args.merge(status: 'ok', parts_count: 3, suffix: '.zip'),
-          args.merge(status: 'ok', parts_count: 3, suffix: '.z01')
-        ]
-      )
-    end
-
-    it 'logs the discrepancy' do
-      described_class.check_child_zip_part_attributes(zmv, results)
-      msg = "#{result_prefix}: ZippedMoabVersion stated parts count " \
-            "(3) doesn't match actual number of zip parts rows (2)"
-      expect(results.results).to include(
-        a_hash_including(Audit::Results::ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL => msg)
-      )
-    end
-  end
-
-  context 'when total part size is less than the moab size' do
-    before do
-      args = attributes_for(:zip_part)
-      zmv.zip_parts.create!(
-        [
-          args.merge(status: 'ok', parts_count: 3, suffix: '.zip', size: 111),
-          args.merge(status: 'ok', parts_count: 3, suffix: '.z01', size: 222),
-          args.merge(status: 'ok', parts_count: 3, suffix: '.z02', size: 333)
-        ]
-      )
+      it 'logs the discrepancy' do
+        described_class.check_child_zip_part_attributes(zmv, results)
+        msg = "#{result_prefix}: ZippedMoabVersion stated parts count " \
+              "(3) doesn't match actual number of zip parts rows (2)"
+        expect(results.results).to include(
+          a_hash_including(Audit::Results::ZIP_PARTS_COUNT_DIFFERS_FROM_ACTUAL => msg)
+        )
+      end
     end
 
-    it 'logs the discrepancy' do
-      described_class.check_child_zip_part_attributes(zmv, results)
-      msg = "#{result_prefix}: Sum of ZippedMoabVersion child part sizes (666) is less than what is in the Moab: 202938"
-      expect(results.results).to include(
-        a_hash_including(Audit::Results::ZIP_PARTS_SIZE_INCONSISTENCY => msg)
-      )
-    end
-  end
+    context 'when total part size is less than the moab size' do
+      before do
+        args = attributes_for(:zip_part)
+        zmv.zip_parts.create!(
+          [
+            args.merge(status: 'ok', parts_count: 3, suffix: '.zip', size: 111),
+            args.merge(status: 'ok', parts_count: 3, suffix: '.z01', size: 222),
+            args.merge(status: 'ok', parts_count: 3, suffix: '.z02', size: 333)
+          ]
+        )
+      end
 
-  context 'zip parts have been created' do
-    context 'some parts are unreplicated' do
+      it 'logs the discrepancy' do
+        described_class.check_child_zip_part_attributes(zmv, results)
+        msg = "#{result_prefix}: Sum of ZippedMoabVersion child part sizes (666) is less than what is in the Moab: 202938"
+        expect(results.results).to include(
+          a_hash_including(Audit::Results::ZIP_PARTS_SIZE_INCONSISTENCY => msg)
+        )
+      end
+    end
+
+    context 'when zip parts have been created and some parts are unreplicated' do
       before do
         args = attributes_for(:zip_part)
         zmv.zip_parts.create!(
@@ -133,6 +134,32 @@ RSpec.describe Audit::ReplicationSupport do
       it 'returns true' do
         expect(described_class.check_child_zip_part_attributes(zmv, results)).to be(true)
       end
+    end
+  end
+
+  describe '.zip_part_debug_info' do
+    subject(:debug_info) { described_class.zip_part_debug_info(zip_part.druid) }
+
+    let(:zip_part) { create(:zip_part, zipped_moab_version: zmv) }
+    let(:s3_object) { instance_double(Aws::S3::Object, exists?: true, metadata: { 'checksum_md5' => '00236a2ae558018ed13b5222ef1bd977' }) }
+    let(:provider) { instance_double(Replication::AwsProvider, bucket: instance_double(Aws::S3::Bucket, object: s3_object)) }
+
+    before { allow(Replication::ProviderFactory).to receive(:create).and_return(provider) }
+
+    it 'returns a hash of zip part info sufficient to do troubleshooting' do
+      expect(debug_info).to include(a_hash_including(druid:,
+                                                     preserved_object_version: 3,
+                                                     zipped_moab_version: 1,
+                                                     endpoint_name: /endpoint\d+/,
+                                                     status: 'unreplicated',
+                                                     suffix: /\.z\d+/,
+                                                     parts_count: 1,
+                                                     size: 1234,
+                                                     md5: '00236a2ae558018ed13b5222ef1bd977',
+                                                     id: zip_part.id,
+                                                     s3_key: %r{bz/514/sm/9647/bz514sm9647\.v0001\.z\d+},
+                                                     found_at_endpoint: 'found at endpoint',
+                                                     checksum_md5: '00236a2ae558018ed13b5222ef1bd977'))
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,7 +85,7 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = :random unless config.files_to_run.one?
+  config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
# Why was this change made? 🤔




# How was this change tested? 🤨

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



