### PR TITLE
Adds dashboard page for ZippedMoabRecords

### DIFF
--- a/app/controllers/dashboard/zipped_moab_versions_controller.rb
+++ b/app/controllers/dashboard/zipped_moab_versions_controller.rb
@@ -3,6 +3,10 @@
 module Dashboard
   # Controller for listing ZippedMoabVersions in the dashboard
   class ZippedMoabVersionsController < BaseController
+    def index
+      @results, @total_result = ZippedMoabVersion.zipped_moab_versions_by_zip_endpoint
+    end
+
     def with_errors
       @zipped_moab_versions = ZippedMoabVersion.with_errors.eager_load(:preserved_object).order(:status_updated_at).page(params[:page])
     end

--- a/app/models/concerns/zipped_moab_version_calculations.rb
+++ b/app/models/concerns/zipped_moab_version_calculations.rb
@@ -8,6 +8,24 @@ module ZippedMoabVersionCalculations
 
   STUCK_STATUSES = %w[created incomplete].freeze
 
+  ZippedMoabVersionByZipEndpointResult = Struct.new('ZippedMoabVersionByZipEndpointResult',
+                                                    :zip_endpoint,
+                                                    :zipped_moab_version_count,
+                                                    :ok_count,
+                                                    :failed_count,
+                                                    :created_count,
+                                                    :incomplete_count,
+                                                    keyword_init: true) do
+    def initialize(**kwargs)
+      super
+      self.zipped_moab_version_count ||= 0
+      self.ok_count ||= 0
+      self.failed_count ||= 0
+      self.created_count ||= 0
+      self.incomplete_count ||= 0
+    end
+  end
+
   included do
     # @return [ActiveRecord::Relation<ZippedMoabVersion>] ZippedMoabVersions with failed status
     scope :with_errors, -> { where(status: 'failed').annotate(caller) }
@@ -20,7 +38,7 @@ module ZippedMoabVersionCalculations
     }
   end
 
-  class_methods do
+  class_methods do # rubocop:disable Metrics/BlockLength
     # @return [Integer] count of ZippedMoabVersions with status of created
     def created_count
       where(status: 'created')
@@ -38,6 +56,29 @@ module ZippedMoabVersionCalculations
     # @return [Integer] count of missing ZippedMoabVersions
     def missing_count
       (PreservedObject.sum(:current_version) * ZipEndpoint.count) - count
+    end
+
+    # @return [Array<ZippedMoabVersionByZipEndpointResult>, ZippedMoabVersionByZipEndpointResult] aggregation of ZippedMoabVersions by ZipEndpoint
+    #   and a total aggregation
+    def zipped_moab_versions_by_zip_endpoint # rubocop:disable Metrics/AbcSize
+      result_map = {}
+      total_result = ZippedMoabVersionByZipEndpointResult.new(zipped_moab_version_count: 0)
+      ZipEndpoint.find_each do |zip_endpoint|
+        result_map[zip_endpoint.id] = ZippedMoabVersionByZipEndpointResult.new(
+          zip_endpoint: zip_endpoint
+        )
+      end
+      group(:zip_endpoint_id).count.each do |zip_endpoint_id, count|
+        result_map[zip_endpoint_id].zipped_moab_version_count = count
+        total_result.zipped_moab_version_count += count
+      end
+      group(:zip_endpoint_id, :status).count.each do |(zip_endpoint_id, status), count|
+        count_method = "#{status}_count"
+        result_map[zip_endpoint_id].public_send("#{count_method}=", count)
+        total_count = total_result.public_send(count_method)
+        total_result.public_send("#{count_method}=", total_count + count)
+      end
+      [result_map.values, total_result]
     end
   end
 end

--- a/app/views/dashboard/zipped_moab_versions/index.html.erb
+++ b/app/views/dashboard/zipped_moab_versions/index.html.erb
@@ -1,0 +1,37 @@
+<div class="container mt-4">
+  <h1>Replication of zip part files to cloud endpoints</h1>
+
+  <h2 class="mt-5">ZippedMoabVersions by ZipEndpoint</h2>
+  <table class="table" id="zippedmoabversions-by-zipendpoint-table">
+    <thead>
+      <tr>
+        <th scope="col">Endpoint</th>
+        <th scope="col">ZippedMoabVersion count</th>
+        <th scope="col">ok</th>
+        <th scope="col">failed</th>
+        <th scope="col">created</th>
+        <th scope="col">incomplete</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @results.each do |result| %>
+        <tr>
+          <th scope="row"><%= result.zip_endpoint.endpoint_name %></th>
+          <td><%= number_with_delimiter(result.zipped_moab_version_count) %></td>
+          <td><%= number_with_delimiter(result.ok_count) %></td>
+          <td><%= number_with_delimiter(result.failed_count) %></td>
+          <td><%= number_with_delimiter(result.created_count) %></td>
+          <td><%= number_with_delimiter(result.incomplete_count) %></td>
+        </tr>
+      <% end %>
+      <tr class="fw-bold">
+        <th scope="row">TOTAL</th>
+        <td><%= number_with_delimiter(@total_result.zipped_moab_version_count) %></td>
+        <td><%= number_with_delimiter(@total_result.ok_count) %></td>
+        <td><%= number_with_delimiter(@total_result.failed_count) %></td>
+        <td><%= number_with_delimiter(@total_result.created_count) %></td>
+        <td><%= number_with_delimiter(@total_result.incomplete_count) %></td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/spec/models/concerns/zipped_moab_version_calculations_spec.rb
+++ b/spec/models/concerns/zipped_moab_version_calculations_spec.rb
@@ -67,4 +67,34 @@ RSpec.describe ZippedMoabVersionCalculations do
       expect(ZippedMoabVersion.missing_count).to eq(12)
     end
   end
