### PR TITLE
Adds dashboard page for MoabRecords

### DIFF
--- a/app/controllers/dashboard/moab_records_controller.rb
+++ b/app/controllers/dashboard/moab_records_controller.rb
@@ -3,6 +3,10 @@
 module Dashboard
   # Controller for listing MoabRecords in the dashboard
   class MoabRecordsController < BaseController
+    def index
+      @results, @total_result = MoabRecord.moab_records_by_moab_storage_root
+    end
+
     def with_errors
       @moab_records = MoabRecord.with_errors.eager_load(:preserved_object).order(:updated_at).page(params[:page])
     end

--- a/app/models/concerns/moab_record_calculations.rb
+++ b/app/models/concerns/moab_record_calculations.rb
@@ -11,6 +11,30 @@ module MoabRecordCalculations
                       moab_on_storage_not_found
                       unexpected_version_on_storage].freeze
 
+  MoabRecordsByMoabStorageRootResult = Struct.new('MoabRecordsByMoabStorageRootResult',
+                                                  :moab_storage_root,
+                                                  :total_size,
+                                                  :moab_count,
+                                                  :ok_count,
+                                                  :invalid_moab_count,
+                                                  :invalid_checksum_count,
+                                                  :moab_on_storage_not_found_count,
+                                                  :unexpected_version_on_storage_count,
+                                                  :validity_unknown_count,
+                                                  keyword_init: true) do
+                                                    def initialize(**kwargs) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+                                                      super
+                                                      self.total_size ||= 0
+                                                      self.moab_count ||= 0
+                                                      self.ok_count ||= 0
+                                                      self.invalid_moab_count ||= 0
+                                                      self.invalid_checksum_count ||= 0
+                                                      self.moab_on_storage_not_found_count ||= 0
+                                                      self.unexpected_version_on_storage_count ||= 0
+                                                      self.validity_unknown_count ||= 0
+                                                    end
+                                                  end
+
   included do
     # @return [ActiveRecord::Relation<MoabRecord>] MoabRecords with error statuses
     scope :with_errors, -> { where(status: ERROR_STATUSES).annotate(caller) }
@@ -21,7 +45,7 @@ module MoabRecordCalculations
     }
   end
 
-  class_methods do
+  class_methods do # rubocop:disable Metrics/BlockLength
     # @return [Integer] count of MoabRecords with status of validity_unknown
     def validity_unknown_count
       where(status: 'validity_unknown')
@@ -34,6 +58,33 @@ module MoabRecordCalculations
       where(last_checksum_validation: ...(Time.current - Settings.preservation_policy.fixity_ttl.seconds - 7.days))
         .annotate(caller)
         .count
+    end
+
+    # @return [Array<MoabRecordsByMoabStorageRootResult>, MoabRecordsByMoabStorageRootResult] aggregation of MoabRecords by MoabStorageRoot
+    #   and a total aggregation
+    def moab_records_by_moab_storage_root # rubocop:disable Metrics/AbcSize
+      result_map = {}
+      total_result = MoabRecordsByMoabStorageRootResult.new(moab_count: 0)
+      MoabStorageRoot.find_each do |moab_storage_root|
+        result_map[moab_storage_root.id] = MoabRecordsByMoabStorageRootResult.new(
+          moab_storage_root: moab_storage_root
+        )
+      end
+      group(:moab_storage_root_id).count.each do |moab_storage_root_id, count|
+        result_map[moab_storage_root_id].moab_count = count
+        total_result.moab_count += count
+      end
+      group(:moab_storage_root_id).sum(:size).each do |moab_storage_root_id, size|
+        result_map[moab_storage_root_id].total_size = size || 0
+        total_result.total_size += size || 0
+      end
+      group(:moab_storage_root_id, :status).count.each do |(moab_storage_root_id, status), count|
+        count_method = "#{status}_count"
+        result_map[moab_storage_root_id].public_send("#{count_method}=", count)
+        total_count = total_result.public_send(count_method)
+        total_result.public_send("#{count_method}=", total_count + count)
+      end
+      [result_map.values, total_result]
     end
   end
 end

