### PR TITLE
Prevent replication when MoabRecord is not OK

### DIFF
--- a/app/services/replication/replicate_version_service.rb
+++ b/app/services/replication/replicate_version_service.rb
@@ -17,6 +17,9 @@ module Replication
       # Skip if there are no created or incomplete ZippedMoabVersion for the version
       return unless zipped_moab_versions.created.exists? || zipped_moab_versions.incomplete.exists?
 
+      # Skip if the MoabRecord is not ok
+      return unless preserved_object.moab_record.ok?
+
       # If there is a zip, makes sure it is complete.
       # If it is not complete or not present, creates it.
       create_zip_if_necessary


### PR DESCRIPTION
closes #2532

# Why was this change made? 🤔
Do not want to replication a broken moab.

# How was this change tested? 🤨
Unit

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



