### PR TITLE
Cleanup zip files when zipping fails.

### DIFF
--- a/spec/models/replication/druid_version_zip_spec.rb
+++ b/spec/models/replication/druid_version_zip_spec.rb
@@ -133,12 +133,6 @@ describe Replication::DruidVersionZip do
         expect(dvz.parts_and_checksums_paths).to be_empty
       end
 
-      it 'handles errors from zip cleanup gracefully and includes cleanup error messages in the overall message' do
-        cleanup_err_msg = "Errno::EACCES: Permission denied - No delete for you - #{dvz.file_path}"
-        allow(File).to receive(:delete).with(Pathname.new(dvz.file_path)).and_raise(Errno::EACCES, cleanup_err_msg)
-        expect { dvz.create_zip! }.to raise_error(RuntimeError, /#{cleanup_err_msg}/m)
-      end
-
       it 'does not interfere with zip files created for other versions' do
         dvz_v2 = described_class.new(druid, version - 1, 'spec/fixtures/storage_root01/sdr2objects')
         dvz_v2.create_zip!


### PR DESCRIPTION
closes #2492

# Why was this change made? 🤔
Don't fill up temp space.

# How was this change tested? 🤨
Unit

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



