### PR TITLE
Adds help text to dashboard.

### DIFF
--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,0 +1,5 @@
+<div class="card">
+  <div class="card-body">
+    <%= content %>
+  </div>
+</div>

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class CardComponent < ViewComponent::Base
+end

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -24,11 +24,16 @@
     </tbody>
   </table>
 
+  <%= render CardComponent.new do %>
+    <p class="fw-semibold">Any errors shown above require investigation.</p>
+    <p class="mb-1"><span class="fw-medium">Stuck for MoabRecords:</span> status of <italic>validity_unknown</italic> for more than a week</p>
+    <p class="mb-1"><span class="fw-medium">Stuck for ZippedMoabVersions:</span> status of <italic>created</italic> or <italic>incomplete</italic> for more than a week</p>
+    <p>Each of the stuck statuses should be transient; if they persist, that indicates a problem.</p>
+  <% end %>
+
   <hr class="my-5">
 
   <h2>System Level Warnings</h2>
-
-  <p>Large counts for any of the following may indicate system level issues that need investigation.</p>
 
   <table class="table" id="system-warnings-table">
     <thead>
@@ -64,4 +69,10 @@
       </tr>
     </tbody>
   </table>
+
+  <%= render CardComponent.new do %>
+    <p class="fw-semibold">Large counts for any of the above may indicate system level issues that need investigation.</p>
+    <p>In normal operation, a small number of objects in these states is expected.</p>
+    <%= link_to 'Sidekiq Dashboard', sidekiq_web_path, class: 'card-link' %>
+  <% end %>
 </div>

--- a/spec/components/card_component_spec.rb
+++ b/spec/components/card_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CardComponent, type: :component do
+  let(:component) { described_class.new }
+
+  it 'renders the component with provided content' do
+    render_inline(component) do
+      'This is card content'
+    end
+
+    expect(page).to have_css('div.card div.card-body', text: 'This is card content')
+  end
+end


### PR DESCRIPTION
# Why was this change made?
So devs can understand the dashboard better.

# How was this change tested?

⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
