### PR TITLE
decommission_endpoint becomes decommission_endpoint_in_db, and defaults to doing the DB removal in a piecemeal fashion

### DIFF
--- a/lib/tasks/decommission_endpoint.rake
+++ b/lib/tasks/decommission_endpoint.rake
@@ -14,8 +14,8 @@ task :decommission_endpoint_in_db, [:endpoint_name, :dry_run, :batch_size, :limi
   args.with_defaults(dry_run: 'true', batch_size: 50_000, limit: 50_000)
   endpoint_name = args[:endpoint_name]
   dry_run = args[:dry_run] != 'false'
-  limit = args[:limit]
-  batch_size = args[:batch_size]
+  limit = args[:limit].to_i
+  batch_size = args[:batch_size].to_i
 
   logger.info "===== #{task.name}: interpreted args: #{{ endpoint_name:, dry_run:, batch_size:, limit: }}"
   zip_endpoint = ZipEndpoint.find_by(endpoint_name:)

--- a/lib/tasks/decommission_endpoint.rake
+++ b/lib/tasks/decommission_endpoint.rake
@@ -24,6 +24,16 @@ task :decommission_endpoint_in_db, [:endpoint_name, :dry_run, :batch_size, :limi
     exit 1
   end
 
+  endpoint_stats =
+    ZipPart.joins(
+      zipped_moab_version: [:zip_endpoint]
+    ).group(
+      :endpoint_name
+    ).pluck(
+      :endpoint_name, 'COUNT(DISTINCT(zipped_moab_versions.id))', 'COUNT(DISTINCT(zip_parts.id))'
+    )
+  logger.info "endpoint stats (name, zipped_moab_versions count, zip_parts count): #{endpoint_stats}"
+
   unless dry_run
     puts 'Are you sure you want to proceed? (y/n)'
     answer = $stdin.gets.chomp.downcase
@@ -53,9 +63,21 @@ task :decommission_endpoint_in_db, [:endpoint_name, :dry_run, :batch_size, :limi
     end
   end
 
-  # if it's not a dry run and all the zipped_moab_versions are gone, remove the endpoint
-  unless dry_run || zip_endpoint.reload.zipped_moab_versions.exist?
+  # only remove the endpoint if it's not a dry run and all its zipped_moab_versions are gone
+  if dry_run || zip_endpoint.reload.zipped_moab_versions.exist?
+    logger.info "dry run, or zipped_moab_versions remain on #{endpoint_name}, cannot delete zip_endpoints row"
+  else
     logger.info "Deleting ZipEndpoint: #{endpoint_name}"
     zip_endpoint.destroy!
   end
+
+  endpoint_stats =
+    ZipPart.joins(
+      zipped_moab_version: [:zip_endpoint]
+    ).group(
+      :endpoint_name
+    ).pluck(
+      :endpoint_name, 'COUNT(DISTINCT(zipped_moab_versions.id))', 'COUNT(DISTINCT(zip_parts.id))'
+    )
+  logger.info "endpoint stats (name, zipped_moab_versions count, zip_parts count): #{endpoint_stats}"
 end

--- a/lib/tasks/decommission_endpoint.rake
+++ b/lib/tasks/decommission_endpoint.rake
@@ -64,7 +64,7 @@ task :decommission_endpoint_in_db, [:endpoint_name, :dry_run, :batch_size, :limi
   end
 
   # only remove the endpoint if it's not a dry run and all its zipped_moab_versions are gone
-  if dry_run || zip_endpoint.reload.zipped_moab_versions.exist?
+  if dry_run || zip_endpoint.reload.zipped_moab_versions.exists?
     logger.info "dry run, or zipped_moab_versions remain on #{endpoint_name}, cannot delete zip_endpoints row"
   else
     logger.info "Deleting ZipEndpoint: #{endpoint_name}"

--- a/lib/tasks/decommission_endpoint.rake
+++ b/lib/tasks/decommission_endpoint.rake
@@ -5,15 +5,22 @@ desc 'Delete ZippedMoabVersions and ZipParts in batches, delete associated ZipEn
 # Ops will purge the contents of the S3 bucket; or, can provide a time-limited access key and secret access key for
 # the endpoint, in which case it would also be necessary to obtain or generate a list of S3 keys (druid tree paths) for
 # which to delete S3 content.
-task :decommission_endpoint_in_db, [:endpoint_name, :dry_run, :batch_size, :limit] => :environment do |_task, args|
+task :decommission_endpoint_in_db, [:endpoint_name, :dry_run, :batch_size, :limit] => :environment do |task, args|
+  logger = ActiveSupport::BroadcastLogger.new(
+    Logger.new(Rails.root.join('log', 'zip_endpoint_decommission.log')),
+    Logger.new($stdout)
+  )
+
   args.with_defaults(dry_run: 'true', batch_size: 50_000, limit: 50_000)
+  endpoint_name = args[:endpoint_name]
   dry_run = args[:dry_run] != 'false'
   limit = args[:limit]
   batch_size = args[:batch_size]
 
-  zip_endpoint = ZipEndpoint.find_by(endpoint_name: args[:endpoint_name])
+  logger.info "===== #{task.name}: interpreted args: #{{ endpoint_name:, dry_run:, batch_size:, limit: }}"
+  zip_endpoint = ZipEndpoint.find_by(endpoint_name:)
   unless zip_endpoint
-    puts 'Could not find ZipEndpoint'
+    logger.error 'Could not find ZipEndpoint'
     exit 1
   end
 
@@ -21,21 +28,26 @@ task :decommission_endpoint_in_db, [:endpoint_name, :dry_run, :batch_size, :limi
     puts 'Are you sure you want to proceed? (y/n)'
     answer = $stdin.gets.chomp.downcase
     unless answer == 'y'
-      puts 'Quitting.'
+      logger.info 'Quitting.'
       exit
     end
   end
 
   # this should be stable from run to run, as #in_batches orders on primary key
-  zip_endpoint.zipped_moab_versions.limit(limit).in_batches(of: batch_size) do |zipped_moab_versions_relation|
+  # `use_ranges: true` prevents a giant IN clause of individual IDs: https://apidock.com/rails/ActiveRecord/Batches/in_batches
+  zip_endpoint.zipped_moab_versions.limit(limit).in_batches(of: batch_size, use_ranges: true) do |zipped_moab_versions_relation|
     zip_parts_relation = ZipPart.where(zipped_moab_version: zipped_moab_versions_relation)
     zip_info = "#{zip_parts_relation.count} zip parts for #{zipped_moab_versions_relation.count} zipped moab versions " \
-               "(zipped_moab_versions id range: #{zipped_moab_versions_relation.minimum(:id)} to #{zipped_moab_versions_relation.maxiumum(:id)})"
+               "(zipped_moab_versions id range: #{zipped_moab_versions_relation.pluck('MIN(id)')} to " \
+               "#{zipped_moab_versions_relation.pluck('MAX(id)')})"
 
+    logger.debug "zipped_moab_versions_relation.to_sql=#{zipped_moab_versions_relation.to_sql}"
+    logger.debug "zip_parts_relation.to_sql=#{zip_parts_relation.to_sql}"
     if dry_run
-      puts "[Dry run] Deleting: #{zip_info}"
+      logger.info "[Dry run] Deleting: #{zip_info}"
     else
-      puts "Deleting: #{zip_info}"
+      logger.info "Deleting: #{zip_info}"
+      # delete_all issues a single SQL delete without instantiating AR objects: https://apidock.com/rails/ActiveRecord/Relation/delete_all
       zip_parts_relation.delete_all
       zipped_moab_versions_relation.delete_all
     end
@@ -43,7 +55,7 @@ task :decommission_endpoint_in_db, [:endpoint_name, :dry_run, :batch_size, :limi
 
   # if it's not a dry run and all the zipped_moab_versions are gone, remove the endpoint
   unless dry_run || zip_endpoint.reload.zipped_moab_versions.exist?
-    puts "Deleting ZipEndpoint: #{args[:endpoint_name]}"
+    logger.info "Deleting ZipEndpoint: #{endpoint_name}"
     zip_endpoint.destroy!
   end
 end

--- a/lib/tasks/decommission_endpoint.rake
+++ b/lib/tasks/decommission_endpoint.rake
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
-desc 'Purge zips from cloud storage for decommissioned ZipEndpoint and remove ZippedMoabVersions and ZipParts'
-# For decommissioning a cloud storage endpoint
-# Ops will provide a time-limited access key and secret access key for the endpoint.
-task :decommission_endpoint, [:endpoint_name, :access_key, :secret_access_key, :dry_run] => :environment do |_task, args|
-  args.with_defaults(dry_run: 'true')
+desc 'Delete ZippedMoabVersions and ZipParts in batches, delete associated ZipEndpoint on last batch'
+# For decommissioning a cloud storage endpoint (without having to remove everything all at once).
+# Ops will purge the contents of the S3 bucket; or, can provide a time-limited access key and secret access key for
+# the endpoint, in which case it would also be necessary to obtain or generate a list of S3 keys (druid tree paths) for
+# which to delete S3 content.
+task :decommission_endpoint_in_db, [:endpoint_name, :dry_run, :batch_size, :limit] => :environment do |_task, args|
+  args.with_defaults(dry_run: 'true', batch_size: 50_000, limit: 50_000)
   dry_run = args[:dry_run] != 'false'
+  limit = args[:limit]
+  batch_size = args[:batch_size]
 
   zip_endpoint = ZipEndpoint.find_by(endpoint_name: args[:endpoint_name])
   unless zip_endpoint
@@ -22,21 +26,24 @@ task :decommission_endpoint, [:endpoint_name, :access_key, :secret_access_key, :
     end
   end
 
-  zip_endpoint.zipped_moab_versions.find_each do |zipped_moab_version|
-    zip_info = "#{zipped_moab_version.druid} (#{zipped_moab_version.version})"
+  # this should be stable from run to run, as #in_batches orders on primary key
+  zip_endpoint.zipped_moab_versions.limit(limit).in_batches(of: batch_size) do |zipped_moab_versions_relation|
+    zip_parts_relation = ZipPart.where(zipped_moab_version: zipped_moab_versions_relation)
+    zip_info = "#{zip_parts_relation.count} zip parts for #{zipped_moab_versions_relation.count} zipped moab versions " \
+               "(zipped_moab_versions id range: #{zipped_moab_versions_relation.minimum(:id)} to #{zipped_moab_versions_relation.maxiumum(:id)})"
+
     if dry_run
-      puts "Dry run deleting: #{zip_info}"
+      puts "[Dry run] Deleting: #{zip_info}"
     else
       puts "Deleting: #{zip_info}"
-      zipped_moab_version.zip_parts.destroy_all
+      zip_parts_relation.delete_all
+      zipped_moab_versions_relation.delete_all
     end
   end
 
-  unless dry_run
+  # if it's not a dry run and all the zipped_moab_versions are gone, remove the endpoint
+  unless dry_run || zip_endpoint.reload.zipped_moab_versions.exist?
     puts "Deleting ZipEndpoint: #{args[:endpoint_name]}"
-    zip_endpoint.reload
-    zip_endpoint.zipped_moab_versions.destroy_all
-    zip_endpoint.reload
     zip_endpoint.destroy!
   end
 end

--- a/lib/tasks/decommission_endpoint.rake
+++ b/lib/tasks/decommission_endpoint.rake
@@ -1,42 +1,83 @@
 # frozen_string_literal: true
 
-desc 'Purge zips from cloud storage for decommissioned ZipEndpoint and remove ZippedMoabVersions and ZipParts'
-# For decommissioning a cloud storage endpoint
-# Ops will provide a time-limited access key and secret access key for the endpoint.
-task :decommission_endpoint, [:endpoint_name, :access_key, :secret_access_key, :dry_run] => :environment do |_task, args|
-  args.with_defaults(dry_run: 'true')
-  dry_run = args[:dry_run] != 'false'
+desc 'Delete ZippedMoabVersions and ZipParts in batches, delete associated ZipEndpoint on last batch'
+# For decommissioning a cloud storage endpoint (without having to remove everything all at once).
+# Ops will purge the contents of the S3 bucket; or, can provide a time-limited access key and secret access key for
+# the endpoint, in which case it would also be necessary to obtain or generate a list of S3 keys (druid tree paths) for
+# which to delete S3 content.
+task :decommission_endpoint_in_db, [:endpoint_name, :dry_run, :batch_size, :limit] => :environment do |task, args|
+  logger = ActiveSupport::BroadcastLogger.new(
+    Logger.new(Rails.root.join('log/zip_endpoint_decommission.log')),
+    Logger.new($stdout)
+  )
 
-  zip_endpoint = ZipEndpoint.find_by(endpoint_name: args[:endpoint_name])
+  args.with_defaults(dry_run: 'true', batch_size: 50_000, limit: 50_000)
+  endpoint_name = args[:endpoint_name]
+  dry_run = args[:dry_run] != 'false'
+  limit = args[:limit].to_i
+  batch_size = args[:batch_size].to_i
+
+  logger.info "===== #{task.name}: interpreted args: #{{ endpoint_name:, dry_run:, batch_size:, limit: }}"
+  zip_endpoint = ZipEndpoint.find_by(endpoint_name:)
   unless zip_endpoint
-    puts 'Could not find ZipEndpoint'
+    logger.error 'Could not find ZipEndpoint'
     exit 1
   end
+
+  endpoint_stats =
+    ZipPart.joins(
+      zipped_moab_version: [:zip_endpoint]
+    ).group(
+      :endpoint_name
+    ).pluck(
+      :endpoint_name, 'COUNT(DISTINCT(zipped_moab_versions.id))', 'COUNT(DISTINCT(zip_parts.id))'
+    )
+  logger.info "endpoint stats (name, zipped_moab_versions count, zip_parts count): #{endpoint_stats}"
 
   unless dry_run
     puts 'Are you sure you want to proceed? (y/n)'
     answer = $stdin.gets.chomp.downcase
     unless answer == 'y'
-      puts 'Quitting.'
+      logger.info 'Quitting.'
       exit
     end
   end
 
-  zip_endpoint.zipped_moab_versions.find_each do |zipped_moab_version|
-    zip_info = "#{zipped_moab_version.druid} (#{zipped_moab_version.version})"
+  # this should be stable from run to run, as #in_batches orders on primary key
+  # `use_ranges: true` prevents a giant IN clause of individual IDs: https://apidock.com/rails/ActiveRecord/Batches/in_batches
+  zip_endpoint.zipped_moab_versions.limit(limit).in_batches(of: batch_size, use_ranges: true) do |zipped_moab_versions_relation|
+    zip_parts_relation = ZipPart.where(zipped_moab_version: zipped_moab_versions_relation)
+    zip_info = "#{zip_parts_relation.count} zip parts for #{zipped_moab_versions_relation.count} zipped moab versions " \
+               "(zipped_moab_versions id range: #{zipped_moab_versions_relation.pluck('MIN(id)')} to " \
+               "#{zipped_moab_versions_relation.pluck('MAX(id)')})"
+
+    logger.debug "zipped_moab_versions_relation.to_sql=#{zipped_moab_versions_relation.to_sql}"
+    logger.debug "zip_parts_relation.to_sql=#{zip_parts_relation.to_sql}"
     if dry_run
-      puts "Dry run deleting: #{zip_info}"
+      logger.info "[Dry run] Deleting: #{zip_info}"
     else
-      puts "Deleting: #{zip_info}"
-      zipped_moab_version.zip_parts.destroy_all
+      logger.info "Deleting: #{zip_info}"
+      # delete_all issues a single SQL delete without instantiating AR objects: https://apidock.com/rails/ActiveRecord/Relation/delete_all
+      zip_parts_relation.delete_all
+      zipped_moab_versions_relation.delete_all
     end
   end
 
-  unless dry_run
-    puts "Deleting ZipEndpoint: #{args[:endpoint_name]}"
-    zip_endpoint.reload
-    zip_endpoint.zipped_moab_versions.destroy_all
-    zip_endpoint.reload
+  # only remove the endpoint if it's not a dry run and all its zipped_moab_versions are gone
+  if dry_run || zip_endpoint.reload.zipped_moab_versions.exists?
+    logger.info "dry run, or zipped_moab_versions remain on #{endpoint_name}, cannot delete zip_endpoints row"
+  else
+    logger.info "Deleting ZipEndpoint: #{endpoint_name}"
     zip_endpoint.destroy!
   end
+
+  endpoint_stats =
+    ZipPart.joins(
+      zipped_moab_version: [:zip_endpoint]
+    ).group(
+      :endpoint_name
+    ).pluck(
+      :endpoint_name, 'COUNT(DISTINCT(zipped_moab_versions.id))', 'COUNT(DISTINCT(zip_parts.id))'
+    )
+  logger.info "endpoint stats (name, zipped_moab_versions count, zip_parts count): #{endpoint_stats}"
 end


### PR DESCRIPTION
# Why was this change made?

https://stanfordlib.slack.com/archives/C0RK5EM9N/p1775058777691269


# How was this change tested?

⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
