### PR TITLE
Remove unnecessary checking of argument passed to jobs.

### DIFF
--- a/app/jobs/audit/catalog_to_moab_job.rb
+++ b/app/jobs/audit/catalog_to_moab_job.rb
@@ -6,10 +6,6 @@ module Audit
   class CatalogToMoabJob < ApplicationJob
     queue_as :c2m
 
-    before_enqueue do |job|
-      raise ArgumentError, 'MoabRecord param required' unless job.arguments.first.is_a?(MoabRecord)
-    end
-
     include UniqueJob
 
     # @param [MoabRecord] moab_record object to C2M check

--- a/app/jobs/audit/checksum_validation_job.rb
+++ b/app/jobs/audit/checksum_validation_job.rb
@@ -8,10 +8,6 @@ module Audit
 
     queue_as :checksum_validation
 
-    before_enqueue do |job|
-      raise ArgumentError, 'MoabRecord param required' unless job.arguments.first.is_a?(MoabRecord)
-    end
-
     RETRIES = 5
 
     # Retriable jobs should retry when any exception is raised. Retry

--- a/app/jobs/audit/moab_to_catalog_job.rb
+++ b/app/jobs/audit/moab_to_catalog_job.rb
@@ -6,10 +6,6 @@ module Audit
   class MoabToCatalogJob < ApplicationJob
     queue_as :m2c
 
-    before_enqueue do |job|
-      raise ArgumentError, 'MoabStorageRoot param required' unless job.arguments.first.is_a?(MoabStorageRoot)
-    end
-
     include UniqueJob
 
     # @param [MoabStorageRoot] root mount containing the Moab

--- a/spec/jobs/audit/checksum_validation_job_spec.rb
+++ b/spec/jobs/audit/checksum_validation_job_spec.rb
@@ -20,15 +20,6 @@ describe Audit::ChecksumValidationJob do
     end
   end
 
-  describe 'before_enqueue' do
-    before { allow(described_class).to receive(:perform_later).and_call_original } # undo rails_helper block
-
-    it 'raises on bad param' do
-      expect { described_class.perform_later(3) }.to raise_error(ArgumentError)
-      expect { described_class.perform_later }.to raise_error(ArgumentError)
-    end
-  end
-
   context 'a subclass with message(s) queued' do
     around do |example|
       old_adapter = described_class.queue_adapter


### PR DESCRIPTION
# Why was this change made?
Check isn't necessary. Code adds additional cognitive load.

# How was this change tested?

⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
