### PR TITLE
When updating the catalog is requested for the currently recorded version, treat as a no-op.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -28,7 +28,7 @@ class CatalogController < ApiController
     results = MoabRecordService::UpdateVersion.execute(druid: bare_druid, incoming_version: incoming_version, incoming_size: incoming_size,
                                                        moab_storage_root: moab_storage_root, checksums_validated: checksums_validated)
     status_code =
-      if results.contains_result_code?(:actual_vers_gt_db_obj)
+      if results.contains_result_code?(:actual_vers_gt_db_obj) || results.contains_result_code?(:version_matches)
         :ok # 200
       elsif results.contains_result_code?(:db_obj_does_not_exist)
         :not_found # 404

--- a/app/services/moab_record_service/update_version.rb
+++ b/app/services/moab_record_service/update_version.rb
@@ -33,6 +33,8 @@ module MoabRecordService
 
         if incoming_version > moab_record.version
           update_moab_record_to_expected_version(status: status, checksums_validated: checksums_validated)
+        elsif incoming_version == moab_record.version
+          results.add_result(Results::VERSION_MATCHES, 'MoabRecord')
         else
           status = 'unexpected_version_on_storage' if set_status_to_unexpected_version
           update_moab_record_to_unexpected_version(status: status)
@@ -66,9 +68,7 @@ module MoabRecordService
 
     # expects @incoming_version to be numeric
     def version_comparison_results
-      if incoming_version == moab_record.version
-        results.add_result(Results::VERSION_MATCHES, moab_record.class.name)
-      elsif incoming_version < moab_record.version
+      if incoming_version < moab_record.version
         results.add_result(
           Results::ACTUAL_VERS_LT_DB_OBJ,
           db_obj_name: moab_record.class.name, db_obj_version: moab_record.version

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -163,6 +163,31 @@ RSpec.describe CatalogController do
       end
     end
 
+    context 'incoming version matches catalog version (no-op)' do
+      before do
+        patch :update, params: { druid: prefixed_druid, incoming_version: comp_moab.version, incoming_size: size,
+                                 storage_location: storage_location_param }
+      end
+
+      it 'does not change MoabRecord#version' do
+        expect { comp_moab.reload }.not_to change(comp_moab, :version)
+      end
+
+      it 'does not change PreservedObject#current_version' do
+        expect { pres_obj.reload }.not_to change(pres_obj, :current_version)
+      end
+
+      it 'response contains version_matches code' do
+        version_matches_msg = "actual version (#{comp_moab.version}) matches MoabRecord db version"
+        exp_msg = [{ Results::VERSION_MATCHES => version_matches_msg }]
+        expect(response.body).to include(exp_msg.to_json)
+      end
+
+      it 'returns an ok response code' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
     context 'with invalid params' do
       before do
         patch :update, params: { druid: prefixed_druid, incoming_version: ver, incoming_size: size, storage_location: nil }

--- a/spec/services/moab_record_service/shared_examples.rb
+++ b/spec/services/moab_record_service/shared_examples.rb
@@ -176,7 +176,7 @@ RSpec.shared_examples 'unexpected version' do |actual_version|
   end
 end
 
-RSpec.shared_examples 'unexpected version with validation' do |service, incoming_version, new_status|
+RSpec.shared_examples 'unexpected version with validation' do |service, incoming_version, new_status, results_count = nil|
   let(:moab_record_service) do
     described_class.new(druid: druid, incoming_version: incoming_version, incoming_size: 1, moab_storage_root: moab_storage_root)
   end
@@ -237,12 +237,7 @@ RSpec.shared_examples 'unexpected version with validation' do |service, incoming
 
     it 'number of results' do
       expect(results).to be_an_instance_of Results
-      case service
-      when :check_existence
-        expect(results.size).to eq 2
-      when :update_version_after_validation
-        expect(results.size).to eq 4
-      end
+      expect(results.size).to eq(results_count || (service == :check_existence ? 2 : 4))
     end
 
     if service == :update_version_after_validation

--- a/spec/services/moab_record_service/update_version_after_validation_spec.rb
+++ b/spec/services/moab_record_service/update_version_after_validation_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe MoabRecordService::UpdateVersionAfterValidation do
         end
 
         context 'incoming version same as catalog versions (both)' do
-          it_behaves_like 'unexpected version with validation', :update_version_after_validation, 2, 'invalid_moab'
+          it_behaves_like 'unexpected version with validation', :update_version_after_validation, 2, 'invalid_moab', 3
         end
 
         context 'incoming version lower than catalog versions (both)' do

--- a/spec/services/moab_record_service/update_version_spec.rb
+++ b/spec/services/moab_record_service/update_version_spec.rb
@@ -168,7 +168,43 @@ RSpec.describe MoabRecordService::UpdateVersion do
       end
 
       context 'incoming version same as catalog versions (both)' do
-        it_behaves_like 'unexpected version', 2, 'ok'
+        let(:moab_record_service) do
+          described_class.new(druid: druid, incoming_version: 2, incoming_size: 1, moab_storage_root: moab_storage_root)
+        end
+        let(:version_matches_msg) { 'actual version (2) matches MoabRecord db version' }
+
+        context 'MoabRecord unchanged' do
+          it 'status' do
+            expect { moab_record_service.execute }.not_to change(moab_record, :status)
+          end
+
+          it 'version' do
+            expect { moab_record_service.execute }.not_to change(moab_record, :version)
+          end
+
+          it 'size' do
+            expect { moab_record_service.execute }.not_to change(moab_record, :size)
+          end
+
+          it 'last_version_audit' do
+            expect { moab_record_service.execute }.not_to change(moab_record, :last_version_audit)
+          end
+        end
+
+        it 'PreservedObject current_version stays the same' do
+          expect { moab_record_service.execute }.not_to change(preserved_object, :current_version)
+          expect(ReplicationJob).not_to have_received(:perform_later)
+        end
+
+        context 'returns' do
+          let!(:results) { moab_record_service.execute }
+
+          it '1 VERSION_MATCHES result' do
+            expect(results).to be_an_instance_of Results
+            expect(results.size).to eq 1
+            expect(results.to_a).to include(a_hash_including(Results::VERSION_MATCHES => version_matches_msg))
+          end
+        end
       end
 
       context 'incoming version lower than catalog versions (both)' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,9 @@
 
 require 'simplecov'
 SimpleCov.start :rails do
-  add_filter '/spec/'
-  add_filter '/vendor/'
-  add_filter '/lib/'
+  skip '/spec/'
+  skip '/vendor/'
+  skip '/lib/'
 
   if ENV['CI']
     require 'simplecov_json_formatter'


### PR DESCRIPTION
closes #2651

# Why was this change made?
See ticket for description of race condition.



# How was this change tested?
Unit, stage

⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
