### PR TITLE
change migration to better reflect what happened in prod

### DIFF
--- a/db/migrate/20260107124042_add_status_to_zipped_moab_versions.rb
+++ b/db/migrate/20260107124042_add_status_to_zipped_moab_versions.rb
@@ -12,7 +12,12 @@ class AddStatusToZippedMoabVersions < ActiveRecord::Migration[8.0]
     # Set status to 'ok'. Auditing will set this correctly later.
     ZippedMoabVersion.update_all(status: 0)
 
+    # NOTE: We went back and modified this for the historical record, as we didn't run this last step
+    # for the prod migration.  It hit a PostgreSQL connection timeout after a couple hours of running.
+    # We did this out-of-band from cap deployment migration by running the new replication audit job on
+    # these same objects in a rails console session in screen.
+    #
     # For ZippedMoabVersions without any ZipParts, set status to 'created'.
-    ZippedMoabVersion.where.missing(:zip_parts).update_all(status: 2, status_updated_at: Time.current)
+    # ZippedMoabVersion.where.missing(:zip_parts).update_all(status: 2, status_updated_at: Time.current)
   end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

see slack discussion: https://stanfordlib.slack.com/archives/C04D8DJDRJ9/p1768604487736579

basically:
* the migration as it was before this PR ran for a couple hours, and crashed with a connection timeout on the second of the two UPDATE statements
* we determined that we could accomplish the goal of that statement using queries to feed replication audits, in rails console, manually, outside the context of a rails migration managed by capistrano
* i went onto the server, into a cap directory for the latest failed deploy, commented out all lines of this migration, put in a `ZippedMoabVersions.count` just to have something, and manually ran `RAILS_ENV=production bin/rake db:migrate`
* this made it so that the migration was recorded in the history, so that no attempt would be made to re-run it on prod on subsequent deploys
* i undid my changes and logged off the VM
* i re-deployed main.  indeed, no migrations were run, as the metadata in pres cat prod showed that it was caught up to the latest migration (true enough)

follow on to deployment plan in https://github.com/sul-dlss/preservation_catalog/pull/2518/




# How was this change tested? 🤨

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