--- a/app/views/dashboard/moab_records/index.html.erb
+++ b/app/views/dashboard/moab_records/index.html.erb
@@ -1,0 +1,61 @@
+<div class="container mt-4">
+  <h1>Files in Moabs on Local Storage</h1>
+
+  <h2 class="mt-5">MoabRecords by MoabStorageRoot</h2>
+  <table class="table" id="moabrecords-by-moabstorageroot-table">
+    <thead>
+      <tr>
+        <th scope="col">Storage root</th>
+        <th scope="col">Storage location</th>
+        <th scope="col">Total size</th>
+        <th scope="col">Moab count</th>
+        <th scope="col">ok</th>
+        <th scope="col">invalid_moab</th>
+        <th scope="col">invalid_checksum</th>
+        <th scope="col">moab_on_storage_not_found</th>
+        <th scope="col">unexpected_version_on_storage</th>
+        <th scope="col">validity_unknown</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @results.each do |result| %>
+        <tr>
+          <th scope="row"><%= result.moab_storage_root.name %></th>
+          <td><%= result.moab_storage_root.storage_location %></td>
+          <td><%= number_to_human_size(result.total_size) %></td>
+          <td><%= number_with_delimiter(result.moab_count) %></td>
+          <td><%= number_with_delimiter(result.ok_count) %></td>
+          <td><%= number_with_delimiter(result.invalid_moab_count) %></td>
+          <td><%= number_with_delimiter(result.invalid_checksum_count) %></td>
+          <td><%= number_with_delimiter(result.moab_on_storage_not_found_count) %></td>
+          <td><%= number_with_delimiter(result.unexpected_version_on_storage_count) %></td>
+          <td><%= number_with_delimiter(result.validity_unknown_count) %></td>
+        </tr>
+      <% end %>
+      <tr class="fw-bold">
+        <th scope="row" colspan="2">TOTAL</th>
+        <td><%= number_to_human_size(@total_result.total_size) %></td>
+        <td><%= number_with_delimiter(@total_result.moab_count) %></td>
+        <td><%= number_with_delimiter(@total_result.ok_count) %></td>
+        <td><%= number_with_delimiter(@total_result.invalid_moab_count) %></td>
+        <td><%= number_with_delimiter(@total_result.invalid_checksum_count) %></td>
+        <td><%= number_with_delimiter(@total_result.moab_on_storage_not_found_count) %></td>
+        <td><%= number_with_delimiter(@total_result.unexpected_version_on_storage_count) %></td>
+        <td><%= number_with_delimiter(@total_result.validity_unknown_count) %></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <hr class="my-5">
+
+  <h2>Versions</h2>
+
+  <table class="table" id="versions-table">
+    <tbody>
+      <tr>
+        <th scope="row">Max version</th>
+        <td><%= number_with_delimiter(MoabRecord.maximum(:version)) %></td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:12
+    image: postgres:16
     ports:
       - 5432:5432
     environment:

--- a/spec/system/dashboard/show_moab_records_overview_spec.rb
+++ b/spec/system/dashboard/show_moab_records_overview_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show MoabRecords overview' do
+  let(:moab_storage_root1) { create(:moab_storage_root) }
+  let(:moab_storage_root2) { create(:moab_storage_root) }
+
+  before do
+    create(:moab_record, moab_storage_root: moab_storage_root1, status: 'ok', size: 100, version: 66)
+    create_list(:moab_record, 2, moab_storage_root: moab_storage_root1, status: 'invalid_moab', size: 101)
+    create_list(:moab_record, 3, moab_storage_root: moab_storage_root1, status: 'invalid_checksum', size: 102)
+    create_list(:moab_record, 4, moab_storage_root: moab_storage_root1, status: 'moab_on_storage_not_found', size: 103)
+    create_list(:moab_record, 5, moab_storage_root: moab_storage_root1, status: 'unexpected_version_on_storage', size: 104)
+    create_list(:moab_record, 6, moab_storage_root: moab_storage_root1, status: 'validity_unknown', size: 105)
+    create_list(:moab_record, 7, moab_storage_root: moab_storage_root2, status: 'ok', size: 200)
+  end
+
+  it 'shows the MoabRecords overview page' do
+    visit dashboard_moab_records_path
+
+    expect(page).to have_css('h1', text: 'Files in Moabs on Local Storage')
+
+    within('table#moabrecords-by-moabstorageroot-table tbody') do
+      row = page.all('tr').find { |r| r.has_css?('th', text: moab_storage_root1.name) }
+      within(row) do
+        expect(page).to have_css('td:nth-of-type(1)', text: moab_storage_root1.storage_location)
+        expect(page).to have_css('td:nth-of-type(2)', text: '2.12 KB')
+        expect(page).to have_css('td:nth-of-type(3)', text: '21')
+        expect(page).to have_css('td:nth-of-type(4)', text: '1')
+        expect(page).to have_css('td:nth-of-type(5)', text: '2')
+        expect(page).to have_css('td:nth-of-type(6)', text: '3')
+        expect(page).to have_css('td:nth-of-type(7)', text: '4')
+        expect(page).to have_css('td:nth-of-type(8)', text: '5')
+        expect(page).to have_css('td:nth-of-type(9)', text: '6')
+      end
+
+      within('tr:last-of-type') do
+        expect(page).to have_css('th', text: 'TOTAL')
+        expect(page).to have_css('td:nth-of-type(1)', text: '3.49 KB')
+        expect(page).to have_css('td:nth-of-type(2)', text: '28')
+        expect(page).to have_css('td:nth-of-type(3)', text: '8')
+        expect(page).to have_css('td:nth-of-type(4)', text: '2')
+        expect(page).to have_css('td:nth-of-type(5)', text: '3')
+        expect(page).to have_css('td:nth-of-type(6)', text: '4')
+        expect(page).to have_css('td:nth-of-type(7)', text: '5')
+        expect(page).to have_css('td:nth-of-type(8)', text: '6')
+      end
+    end
+
+    within('table#versions-table tbody') do
+      within('tr:nth-of-type(1)') do
+        expect(page).to have_css('th', text: 'Max version')
+        expect(page).to have_css('td', text: '66')
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #2550

# Why was this change made? 🤔




# How was this change tested? 🤨

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



