### PR TITLE
Retry checksum validation job up to 5x over ~10m

### DIFF
--- a/app/jobs/audit/checksum_validation_job.rb
+++ b/app/jobs/audit/checksum_validation_job.rb
@@ -4,17 +4,32 @@ module Audit
   # Confirm checksum for one Moab on storage and update MoabRecord in database
   # @see Audit::ChecksumValidationService
   class ChecksumValidationJob < ApplicationJob
+    include UniqueJob
+
     queue_as :checksum_validation
 
     before_enqueue do |job|
       raise ArgumentError, 'MoabRecord param required' unless job.arguments.first.is_a?(MoabRecord)
     end
 
-    include UniqueJob
+    RETRIES = 5
 
+    # Retriable jobs should retry when any exception is raised. Retry
+    # `RETRIES` times, and use exponential backoff so that the tries are
+    # spread across a span of roughly ten minutes.
+    #
+    # If the number of attempts exceeds `RETRIES`, raise the exception.
+    #
     # @param [MoabRecord] moab_record object to checksum
     def perform(moab_record)
+      tries ||= 0
       Audit::ChecksumValidationService.new(moab_record).validate_checksums
+    rescue StandardError
+      if (tries += 1) <= RETRIES
+        sleep (tries**4) + (Kernel.rand * (tries**3)) + 2
+        retry
+      end
+      raise
     end
   end
 end


### PR DESCRIPTION
# Why was this change made?

Fixes #2557

Takes inspiration from https://github.com/sul-dlss/preservation_robots/commit/831bb24a2ab1f54bfe09b30fc7f571fc501726c8 and https://github.com/sul-dlss/heracles-etd/blob/main/app/jobs/retriable_job.rb


# How was this change tested?

CI