+
+  describe '.zipped_moab_versions_by_zip_endpoint' do
+    let(:zip_endpoint1) { create(:zip_endpoint) }
+    let(:zip_endpoint2) { create(:zip_endpoint) }
+
+    before do
+      create_list(:zipped_moab_version, 1, zip_endpoint: zip_endpoint1, status: :ok)
+      create_list(:zipped_moab_version, 2, zip_endpoint: zip_endpoint1, status: :failed)
+      create_list(:zipped_moab_version, 3, zip_endpoint: zip_endpoint1, status: :created)
+      create_list(:zipped_moab_version, 4, zip_endpoint: zip_endpoint1, status: :incomplete)
+      create_list(:zipped_moab_version, 5, zip_endpoint: zip_endpoint2, status: :ok)
+    end
+
+    it 'returns the aggregation of ZippedMoabVersions by ZipEndpoint and a total aggregation' do
+      results, total_result = ZippedMoabVersion.zipped_moab_versions_by_zip_endpoint
+
+      result1 = results.find { |r| r.zip_endpoint == zip_endpoint1 }
+      expect(result1.zipped_moab_version_count).to eq(10)
+      expect(result1.ok_count).to eq(1)
+      expect(result1.failed_count).to eq(2)
+      expect(result1.created_count).to eq(3)
+      expect(result1.incomplete_count).to eq(4)
+
+      expect(total_result.zipped_moab_version_count).to eq(15)
+      expect(total_result.ok_count).to eq(6)
+      expect(total_result.failed_count).to eq(2)
+      expect(total_result.created_count).to eq(3)
+      expect(total_result.incomplete_count).to eq(4)
+    end
+  end
 end

--- a/spec/system/dashboard/show_zipped_moab_versions_overview_spec.rb
+++ b/spec/system/dashboard/show_zipped_moab_versions_overview_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show ZippedMoabVersions overview' do
+  let(:zip_endpoint1) { create(:zip_endpoint) }
+  let(:zip_endpoint2) { create(:zip_endpoint) }
+
+  before do
+    create_list(:zipped_moab_version, 1, zip_endpoint: zip_endpoint1, status: :ok)
+    create_list(:zipped_moab_version, 2, zip_endpoint: zip_endpoint1, status: :failed)
+    create_list(:zipped_moab_version, 3, zip_endpoint: zip_endpoint1, status: :created)
+    create_list(:zipped_moab_version, 4, zip_endpoint: zip_endpoint1, status: :incomplete)
+    create_list(:zipped_moab_version, 5, zip_endpoint: zip_endpoint2, status: :ok)
+  end
+
+  it 'shows the ZippedMoabVersions overview page' do
+    visit dashboard_zipped_moab_versions_path
+
+    expect(page).to have_css('h1', text: 'Replication of zip part files to cloud endpoints')
+
+    within('table#zippedmoabversions-by-zipendpoint-table tbody') do
+      row = page.all('tr').find { |r| r.has_css?('th', text: zip_endpoint1.endpoint_name) }
+      within(row) do
+        expect(page).to have_css('td:nth-of-type(1)', text: '10')
+        expect(page).to have_css('td:nth-of-type(2)', text: '1')
+        expect(page).to have_css('td:nth-of-type(3)', text: '2')
+        expect(page).to have_css('td:nth-of-type(4)', text: '3')
+        expect(page).to have_css('td:nth-of-type(5)', text: '4')
+      end
+
+      within('tr:last-of-type') do
+        expect(page).to have_css('th', text: 'TOTAL')
+        expect(page).to have_css('td:nth-of-type(1)', text: '15')
+        expect(page).to have_css('td:nth-of-type(2)', text: '6')
+        expect(page).to have_css('td:nth-of-type(3)', text: '2')
+        expect(page).to have_css('td:nth-of-type(4)', text: '3')
+        expect(page).to have_css('td:nth-of-type(5)', text: '4')
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #2551

# Why was this change made? 🤔




# How was this change tested? 🤨

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



