### PR TITLE
Refactor purge zip rake task.

### DIFF
--- a/app/models/zipped_moab_version.rb
+++ b/app/models/zipped_moab_version.rb
@@ -24,6 +24,8 @@ class ZippedMoabVersion < ApplicationRecord
     'failed' => 3
   }
 
+  delegate :druid, to: :preserved_object
+
   scope :by_druid, lambda { |druid|
     joins(:preserved_object).where(preserved_objects: { druid: druid })
   }

--- a/app/services/replication/provider_factory.rb
+++ b/app/services/replication/provider_factory.rb
@@ -7,8 +7,13 @@ module Replication
       new(...).create
     end
 
-    def initialize(zip_endpoint:)
+    # @param zip_endpoint [ZipEndpoint] the ZipEndpoint to use for configuration
+    # @param access_key_id [String, nil] optional access key override
+    # @param secret_access_key [String, nil] optional secret access key override
+    def initialize(zip_endpoint:, access_key_id: nil, secret_access_key: nil)
       @zip_endpoint = zip_endpoint
+      @access_key_id = access_key_id
+      @secret_access_key = secret_access_key
     end
 
     # @return [Replication::AwsProvider, Replication::IbmProvider, Replication::GcpProvider]
@@ -17,14 +22,14 @@ module Replication
 
       provider_class.new(
         region: endpoint_settings.region,
-        access_key_id: endpoint_settings.access_key_id,
-        secret_access_key: endpoint_settings.secret_access_key
+        access_key_id: access_key_id || endpoint_settings.access_key_id,
+        secret_access_key: secret_access_key || endpoint_settings.secret_access_key
       )
     end
 
     private
 
-    attr_reader :zip_endpoint
+    attr_reader :zip_endpoint, :access_key_id, :secret_access_key
 
     def endpoint_settings
       @endpoint_settings ||= Settings.zip_endpoints[zip_endpoint.endpoint_name]

--- a/app/services/results.rb
+++ b/app/services/results.rb
@@ -98,7 +98,7 @@ class Results # rubocop:disable Metrics/ClassLength
                                     'Sum of ZippedMoabVersion child part sizes (%{total_part_size}) is less than what is in ' \
                                     'the Moab: %{moab_version_size}',
     ZIP_PARTS_NOT_ALL_REPLICATED => '%{version} on %{endpoint_name}: not all ' \
-                                    'ZippedMoabVersion parts are replicated yet: %{unreplicated_parts_list}',
+                                    'ZippedMoabVersion parts are replicated yet',
     ZIP_PARTS_NOT_CREATED => '%{version} on %{endpoint_name}: no zip_parts exist yet for this ZippedMoabVersion'
   }.freeze
 

--- a/spec/services/replication/provider_factory_spec.rb
+++ b/spec/services/replication/provider_factory_spec.rb
@@ -14,6 +14,22 @@ RSpec.describe Replication::ProviderFactory do
     end
   end
 
+  context 'when access keys are overridden' do
+    subject(:provider) do
+      described_class.create(zip_endpoint:, access_key_id:, secret_access_key:)
+    end
+
+    let(:zip_endpoint) { instance_double(ZipEndpoint, endpoint_name: 'aws_s3_west_2') }
+    let(:access_key_id) { 'OVERRIDDEN_ACCESS_KEY_ID' }
+    let(:secret_access_key) { 'OVERRIDDEN_SECRET_ACCESS_KEY' }
+
+    it 'creates the provider with the overridden keys' do
+      expect(provider).to be_an_instance_of(Replication::AwsProvider)
+      expect(provider.client.config.credentials.access_key_id).to eq(access_key_id)
+      expect(provider.client.config.credentials.secret_access_key).to eq(secret_access_key)
+    end
+  end
+
   context 'when the endpoint configuration is missing' do
     let(:zip_endpoint) { instance_double(ZipEndpoint, endpoint_name: 'non_existent_endpoint') }
 


### PR DESCRIPTION
closes #2558

# Why was this change made? 🤔
Update for replication refactor.



# How was this change tested? 🤨
Dry run on QA.

⚠ If this change has cross service impact, or if it changes code used internally for cloud replication, **_run [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) against stage, as it tests preservation (including cloud replication)_**, and/or test manually in stage environment, in addition to specs.

The main classes relevant to replication are `ZipmakerJob`, `DeliveryDispatcherJob`, `*DeliveryJob`, `ResultsRecorderJob`, and `DruidVersionZip`; [see here for overview diagram of replication pipeline](https://github.com/sul-dlss/preservation_catalog/wiki/Replication-Flow).

⚠ Run any integration tests that exercise other services impacted by the change, if any.

⚠ If the changes impact JS, Bootstrap, Rails, or any other UI related plumbing: deploy to stage or qa, visit the `/dashboard` URL, and confirm that the dashboard still functions correctly. Some sections may take a minute to load, as they are running somewhat expensive queries.


# Does your change introduce accessibility violations? 🩺

⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail.



