### PR TITLE
Increase unique job lock timeout for ReplicationJob.

### DIFF
--- a/app/jobs/concerns/unique_job.rb
+++ b/app/jobs/concerns/unique_job.rb
@@ -62,7 +62,7 @@ module UniqueJob
     def lock_timeout
       # 1 hour is a reasonable default, because most jobs in this app will
       # cause only minor trouble if re-executed too aggressively.
-      3600
+      1.hour.to_i
     end
 
     # @return [String] the key for locking this job/payload combination, e.g. 'lock:MySpecificJob-bt821jk7040;1'

--- a/app/jobs/replication_job.rb
+++ b/app/jobs/replication_job.rb
@@ -5,6 +5,11 @@ class ReplicationJob < ApplicationJob
   queue_as :replication
   include UniqueJob
 
+  def lock_timeout
+    # Between the zipping and the replication, this can take a while.
+    3.days.to_i
+  end
+
   def perform(preserved_object)
     preserved_object.populate_zipped_moab_versions!
 


### PR DESCRIPTION
# Why was this change made?
Replication can take a long time, so don't want to release the hold.


# How was this change tested?


⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
