### PR TITLE
Remove references to IBM cloud storage endpoint

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -21,12 +21,6 @@ zip_endpoints:
     storage_location: 'sul-sdr-aws-us-west-2-test'
     access_key_id: 'overridden-by-env-var-in-ci'
     secret_access_key: 'overridden-by-env-var-in-ci'
-  ibm_us_south:
-    region: 'us-south'
-    endpoint_node: 'https://s3.us-south.cloud-object-storage.appdomain.cloud'
-    storage_location: 'sul-sdr-ibm-us-south-1-test'
-    access_key_id: 'overridden-by-env-var-in-ci'
-    secret_access_key: 'overridden-by-env-var-in-ci'
   gcp_s3_south_1:
     region: 'us-south1'
     endpoint_node: 'https://storage.googleapis.com'

--- a/spec/models/zip_endpoint_spec.rb
+++ b/spec/models/zip_endpoint_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ZipEndpoint do
       # run it a second time
       expect { described_class.seed_from_config }
         .not_to change { described_class.pluck(:endpoint_name).sort }
-        .from(%w[aws_s3_west_2 gcp_s3_south_1 ibm_us_south zip-endpoint])
+        .from(%w[aws_s3_west_2 gcp_s3_south_1 zip-endpoint])
     end
 
     it 'adds new ZipEndpoint record if there are new Settings.zip_endpoint key names' do
@@ -52,7 +52,7 @@ RSpec.describe ZipEndpoint do
 
       # run it a second time
       described_class.seed_from_config
-      expected_ep_names = %w[aws_s3_west_2 fixture_archiveTest gcp_s3_south_1 ibm_us_south zip-endpoint]
+      expected_ep_names = %w[aws_s3_west_2 fixture_archiveTest gcp_s3_south_1 zip-endpoint]
       expect(described_class.pluck(:endpoint_name).sort).to eq expected_ep_names
     end
   end


### PR DESCRIPTION
# Why was this change made?

Fixes #2586 
Fixes #2587 


# How was this change tested?

⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
