### PR TITLE
Reload parent resources so they can be deleted

### DIFF
--- a/lib/tasks/decommission_endpoint.rake
+++ b/lib/tasks/decommission_endpoint.rake
@@ -36,11 +36,13 @@ task :decommission_endpoint, [:endpoint_name, :access_key, :secret_access_key, :
         zip_part.destroy!
       end
     end
+    zipped_moab_version.reload
     zipped_moab_version.destroy! unless dry_run
   end
 
   unless dry_run
     puts "Deleting ZipEndpoint: #{args[:endpoint_name]}"
+    zip_endpoint.reload
     zip_endpoint.destroy!
   end
 end


### PR DESCRIPTION
# Why was this change made?

Simple fixup, these reloads were required to delete parent resources.


# How was this change tested?

⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
