### PR TITLE
Remove unused total_size_of_moab_version method

### DIFF
--- a/app/models/preserved_object.rb
+++ b/app/models/preserved_object.rb
@@ -46,12 +46,6 @@ class PreservedObject < ApplicationRecord
     Audit::ReplicationAuditJob.perform_later(self)
   end
 
-  def total_size_of_moab_version(version)
-    return 0 unless moab_record
-
-    Replication::DruidVersionZip.new(druid, version, moab_record.moab_storage_root.storage_location).moab_version_size
-  end
-
   # Number of PreservedObjects to audit on a daily basis.
   def self.daily_check_count
     PreservedObject.count / (Settings.preservation_policy.fixity_ttl / (60 * 60 * 24))

--- a/spec/models/preserved_object_spec.rb
+++ b/spec/models/preserved_object_spec.rb
@@ -102,39 +102,4 @@ RSpec.describe PreservedObject do
       expect(described_class.daily_check_count).to eq 11
     end
   end
-
-  describe '#total_size_of_moab_version' do
-    let(:druid) { 'bz514sm9647' }
-    let(:preserved_object) { create(:preserved_object, druid: druid, current_version: current_version) }
-    let(:current_version) { 3 }
-
-    context 'when MoabRecord is nil' do
-      it 'returns 0' do
-        expect(preserved_object.total_size_of_moab_version(current_version)).to eq(0)
-      end
-    end
-
-    context 'when MoabRecord exists' do
-      let!(:moab_rec1) { create(:moab_record, preserved_object: preserved_object, version: current_version, moab_storage_root: msr) } # rubocop:disable RSpec/LetSetup
-
-      context 'when moab version path does not exist' do
-        let(:msr) { create(:moab_storage_root) }
-
-        it 'raises a runtime error' do
-          expect { preserved_object.total_size_of_moab_version(current_version) }.to raise_error(
-            RuntimeError,
-            /Moab version does not exist:/
-          )
-        end
-      end
-
-      context 'when moab version exists' do
-        let(:msr) { MoabStorageRoot.find_by!(storage_location: 'spec/fixtures/storage_root01/sdr2objects') }
-
-        it 'returns the sum of the file sizes' do
-          expect(preserved_object.total_size_of_moab_version(current_version)).to eq(37_989)
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
# Why was this change made?

A bit of housekeeping.


# How was this change tested?

⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
