### PR TITLE
Adds dashboard list pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'importmap-rails'
 gem 'jbuilder' # Build JSON APIs with ease.
 gem 'jwt' # for gating programmatic access to the application
+gem 'kaminari' # pagination
 gem 'lograge'
 gem 'moab-versioning', '~> 6.0' # work with Moab Objects
 gem 'okcomputer' # ReST endpoint with upness status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,18 @@ GEM
       multi_json
     jwt (3.1.2)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -611,6 +623,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jwt
+  kaminari
   listen (~> 3)
   lograge
   moab-versioning (~> 6.0)

--- a/app/controllers/dashboard/moab_records_controller.rb
+++ b/app/controllers/dashboard/moab_records_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Dashboard
+  # Controller for listing MoabRecords in the dashboard
+  class MoabRecordsController < BaseController
+    def with_errors
+      @moab_records = MoabRecord.with_errors.eager_load(:preserved_object).order(:updated_at).page(params[:page])
+    end
+
+    def stuck
+      @moab_records = MoabRecord.stuck.eager_load(:preserved_object).order(:updated_at).page(params[:page])
+    end
+  end
+end

--- a/app/controllers/dashboard/zipped_moab_versions_controller.rb
+++ b/app/controllers/dashboard/zipped_moab_versions_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Dashboard
+  # Controller for listing ZippedMoabVersions in the dashboard
+  class ZippedMoabVersionsController < BaseController
+    def with_errors
+      @zipped_moab_versions = ZippedMoabVersion.with_errors.eager_load(:preserved_object).order(:status_updated_at).page(params[:page])
+    end
+
+    def stuck
+      @zipped_moab_versions = ZippedMoabVersion.stuck.eager_load(:preserved_object).order(:status_updated_at).page(params[:page])
+    end
+  end
+end

--- a/app/models/moab_record.rb
+++ b/app/models/moab_record.rb
@@ -40,6 +40,8 @@ class MoabRecord < ApplicationRecord
     where('last_checksum_validation < ? or last_checksum_validation IS NULL', Time.zone.now - Settings.preservation_policy.fixity_ttl.seconds)
   }
 
+  delegate :druid, to: :preserved_object
+
   # Send to asynchronous checksum validation pipeline
   def validate_checksums!
     Audit::ChecksumValidationJob.perform_later(self)

--- a/app/models/zipped_moab_version.rb
+++ b/app/models/zipped_moab_version.rb
@@ -36,7 +36,7 @@ class ZippedMoabVersion < ApplicationRecord
   end
 
   def update_status_updated_at
-    self.status_updated_at = Time.current if status_changed?
+    self.status_updated_at = Time.current if status_changed? && !status_updated_at_changed?
   end
 
   def update_status_details

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -13,13 +13,13 @@
     <tbody>
       <tr>
         <th scope="row">MoabRecords</th>
-        <td><%= number_with_delimiter(MoabRecord.errors_count) %></td>
-        <td><%= number_with_delimiter(MoabRecord.stuck_count) %></td>
+        <td><%= link_to number_with_delimiter(MoabRecord.with_errors.count), with_errors_dashboard_moab_records_path %></td>
+        <td><%= link_to number_with_delimiter(MoabRecord.stuck.count), stuck_dashboard_moab_records_path %></td>
       </tr>
       <tr>
         <th scope="row">ZippedMoabVersions</th>
-        <td><%= number_with_delimiter(ZippedMoabVersion.errors_count) %></td>
-        <td><%= number_with_delimiter(ZippedMoabVersion.stuck_count) %></td>
+        <td><%= link_to number_with_delimiter(ZippedMoabVersion.with_errors.count), with_errors_dashboard_zipped_moab_versions_path %></td>
+        <td><%= link_to number_with_delimiter(ZippedMoabVersion.stuck.count), stuck_dashboard_zipped_moab_versions_path %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/dashboard/moab_records/stuck.html.erb
+++ b/app/views/dashboard/moab_records/stuck.html.erb
@@ -1,0 +1,27 @@
+<div class="container mt-4">
+  <h1>Stuck MoabRecords</h1>
+
+  <table class="table" id="stuck-moab-records-table">
+    <thead>
+      <tr>
+        <th scope="col">Druid</th>
+        <th scope="col">Stuck since</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @moab_records.each do |moab_record| %>
+        <tr>
+          <th scope="row"><%= link_to moab_record.druid, dashboard_object_path(moab_record.druid) %></th>
+          <td><%= l moab_record.updated_at %></td>
+        </tr>
+      <% end %>
+      <% if @moab_records.empty? %>
+        <tr>
+          <td colspan="4">No records found.</td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @moab_records %>
+</div>

