### PR TITLE
Rename prod worker boxes

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,9 +2,9 @@
 
 server 'preservation-catalog-web-prod-01.stanford.edu', user: 'pres', roles: %w[app web]
 server 'preservation-catalog-web-prod-02.stanford.edu', user: 'pres', roles: %w[app web]
-server 'preservation-catalog-prod-02.stanford.edu', user: 'pres', roles: %w[app db worker queue_populator]
-server 'preservation-catalog-prod-03.stanford.edu', user: 'pres', roles: %w[app worker]
-server 'preservation-catalog-prod-04.stanford.edu', user: 'pres', roles: %w[app worker cache_cleaner]
+server 'preservation-catalog-worker-prod-01.stanford.edu', user: 'pres', roles: %w[app db worker queue_populator]
+server 'preservation-catalog-worker-prod-02.stanford.edu', user: 'pres', roles: %w[app worker]
+server 'preservation-catalog-worker-prod-03.stanford.edu', user: 'pres', roles: %w[app worker cache_cleaner]
 
 set :rails_env, 'production'
 set :bundle_without, 'deploy test'


### PR DESCRIPTION
# Why was this change made?

Fixes #1885 


# How was this change tested?

⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
