### PR TITLE
Rename deploy target for QA worker

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -2,7 +2,7 @@
 
 server 'preservation-catalog-web-qa-01.stanford.edu', user: 'pres', roles: %w[app web]
 server 'preservation-catalog-web-qa-02.stanford.edu', user: 'pres', roles: %w[app web]
-server 'preservation-catalog-qa-02.stanford.edu', user: 'pres', roles: %w[app worker db queue_populator cache_cleaner]
+server 'preservation-catalog-worker-qa-01.stanford.edu', user: 'pres', roles: %w[app worker db queue_populator cache_cleaner]
 
 set :rails_env, 'production'
 set :bundle_without, 'deploy test'


### PR DESCRIPTION
# Why was this change made?

Part of #1885 


# How was this change tested?

⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