--- a/app/views/dashboard/moab_records/with_errors.html.erb
+++ b/app/views/dashboard/moab_records/with_errors.html.erb
@@ -1,0 +1,31 @@
+<div class="container mt-4">
+  <h1>MoabRecords in error statuses</h1>
+
+  <table class="table" id="moab-records-with-errors-table">
+    <thead>
+      <tr>
+        <th scope="col">Druid</th>
+        <th scope="col">Status</th>
+        <th scope="col">Status detail</th>
+        <th scope="col">Last updated</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @moab_records.each do |moab_record| %>
+        <tr>
+          <th scope="row"><%= link_to moab_record.druid, dashboard_object_path(moab_record.druid) %></th>
+          <td><%= moab_record.status %></td>
+          <td><%= moab_record.status_details %></td>
+          <td><%= l moab_record.updated_at %></td>
+        </tr>
+      <% end %>
+      <% if @moab_records.empty? %>
+        <tr>
+          <td colspan="4">No records found.</td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @moab_records %>
+</div>

--- a/app/views/dashboard/zipped_moab_versions/stuck.html.erb
+++ b/app/views/dashboard/zipped_moab_versions/stuck.html.erb
@@ -1,0 +1,27 @@
+<div class="container mt-4">
+  <h1>Stuck ZippedMoabVersions</h1>
+
+  <table class="table" id="stuck-zipped-moab-versions-table">
+    <thead>
+      <tr>
+        <th scope="col">Druid</th>
+        <th scope="col">Stuck since</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @zipped_moab_versions.each do |zipped_moab_version| %>
+        <tr>
+          <th scope="row"><%= link_to zipped_moab_version.druid, dashboard_object_path(zipped_moab_version.druid) %></th>
+          <td><%= l zipped_moab_version.status_updated_at %></td>
+        </tr>
+      <% end %>
+      <% if @zipped_moab_versions.empty? %>
+        <tr>
+          <td colspan="4">No records found.</td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @zipped_moab_versions %>
+</div>

--- a/app/views/dashboard/zipped_moab_versions/with_errors.html.erb
+++ b/app/views/dashboard/zipped_moab_versions/with_errors.html.erb
@@ -1,0 +1,31 @@
+<div class="container mt-4">
+  <h1>ZippedMoabVersions in failed status</h1>
+
+  <table class="table" id="zipped-moab-versions-with-errors-table">
+    <thead>
+      <tr>
+        <th scope="col">Druid</th>
+        <th scope="col">Status</th>
+        <th scope="col">Status detail</th>
+        <th scope="col">Last updated</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @zipped_moab_versions.each do |zipped_moab_version| %>
+        <tr>
+          <th scope="row"><%= link_to zipped_moab_version.druid, dashboard_object_path(zipped_moab_version.druid) %></th>
+          <td><%= zipped_moab_version.status %></td>
+          <td><%= zipped_moab_version.status_details %></td>
+          <td><%= l zipped_moab_version.status_updated_at %></td>
+        </tr>
+      <% end %>
+      <% if @zipped_moab_versions.empty? %>
+        <tr>
+          <td colspan="4">No records found.</td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @zipped_moab_versions %>
+</div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 100
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,6 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  time:
+    formats:
+      default: "%Y-%m-%d %H:%M:%S %z"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   namespace :dashboard do
     root to: 'dashboard#index' # Preservation System Status Overview page
 
-    resources :objects, only: [:show] # show -> Object show page
+    resources :objects, only: [:show], param: :druid # show -> Object show page
     resources :moab_records, only: [:index] do # index -> Files in moabs on local storage page
       collection do
         get 'with_errors' # MoabRecords in error statuses list page

--- a/spec/models/concerns/moab_record_calculations_spec.rb
+++ b/spec/models/concerns/moab_record_calculations_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe MoabRecordCalculations do
-  describe '.errors_count' do
+  describe '.with_errors' do
     before do
       create(:moab_record, status: :ok)
       create(:moab_record, status: :invalid_moab)
@@ -13,12 +13,12 @@ RSpec.describe MoabRecordCalculations do
       create(:moab_record, status: :validity_unknown)
     end
 
-    it 'returns the count of MoabRecords with error statuses' do
-      expect(MoabRecord.errors_count).to eq(4)
+    it 'returns MoabRecords with error statuses' do
+      expect(MoabRecord.with_errors.count).to eq(4)
     end
   end
 
-  describe '.stuck_count' do
+  describe '.stuck' do
     before do
       create(:moab_record, status: :validity_unknown, updated_at: 2.weeks.ago)
       create(:moab_record, status: :validity_unknown, updated_at: 3.days.ago)
