### PR TITLE
Adds lane-id to validate-moab endpoint.

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -28,7 +28,7 @@ class ObjectsController < ApiController
     # queue successfully. It will return false if the job was not enqueued.
     # The most likely cause is a temporary queue lock for the job and its specific payload, so
     # it is up to the caller to determine whether retrying later is appropriate.
-    if ValidateMoabJob.perform_later(druid)
+    if ValidateMoabJob.set(queue: validate_queue).perform_later(druid)
       render(plain: 'ok', status: :ok)
     else
       err_msg = "Failed to enqueue ValidateMoabJob for #{druid}. " \
@@ -112,5 +112,14 @@ class ObjectsController < ApiController
     content_group.path_hash.map do |file, signature|
       { filename: file, md5: signature.md5, sha1: signature.sha1, sha256: signature.sha256, filesize: signature.size }
     end
+  end
+
+  def lane_id
+    params['lane-id']
+  end
+
+  def validate_queue
+    lane = ['low', 'high'].include?(lane_id) ? lane_id : 'default'
+    :"validate_moab_#{lane}"
   end
 end

--- a/app/jobs/validate_moab_job.rb
+++ b/app/jobs/validate_moab_job.rb
@@ -6,7 +6,7 @@
 # (https://github.com/sul-dlss/workflow-server-rails/blob/main/config/workflows/preservationIngestWF.xml#L18) -
 # For explanation as to why, see comment in preservation_robots Robots::SdrRepo::PreservationIngest::ValidateMoab.
 class ValidateMoabJob < ApplicationJob
-  queue_as :validate_moab
+  queue_as :validate_moab_default
 
   include UniqueJob
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -143,6 +143,16 @@ paths:
           example: 'druid:bc123df4567'
           schema:
             $ref: '#/components/schemas/Druid'
+        - name: lane-id
+          in: query
+          schema:
+            description: Lane for prioritizing the work
+            type: string
+            enum:
+              - "default"
+              - "low"
+              - "high"
+            default: "default"
   /v1/objects/{id}/checksum:
     get:
       tags:
@@ -340,7 +350,6 @@ components:
               $ref: '#/components/schemas/Druid'
           required:
             - druid
-
     ContentDiff:
       description: A diff between given and existing content metadata (XML)
       type: object

--- a/spec/requests/objects_controller_validate_moab_spec.rb
+++ b/spec/requests/objects_controller_validate_moab_spec.rb
@@ -5,23 +5,34 @@ RSpec.describe ObjectsController do
   let(:prefixed_druid) { 'druid:bj102hs9687' }
   let(:bare_druid) { 'bj102hs9687' }
   let(:post_headers) { valid_auth_header.merge('Content-Type' => 'application/json') }
+  let(:job) { class_double(ValidateMoabJob, perform_later: 123) }
 
   describe 'GET #validate_moab' do
     context 'when valid druid passed in' do
       before do
-        allow(ValidateMoabJob).to receive(:perform_later).and_return(ValidateMoabJob.new)
+        allow(ValidateMoabJob).to receive(:set).and_return(job)
       end
 
       it 'queues the job and response ok' do
         get validate_moab_object_url(prefixed_druid), headers: valid_auth_header
         expect(response).to have_http_status(:ok)
-        expect(ValidateMoabJob).to have_received(:perform_later).with(bare_druid)
+        expect(ValidateMoabJob).to have_received(:set).with(queue: :validate_moab_default)
+        expect(job).to have_received(:perform_later).with(bare_druid)
       end
 
       it 'queues the job and response ok when given a bare druid' do
         get validate_moab_object_url(bare_druid), headers: valid_auth_header
         expect(response).to have_http_status(:ok)
-        expect(ValidateMoabJob).to have_received(:perform_later).with(bare_druid)
+        expect(job).to have_received(:perform_later).with(bare_druid)
+      end
+
+      context 'with a provided lane-id' do
+        it 'queues the job and response ok' do
+          get validate_moab_object_url(prefixed_druid, 'lane-id': 'high'), headers: valid_auth_header
+          expect(response).to have_http_status(:ok)
+          expect(ValidateMoabJob).to have_received(:set).with(queue: :validate_moab_high)
+          expect(job).to have_received(:perform_later).with(bare_druid)
+        end
       end
     end
 
@@ -29,16 +40,17 @@ RSpec.describe ObjectsController do
       it 'returns a 400 response code' do
         get validate_moab_object_url('not a druid'), headers: valid_auth_header
         expect(response).to have_http_status(:bad_request)
-        expect(ValidateMoabJob).not_to receive(:perform_later)
+        expect(job).not_to receive(:perform_later)
       end
     end
 
     context 'when the caller tries to enqueue the job for a valid druid that is already in the queue' do
       before do
+        allow(ValidateMoabJob).to receive(:set).and_return(job)
         # the first attempt to enqueue is successful and returns an instance of the job class,
         # the second attempt fails and returns false (simulating an attempt to queue when the
         # same job is already waiting to be worked)
-        allow(ValidateMoabJob).to receive(:perform_later).and_return(ValidateMoabJob.new, false)
+        allow(job).to receive(:perform_later).and_return(123, false)
       end
 
       it 'returns a 423 response code' do
@@ -52,7 +64,7 @@ RSpec.describe ObjectsController do
         expect(response.body).to include("Failed to enqueue ValidateMoabJob for #{bare_druid}")
         expect(response.body).to include('The most likely cause is that the job was already enqueued')
 
-        expect(ValidateMoabJob).to have_received(:perform_later).with(bare_druid).exactly(2).times
+        expect(job).to have_received(:perform_later).with(bare_druid).exactly(2).times
       end
     end
   end


### PR DESCRIPTION
refs #2653

# Why was this change made?
Prevent bulk accessioning from interfering with normal accessioning.



# How was this change tested?
Unit

⚠ If this change has cross service impact or if it changes code used internally for cloud replication, running [integration test preassembly_reaccessioning_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/preassembly_reaccessioning_spec.rb) is recommended.
