### PR TITLE
Rename stage worker server

### DIFF
--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,7 +2,7 @@
 
 server 'preservation-catalog-web-stage-01.stanford.edu', user: 'pres', roles: %w[app web]
 server 'preservation-catalog-web-stage-02.stanford.edu', user: 'pres', roles: %w[app web]
-server 'preservation-catalog-stage-02.stanford.edu', user: 'pres', roles: %w[app db worker queue_populator cache_cleaner]
+server 'preservation-catalog-worker-stage-01.stanford.edu', user: 'pres', roles: %w[app db worker queue_populator cache_cleaner]
 
 set :rails_env, 'production'
 set :bundle_without, 'deploy test'


### PR DESCRIPTION
# Why was this change made?

Renames the stage worker server as part of #1885 


# How was this change tested?

⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