@@ -26,8 +26,8 @@ RSpec.describe MoabRecordCalculations do
       create(:moab_record, status: :ok)
     end
 
-    it 'returns the count of MoabRecords with status of validity_unknown for more than a week' do
-      expect(MoabRecord.stuck_count).to eq(2)
+    it 'returns MoabRecords with status of validity_unknown for more than a week' do
+      expect(MoabRecord.stuck.count).to eq(1)
     end
   end
 

--- a/spec/models/concerns/zipped_moab_version_calculations_spec.rb
+++ b/spec/models/concerns/zipped_moab_version_calculations_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ZippedMoabVersionCalculations do
-  describe '.errors_count' do
+  describe '.with_errors' do
     before do
       create(:zipped_moab_version, status: :ok)
       create(:zipped_moab_version, status: :failed)
@@ -12,20 +12,20 @@ RSpec.describe ZippedMoabVersionCalculations do
     end
 
     it 'returns the count of ZippedMoabVersions with failed status' do
-      expect(ZippedMoabVersion.errors_count).to eq(1)
+      expect(ZippedMoabVersion.with_errors.count).to eq(1)
     end
   end
 
-  describe '.stuck_count' do
+  describe '.stuck' do
     before do
-      create(:zipped_moab_version, status: :incomplete, updated_at: 2.weeks.ago)
-      create(:zipped_moab_version, status: :incomplete, updated_at: 3.days.ago)
-      create(:zipped_moab_version, status: :created)
+      create(:zipped_moab_version, status: :incomplete, status_updated_at: 2.weeks.ago)
+      create(:zipped_moab_version, status: :incomplete)
+      create(:zipped_moab_version, status: :created, status_updated_at: 8.days.ago)
       create(:zipped_moab_version, status: :ok)
     end
 
-    it 'returns the count of ZippedMoabVersions with status of validity_unknown for more than a week' do
-      expect(ZippedMoabVersion.stuck_count).to eq(2)
+    it 'returns the count of ZippedMoabVersions with incomplete or created statusfor more than a week' do
+      expect(ZippedMoabVersion.stuck.count).to eq(2)
     end
   end
 

--- a/spec/system/dashboard/show_moab_records_with_errors_spec.rb
+++ b/spec/system/dashboard/show_moab_records_with_errors_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show MoabRecords with errors' do
+  context 'when there are no MoabRecords with errors' do
+    it 'reports no records with errors' do
+      visit with_errors_dashboard_moab_records_path
+
+      expect(page).to have_css('h1', text: 'MoabRecords in error statuses')
+      expect(page).to have_text('No records found.')
+    end
+  end
+
+  context 'when there are MoabRecords with errors' do
+    let(:preserved_object) { create(:preserved_object) }
+    let!(:moab_record) do
+      create(:moab_record,
+             preserved_object: preserved_object,
+             status: 'invalid_checksum',
+             status_details: 'Checksum mismatch detected')
+    end
+
+    before do
+      create_list(:moab_record, 3, status: 'invalid_moab')
+
+      Kaminari.configure do |config|
+        config.default_per_page = 3
+      end
+    end
+
+    it 'lists the MoabRecords with errors' do
+      visit with_errors_dashboard_moab_records_path
+
+      expect(page).to have_css('h1', text: 'MoabRecords in error statuses')
+
+      within('table#moab-records-with-errors-table tbody') do
+        expect(page).to have_css('tr', count: 3)
+
+        within('tr:nth-of-type(1)') do
+          expect(page).to have_css('th', text: moab_record.druid)
+          expect(page).to have_link(moab_record.druid, href: dashboard_object_path(moab_record.druid))
+          expect(page).to have_css('td:nth-of-type(1)', text: 'invalid_checksum')
+          expect(page).to have_css('td:nth-of-type(2)', text: 'Checksum mismatch detected')
+        end
+      end
+
+      expect(page).to have_css('nav.pagination')
+    end
+  end
+end

--- a/spec/system/dashboard/show_stuck_moab_records_spec.rb
+++ b/spec/system/dashboard/show_stuck_moab_records_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show stuck MoabRecords' do
+  context 'when there are no stuck MoabRecords' do
+    it 'reports no stuck MoabRecords' do
+      visit stuck_dashboard_moab_records_path
+
+      expect(page).to have_css('h1', text: 'Stuck MoabRecords')
+      expect(page).to have_text('No records found.')
+    end
+  end
+
+  context 'when there are stuck MoabRecords' do
+    let(:preserved_object) { create(:preserved_object) }
+    let!(:moab_record) do
+      create(:moab_record,
+             preserved_object: preserved_object,
+             status: 'validity_unknown',
+             updated_at: 3.weeks.ago)
+    end
+
+    before do
+      create_list(:moab_record, 3, status: 'validity_unknown', updated_at: 2.weeks.ago)
+
+      Kaminari.configure do |config|
+        config.default_per_page = 3
+      end
+    end
+
+    it 'lists the stuck MoabRecords' do
+      visit stuck_dashboard_moab_records_path
+
+      expect(page).to have_css('h1', text: 'Stuck MoabRecords')
+
+      within('table#stuck-moab-records-table tbody') do
+        expect(page).to have_css('tr', count: 3)
+
+        within('tr:nth-of-type(1)') do
+          expect(page).to have_css('th', text: moab_record.druid)
+          expect(page).to have_link(moab_record.druid, href: dashboard_object_path(moab_record.druid))
+        end
+      end
+
+      expect(page).to have_css('nav.pagination')
+    end
+  end
+end

--- a/spec/system/dashboard/show_stuck_zipped_moab_versions_spec.rb
+++ b/spec/system/dashboard/show_stuck_zipped_moab_versions_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show stuck ZippedMoabVersions' do
+  context 'when there are no stuck ZippedMoabVersions' do
+    it 'reports no stuck ZippedMoabVersions' do
+      visit stuck_dashboard_zipped_moab_versions_path
+
+      expect(page).to have_css('h1', text: 'Stuck ZippedMoabVersions')
+      expect(page).to have_text('No records found.')
+    end
+  end
+
+  context 'when there are stuck ZippedMoabVersions' do
+    let(:preserved_object) { create(:preserved_object) }
+    let!(:zipped_moab_version) do
+      create(:zipped_moab_version,
+             preserved_object: preserved_object,
+             status: 'incomplete',
+             status_updated_at: 3.weeks.ago)
+    end
+
+    before do
+      create_list(:zipped_moab_version, 3, status: 'created', status_updated_at: 2.weeks.ago)
+      Kaminari.configure do |config|
+        config.default_per_page = 3
+      end
+    end
+
+    it 'lists the stuck ZippedMoabVersions' do
+      visit stuck_dashboard_zipped_moab_versions_path
+
+      expect(page).to have_css('h1', text: 'Stuck ZippedMoabVersions')
+
+      within('table#stuck-zipped-moab-versions-table tbody') do
+        expect(page).to have_css('tr', count: 3)
+
+        within('tr:nth-of-type(1)') do
+          expect(page).to have_css('th', text: zipped_moab_version.druid)
+          expect(page).to have_link(zipped_moab_version.druid, href: dashboard_object_path(zipped_moab_version.druid))
+        end
+      end
+
+      expect(page).to have_css('nav.pagination')
+    end
+  end
+end

--- a/spec/system/dashboard/show_zipped_moab_versions_with_errors_spec.rb
+++ b/spec/system/dashboard/show_zipped_moab_versions_with_errors_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show ZippedMoabVersions with errors' do
+  context 'when there are no ZippedMoabVersions with errors' do
+    it 'reports no records with errors' do
+      visit with_errors_dashboard_zipped_moab_versions_path
+
+      expect(page).to have_css('h1', text: 'ZippedMoabVersions in failed status')
+      expect(page).to have_text('No records found.')
+    end
+  end
+
+  context 'when there are ZippedMoabVersions with errors' do
+    let(:preserved_object) { create(:preserved_object) }
+    let!(:zipped_moab_version) do
+      create(:zipped_moab_version,
+             preserved_object: preserved_object,
+             status: 'failed',
+             status_details: 'Missing from cloud endpoint')
+    end
+
+    before do
+      create_list(:zipped_moab_version, 3, status: 'failed')
+      Kaminari.configure do |config|
+        config.default_per_page = 3
+      end
+    end
+
+    it 'lists the ZippedMoabVersions with errors' do
+      visit with_errors_dashboard_zipped_moab_versions_path
+
+      expect(page).to have_css('h1', text: 'ZippedMoabVersions in failed status')
+
+      within('table#zipped-moab-versions-with-errors-table tbody') do
+        expect(page).to have_css('tr', count: 3)
+
+        within('tr:nth-of-type(1)') do
+          expect(page).to have_css('th', text: zipped_moab_version.druid)
+          expect(page).to have_link(zipped_moab_version.druid, href: dashboard_object_path(zipped_moab_version.druid))
+          expect(page).to have_css('td:nth-of-type(1)', text: 'failed')
+          expect(page).to have_css('td:nth-of-type(2)', text: 'Missing from cloud endpoint')
+        end
+      end
+
+      expect(page).to have_css('nav.pagination')
+    end
+  end
+end


### PR DESCRIPTION
closes #2552

# Why was this change made? 🤔




# How was this change tested? 🤨

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



